### PR TITLE
feat: add Kometa mode for asset directory integration

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -1116,6 +1116,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/images/kometa/item": {
+            "get": {
+                "description": "Serve a locally-imported Kometa asset by its image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e) from the configured asset directory.",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Get Kometa Asset Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kometa image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e)",
+                        "name": "asset_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Image data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/images/media/collection": {
             "get": {
                 "description": "Get a collection item image (poster or backdrop) from the media server by rating key and image type",
@@ -1437,6 +1472,105 @@ const docTemplate = `{
                                     "properties": {
                                         "data": {
                                             "$ref": "#/definitions/routes_jobs.runJobResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/kometa/import": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Return whether a Kometa asset import is currently running and the result of the most recent run.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Kometa"
+                ],
+                "summary": "Get Kometa Asset Import Status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_kometa.importResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Scan the configured Kometa asset directory, upload matching assets to Plex, and record them in the database. Runs asynchronously; poll GET /api/kometa/import for progress.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Kometa"
+                ],
+                "summary": "Trigger Kometa Asset Import",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_kometa.importResponse"
                                         }
                                     }
                                 }
@@ -3231,6 +3365,14 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "kometa": {
+                    "description": "Settings for Kometa asset directory integration (Plex only).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/config.Config_Kometa"
+                        }
+                    ]
+                },
                 "save_images_locally": {
                     "description": "Settings for saving images locally alongside content.",
                     "allOf": [
@@ -3238,6 +3380,23 @@ const docTemplate = `{
                             "$ref": "#/definitions/config.Config_SaveImagesLocally"
                         }
                     ]
+                }
+            }
+        },
+        "config.Config_Kometa": {
+            "type": "object",
+            "properties": {
+                "asset_directory": {
+                    "description": "Path to the Kometa asset directory (the same directory Kometa reads assets from). Uses the folder-per-item (asset_folders: true) layout.",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Whether to write downloaded images into the Kometa asset directory using Kometa naming conventions. Plex exclusive feature.",
+                    "type": "boolean"
+                },
+                "import_cron": {
+                    "description": "Optional cron expression for periodically importing existing Kometa assets. Empty means import is manual only.",
+                    "type": "string"
                 }
             }
         },
@@ -3652,6 +3811,78 @@ const docTemplate = `{
                 },
                 "spec": {
                     "type": "string"
+                }
+            }
+        },
+        "kometa.FolderOutcome": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "folder": {
+                    "type": "string"
+                },
+                "images_failed": {
+                    "type": "integer"
+                },
+                "images_uploaded": {
+                    "type": "integer"
+                },
+                "managed_by_aura": {
+                    "description": "matched but DB registration skipped to protect MediUX selections",
+                    "type": "boolean"
+                },
+                "outcome": {
+                    "description": "matched, unmatched, collection, error",
+                    "type": "string"
+                },
+                "registered_in_db": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "kometa.ImportResult": {
+            "type": "object",
+            "properties": {
+                "collections": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "folders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/kometa.FolderOutcome"
+                    }
+                },
+                "folders_scanned": {
+                    "type": "integer"
+                },
+                "images_failed": {
+                    "type": "integer"
+                },
+                "images_uploaded": {
+                    "type": "integer"
+                },
+                "items_registered": {
+                    "type": "integer"
+                },
+                "matched": {
+                    "type": "integer"
+                },
+                "skipped_managed_by_aura": {
+                    "type": "integer"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "unmatched_folders": {
+                    "type": "integer"
                 }
             }
         },
@@ -4902,6 +5133,20 @@ const docTemplate = `{
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "routes_kometa.importResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/definitions/kometa.ImportResult"
+                },
+                "running": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -3826,15 +3826,19 @@ const docTemplate = `{
                 "images_failed": {
                     "type": "integer"
                 },
+                "images_skipped_owned": {
+                    "description": "assets not uploaded because a MediUX set owns their image type",
+                    "type": "integer"
+                },
                 "images_uploaded": {
                     "type": "integer"
                 },
                 "managed_by_aura": {
-                    "description": "matched but DB registration skipped to protect MediUX selections",
+                    "description": "one or more image types were skipped to protect MediUX selections",
                     "type": "boolean"
                 },
                 "outcome": {
-                    "description": "matched, unmatched, collection, error",
+                    "description": "matched, unmatched, collection, skipped, error",
                     "type": "string"
                 },
                 "registered_in_db": {
@@ -3866,6 +3870,10 @@ const docTemplate = `{
                 "images_failed": {
                     "type": "integer"
                 },
+                "images_skipped_owned": {
+                    "description": "assets not uploaded because a MediUX set owns their image type",
+                    "type": "integer"
+                },
                 "images_uploaded": {
                     "type": "integer"
                 },
@@ -3876,6 +3884,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "skipped_managed_by_aura": {
+                    "description": "items where at least one image type was protected",
                     "type": "integer"
                 },
                 "started_at": {

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -3818,15 +3818,19 @@
                 "images_failed": {
                     "type": "integer"
                 },
+                "images_skipped_owned": {
+                    "description": "assets not uploaded because a MediUX set owns their image type",
+                    "type": "integer"
+                },
                 "images_uploaded": {
                     "type": "integer"
                 },
                 "managed_by_aura": {
-                    "description": "matched but DB registration skipped to protect MediUX selections",
+                    "description": "one or more image types were skipped to protect MediUX selections",
                     "type": "boolean"
                 },
                 "outcome": {
-                    "description": "matched, unmatched, collection, error",
+                    "description": "matched, unmatched, collection, skipped, error",
                     "type": "string"
                 },
                 "registered_in_db": {
@@ -3858,6 +3862,10 @@
                 "images_failed": {
                     "type": "integer"
                 },
+                "images_skipped_owned": {
+                    "description": "assets not uploaded because a MediUX set owns their image type",
+                    "type": "integer"
+                },
                 "images_uploaded": {
                     "type": "integer"
                 },
@@ -3868,6 +3876,7 @@
                     "type": "integer"
                 },
                 "skipped_managed_by_aura": {
+                    "description": "items where at least one image type was protected",
                     "type": "integer"
                 },
                 "started_at": {

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -1108,6 +1108,41 @@
                 }
             }
         },
+        "/api/images/kometa/item": {
+            "get": {
+                "description": "Serve a locally-imported Kometa asset by its image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e) from the configured asset directory.",
+                "produces": [
+                    "image/jpeg"
+                ],
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Get Kometa Asset Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Kometa image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e)",
+                        "name": "asset_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Image data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/images/media/collection": {
             "get": {
                 "description": "Get a collection item image (poster or backdrop) from the media server by rating key and image type",
@@ -1429,6 +1464,105 @@
                                     "properties": {
                                         "data": {
                                             "$ref": "#/definitions/routes_jobs.runJobResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/kometa/import": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Return whether a Kometa asset import is currently running and the result of the most recent run.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Kometa"
+                ],
+                "summary": "Get Kometa Asset Import Status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_kometa.importResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Scan the configured Kometa asset directory, upload matching assets to Plex, and record them in the database. Runs asynchronously; poll GET /api/kometa/import for progress.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Kometa"
+                ],
+                "summary": "Trigger Kometa Asset Import",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_kometa.importResponse"
                                         }
                                     }
                                 }
@@ -3223,6 +3357,14 @@
                         }
                     ]
                 },
+                "kometa": {
+                    "description": "Settings for Kometa asset directory integration (Plex only).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/config.Config_Kometa"
+                        }
+                    ]
+                },
                 "save_images_locally": {
                     "description": "Settings for saving images locally alongside content.",
                     "allOf": [
@@ -3230,6 +3372,23 @@
                             "$ref": "#/definitions/config.Config_SaveImagesLocally"
                         }
                     ]
+                }
+            }
+        },
+        "config.Config_Kometa": {
+            "type": "object",
+            "properties": {
+                "asset_directory": {
+                    "description": "Path to the Kometa asset directory (the same directory Kometa reads assets from). Uses the folder-per-item (asset_folders: true) layout.",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Whether to write downloaded images into the Kometa asset directory using Kometa naming conventions. Plex exclusive feature.",
+                    "type": "boolean"
+                },
+                "import_cron": {
+                    "description": "Optional cron expression for periodically importing existing Kometa assets. Empty means import is manual only.",
+                    "type": "string"
                 }
             }
         },
@@ -3644,6 +3803,78 @@
                 },
                 "spec": {
                     "type": "string"
+                }
+            }
+        },
+        "kometa.FolderOutcome": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "folder": {
+                    "type": "string"
+                },
+                "images_failed": {
+                    "type": "integer"
+                },
+                "images_uploaded": {
+                    "type": "integer"
+                },
+                "managed_by_aura": {
+                    "description": "matched but DB registration skipped to protect MediUX selections",
+                    "type": "boolean"
+                },
+                "outcome": {
+                    "description": "matched, unmatched, collection, error",
+                    "type": "string"
+                },
+                "registered_in_db": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "kometa.ImportResult": {
+            "type": "object",
+            "properties": {
+                "collections": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "folders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/kometa.FolderOutcome"
+                    }
+                },
+                "folders_scanned": {
+                    "type": "integer"
+                },
+                "images_failed": {
+                    "type": "integer"
+                },
+                "images_uploaded": {
+                    "type": "integer"
+                },
+                "items_registered": {
+                    "type": "integer"
+                },
+                "matched": {
+                    "type": "integer"
+                },
+                "skipped_managed_by_aura": {
+                    "type": "integer"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "unmatched_folders": {
+                    "type": "integer"
                 }
             }
         },
@@ -4894,6 +5125,20 @@
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "routes_kometa.importResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/definitions/kometa.ImportResult"
+                },
+                "running": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -459,13 +459,16 @@ definitions:
         type: string
       images_failed:
         type: integer
+      images_skipped_owned:
+        description: assets not uploaded because a MediUX set owns their image type
+        type: integer
       images_uploaded:
         type: integer
       managed_by_aura:
-        description: matched but DB registration skipped to protect MediUX selections
+        description: one or more image types were skipped to protect MediUX selections
         type: boolean
       outcome:
-        description: matched, unmatched, collection, error
+        description: matched, unmatched, collection, skipped, error
         type: string
       registered_in_db:
         type: boolean
@@ -486,6 +489,9 @@ definitions:
         type: integer
       images_failed:
         type: integer
+      images_skipped_owned:
+        description: assets not uploaded because a MediUX set owns their image type
+        type: integer
       images_uploaded:
         type: integer
       items_registered:
@@ -493,6 +499,7 @@ definitions:
       matched:
         type: integer
       skipped_managed_by_aura:
+        description: items where at least one image type was protected
         type: integer
       started_at:
         type: string

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -145,10 +145,29 @@ definitions:
         allOf:
         - $ref: '#/definitions/config.Config_CacheImages'
         description: Settings for caching images.
+      kometa:
+        allOf:
+        - $ref: '#/definitions/config.Config_Kometa'
+        description: Settings for Kometa asset directory integration (Plex only).
       save_images_locally:
         allOf:
         - $ref: '#/definitions/config.Config_SaveImagesLocally'
         description: Settings for saving images locally alongside content.
+    type: object
+  config.Config_Kometa:
+    properties:
+      asset_directory:
+        description: 'Path to the Kometa asset directory (the same directory Kometa
+          reads assets from). Uses the folder-per-item (asset_folders: true) layout.'
+        type: string
+      enabled:
+        description: Whether to write downloaded images into the Kometa asset directory
+          using Kometa naming conventions. Plex exclusive feature.
+        type: boolean
+      import_cron:
+        description: Optional cron expression for periodically importing existing
+          Kometa assets. Empty means import is manual only.
+        type: string
     type: object
   config.Config_LabelsAndTags:
     properties:
@@ -431,6 +450,54 @@ definitions:
         type: string
       spec:
         type: string
+    type: object
+  kometa.FolderOutcome:
+    properties:
+      detail:
+        type: string
+      folder:
+        type: string
+      images_failed:
+        type: integer
+      images_uploaded:
+        type: integer
+      managed_by_aura:
+        description: matched but DB registration skipped to protect MediUX selections
+        type: boolean
+      outcome:
+        description: matched, unmatched, collection, error
+        type: string
+      registered_in_db:
+        type: boolean
+    type: object
+  kometa.ImportResult:
+    properties:
+      collections:
+        type: integer
+      error:
+        type: string
+      finished_at:
+        type: string
+      folders:
+        items:
+          $ref: '#/definitions/kometa.FolderOutcome'
+        type: array
+      folders_scanned:
+        type: integer
+      images_failed:
+        type: integer
+      images_uploaded:
+        type: integer
+      items_registered:
+        type: integer
+      matched:
+        type: integer
+      skipped_managed_by_aura:
+        type: integer
+      started_at:
+        type: string
+      unmatched_folders:
+        type: integer
     type: object
   logging.LogAction:
     properties:
@@ -1284,6 +1351,15 @@ definitions:
     properties:
       message:
         type: string
+    type: object
+  routes_kometa.importResponse:
+    properties:
+      message:
+        type: string
+      result:
+        $ref: '#/definitions/kometa.ImportResult'
+      running:
+        type: boolean
     type: object
   routes_labels_tags.applyLabelsTagsRequest:
     properties:
@@ -2206,6 +2282,30 @@ paths:
       summary: Health Check
       tags:
       - Health
+  /api/images/kometa/item:
+    get:
+      description: Serve a locally-imported Kometa asset by its image ID (kometa|<folder>/<file>)
+        from the configured asset directory.
+      parameters:
+      - description: Kometa image ID (kometa|<folder>/<file>)
+        in: query
+        name: asset_id
+        required: true
+        type: string
+      produces:
+      - image/jpeg
+      responses:
+        "200":
+          description: Image data
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      summary: Get Kometa Asset Image
+      tags:
+      - Images
   /api/images/media/collection:
     get:
       description: Get a collection item image (poster or backdrop) from the media
@@ -2433,6 +2533,66 @@ paths:
       summary: Run Job
       tags:
       - Jobs
+  /api/kometa/import:
+    get:
+      description: Return whether a Kometa asset import is currently running and the
+        result of the most recent run.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_kometa.importResponse'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Get Kometa Asset Import Status
+      tags:
+      - Kometa
+    post:
+      consumes:
+      - application/json
+      description: Scan the configured Kometa asset directory, upload matching assets
+        to Plex, and record them in the database. Runs asynchronously; poll GET /api/kometa/import
+        for progress.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_kometa.importResponse'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Trigger Kometa Asset Import
+      tags:
+      - Kometa
   /api/labels-tags/apply:
     post:
       consumes:

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -75,6 +75,7 @@ type Config_AutoDownload struct {
 type Config_Images struct {
 	CacheImages       Config_CacheImages       `json:"cache_images" yaml:"CacheImages"`              // Settings for caching images.
 	SaveImagesLocally Config_SaveImagesLocally `json:"save_images_locally" yaml:"SaveImagesLocally"` // Settings for saving images locally alongside content.
+	Kometa            Config_Kometa            `json:"kometa" yaml:"Kometa"`                         // Settings for Kometa asset directory integration (Plex only).
 }
 
 type Config_CacheImages struct {
@@ -86,6 +87,12 @@ type Config_SaveImagesLocally struct {
 	Path                    string `json:"path,omitempty" yaml:"Path,omitempty"`                                         // By default, this is set to alongside the content. If set, this will override that behavior and save all images to this path.
 	EpisodeNamingConvention string `json:"episode_naming_convention,omitempty" yaml:"EpisodeNamingConvention,omitempty"` // Episode naming convention for the media server. Only needed for Plex. Will default to match
 	RunningOnWindows        bool   `json:"running_on_windows,omitempty" yaml:"RunningOnWindows,omitempty"`               // Whether the application is running on Windows. This affects path formatting.
+}
+
+type Config_Kometa struct {
+	Enabled        bool   `json:"enabled" yaml:"Enabled"`                                    // Whether to write downloaded images into the Kometa asset directory using Kometa naming conventions. Plex exclusive feature.
+	AssetDirectory string `json:"asset_directory,omitempty" yaml:"AssetDirectory,omitempty"` // Path to the Kometa asset directory (the same directory Kometa reads assets from). Uses the folder-per-item (asset_folders: true) layout.
+	ImportCron     string `json:"import_cron,omitempty" yaml:"ImportCron,omitempty"`         // Optional cron expression for periodically importing existing Kometa assets. Empty means import is manual only.
 }
 
 type Config_TMDB struct {

--- a/backend/config/defaults.go
+++ b/backend/config/defaults.go
@@ -67,6 +67,9 @@ func DefaultConfig() Config {
 			SaveImagesLocally: Config_SaveImagesLocally{
 				Enabled: false,
 			},
+			Kometa: Config_Kometa{
+				Enabled: false,
+			},
 		},
 		Notifications: Config_Notifications{
 			Enabled:              false,

--- a/backend/config/validate.go
+++ b/backend/config/validate.go
@@ -4,6 +4,7 @@ import (
 	"aura/logging"
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -243,6 +244,39 @@ func ValidateImages(ctx context.Context, Images *Config_Images, msConfig Config_
 		}
 
 	}
+
+	// If Images.Kometa.Enabled is true, validate the Kometa settings (Plex only)
+	if Images.Kometa.Enabled {
+		if msConfig.Type != "Plex" {
+			logAction.SetError("Images.Kometa is only supported for Plex media servers", "Disable Kometa mode or switch to a Plex media server", nil)
+			return false
+		}
+
+		if Images.Kometa.AssetDirectory == "" {
+			logAction.SetError("Images.Kometa.AssetDirectory is required when Kometa mode is enabled", "Set AssetDirectory to the path Kometa reads assets from", nil)
+			return false
+		}
+
+		info, err := os.Stat(Images.Kometa.AssetDirectory)
+		if err != nil || !info.IsDir() {
+			logAction.SetError(
+				fmt.Sprintf("Images.Kometa.AssetDirectory '%s' does not exist or is not a directory", Images.Kometa.AssetDirectory),
+				"Ensure the Kometa asset directory is mounted into the container at this path",
+				nil,
+			)
+			return false
+		}
+
+		if Images.Kometa.ImportCron != "" && !ValidateCron(Images.Kometa.ImportCron) {
+			logAction.SetError(
+				fmt.Sprintf("Images.Kometa.ImportCron: '%s' is not a valid cron expression", Images.Kometa.ImportCron),
+				"Provide a valid cron expression or leave it empty for manual-only imports",
+				nil,
+			)
+			return false
+		}
+	}
+
 	return isValid
 }
 

--- a/backend/download/auto/handle-movie.go
+++ b/backend/download/auto/handle-movie.go
@@ -2,6 +2,7 @@ package autodownload
 
 import (
 	"aura/database"
+	"aura/kometa"
 	"aura/logging"
 	"aura/mediaserver"
 	"aura/mediux"
@@ -87,6 +88,14 @@ func handleMovie(ctx context.Context, mediaItem models.MediaItem, dbItem models.
 		setResult.ID = dbSet.ID
 		setResult.Title = dbSet.Title
 		setResult.UserCreated = dbSet.UserCreated
+
+		// Kometa-imported sets are managed on disk, not via MediUX; never re-fetch them.
+		if kometa.IsKometaSetID(dbSet.ID) {
+			setResult.Result = "skipped"
+			setResult.Reason = "Kometa-imported set; not managed via MediUX"
+			result.Sets = append(result.Sets, setResult)
+			continue
+		}
 
 		// If the set is not set to auto-download, then we skip it
 		if !dbSet.AutoDownload {

--- a/backend/download/auto/handle-show.go
+++ b/backend/download/auto/handle-show.go
@@ -1,6 +1,7 @@
 package autodownload
 
 import (
+	"aura/kometa"
 	"aura/logging"
 	"aura/mediaserver"
 	"aura/mediux"
@@ -155,6 +156,14 @@ func handleShow(ctx context.Context, mediaItem models.MediaItem, dbItem models.D
 		setResult.ID = dbSet.ID
 		setResult.Title = dbSet.Title
 		setResult.UserCreated = dbSet.UserCreated
+
+		// Kometa-imported sets are managed on disk, not via MediUX; never re-fetch them.
+		if kometa.IsKometaSetID(dbSet.ID) {
+			setResult.Result = "skipped"
+			setResult.Reason = "Kometa-imported set; not managed via MediUX"
+			result.Sets = append(result.Sets, setResult)
+			continue
+		}
 
 		// If the set is not set to auto-download, then we skip it
 		if !dbSet.AutoDownload {

--- a/backend/jobs/cron.go
+++ b/backend/jobs/cron.go
@@ -25,6 +25,7 @@ var (
 
 	// Configurable
 	autodownloadJobID cron.EntryID = 0
+	kometaImportJobID cron.EntryID = 0
 )
 
 var manualPrevRun = map[cron.EntryID]string{}
@@ -96,6 +97,8 @@ func GetListOfJobs() []JobInfo {
 				jobInfo.JobName = "Check for Media Item Changes Job"
 			case handleTempIgnoredItemsJobID:
 				jobInfo.JobName = "Handle Temp Ignored Items Job"
+			case kometaImportJobID:
+				jobInfo.JobName = "Kometa Asset Import Job"
 			default:
 				jobInfo.JobName = "Unknown Job"
 			}
@@ -125,6 +128,8 @@ func TriggerJob(jobName string, jobID string) error {
 		entryID = checkForMediaItemChangesJobID
 	case "Handle Temp Ignored Items Job":
 		entryID = handleTempIgnoredItemsJobID
+	case "Kometa Asset Import Job":
+		entryID = kometaImportJobID
 	default:
 		return fmt.Errorf("unknown job name: %s", jobName)
 	}

--- a/backend/jobs/kometa_import.go
+++ b/backend/jobs/kometa_import.go
@@ -1,0 +1,59 @@
+package jobs
+
+import (
+	"aura/config"
+	"aura/kometa"
+	"aura/logging"
+	"runtime/debug"
+)
+
+// StartKometaImportJob (re)schedules the periodic Kometa asset import job. It is a no-op
+// unless Kometa mode is enabled and an ImportCron expression is configured; the import can
+// still be run on demand via the API regardless of this schedule.
+func StartKometaImportJob() error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if c == nil {
+		logging.LOGGER.Error().Timestamp().Msg("Cron Jobs Scheduler is not initialized")
+		return nil
+	}
+
+	if kometaImportJobID != 0 {
+		c.Remove(kometaImportJobID)
+		kometaImportJobID = 0
+	}
+
+	k := config.Current.Images.Kometa
+	if !k.Enabled || k.ImportCron == "" {
+		logging.LOGGER.Info().Timestamp().Msg("Kometa Asset Import Job Stopped")
+		return nil
+	}
+
+	spec := k.ImportCron
+
+	var err error
+	kometaImportJobID, err = c.AddFunc(spec, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logging.LOGGER.Error().
+					Timestamp().
+					Interface("recover", r).
+					Str("stack", string(debug.Stack())).
+					Msg("PANIC: in scheduled Kometa Asset Import Job")
+			}
+		}()
+		if started := kometa.StartImport(); !started {
+			logging.LOGGER.Warn().Timestamp().Msg("Kometa Asset Import skipped (already running or not enabled)")
+		}
+	})
+	if err != nil {
+		return err
+	}
+	jobSpecs[kometaImportJobID] = spec
+
+	logging.LOGGER.Info().Timestamp().
+		Str("cron", spec).
+		Msg("Kometa Asset Import Job Started")
+	return nil
+}

--- a/backend/kometa/import.go
+++ b/backend/kometa/import.go
@@ -101,9 +101,30 @@ func runImport() {
 }
 
 // processItem uploads a folder's assets to a single matched media item and registers them
-// in the database (subject to the precedence guard).
+// in the database. The precedence guard runs BEFORE any upload: image types already owned
+// by a non-Kometa (MediUX) set — and items the user has ignored — are never pushed to Plex,
+// so an import cannot silently replace an AURA-managed image on the server.
 func processItem(ctx context.Context, plexClient *plex.Plex, assetDir string, folder ScannedFolder, item *models.MediaItem, result *ImportResult) {
 	outcome := FolderOutcome{Folder: folder.Name, Outcome: "matched", Detail: item.LibraryTitle}
+
+	// Precedence guard: load AURA's existing records first so owned types are skipped
+	// before their bytes ever reach Plex.
+	ignored, _, existingSets, logErr := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
+	if logErr.Message != "" {
+		// Without the existing sets the guard cannot run; skip the item entirely rather
+		// than risk overwriting a MediUX-managed image on Plex.
+		outcome.Outcome = "error"
+		outcome.Detail = "failed to load existing AURA records; skipped to protect MediUX selections"
+		result.Folders = append(result.Folders, outcome)
+		return
+	}
+	if ignored {
+		outcome.Outcome = "skipped"
+		outcome.Detail = "item is ignored in AURA"
+		result.Folders = append(result.Folders, outcome)
+		return
+	}
+	owned := ownedTypes(existingSets)
 
 	// Load full details so season/episode rating keys resolve (and to verify existence).
 	found, Err := mediaserver.GetMediaItemDetails(ctx, item)
@@ -118,6 +139,12 @@ func processItem(ctx context.Context, plexClient *plex.Plex, assetDir string, fo
 	var selected models.SelectedTypes
 
 	for _, asset := range folder.Assets {
+		if typeOwned(owned, asset.Type) {
+			outcome.ImagesSkippedOwned++
+			result.ImagesSkippedOwned++
+			continue
+		}
+
 		imageFile := models.ImageFile{
 			ID:            imageIDForAsset(folder.Name, asset.FileName),
 			Type:          asset.Type,
@@ -154,68 +181,69 @@ func processItem(ctx context.Context, plexClient *plex.Plex, assetDir string, fo
 		markSelected(&selected, asset.Type)
 	}
 
+	outcome.ManagedByAura = outcome.ImagesSkippedOwned > 0
+	if outcome.ManagedByAura {
+		result.SkippedManagedByAura++
+	}
+
 	if len(uploadedImages) == 0 {
-		outcome.Detail = "no images uploaded"
+		if outcome.ManagedByAura && outcome.ImagesFailed == 0 {
+			outcome.Detail = "all image types are managed by AURA; nothing uploaded"
+		} else {
+			outcome.Detail = "no images uploaded"
+		}
 		result.Folders = append(result.Folders, outcome)
 		return
 	}
 
-	registered, managed := registerImportedItem(ctx, item, folder.Name, uploadedImages, selected)
-	outcome.RegisteredInDB = registered
-	outcome.ManagedByAura = managed
-	if registered {
+	outcome.RegisteredInDB = registerImportedItem(ctx, item, folder.Name, uploadedImages, selected)
+	if outcome.RegisteredInDB {
 		result.ItemsRegistered++
-	}
-	if managed {
-		result.SkippedManagedByAura++
 	}
 	result.Folders = append(result.Folders, outcome)
 }
 
-// registerImportedItem writes a synthetic "Kometa Import" poster set for the item. The
-// precedence guard clears any image type already owned by a non-Kometa (MediUX) set so an
-// import never overwrites the user's AURA selections; if nothing remains, registration is
-// skipped and the item is reported as managed by AURA.
-func registerImportedItem(ctx context.Context, item *models.MediaItem, folderName string, images []models.ImageFile, selected models.SelectedTypes) (registered, managed bool) {
-	ignored, _, existingSets, logErr := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
-	if logErr.Message != "" {
-		// Without the existing sets the precedence guard cannot run; skip registration
-		// rather than risk clobbering MediUX-owned selections.
-		logging.LOGGER.Warn().Timestamp().
-			Str("tmdb_id", item.TMDB_ID).
-			Str("library", item.LibraryTitle).
-			Str("error", logErr.Message).
-			Msg("Kometa import: failed to load existing sets; skipping DB registration")
-		return false, false
-	}
-	if ignored {
-		// The user has explicitly ignored this item in AURA; don't create records for it.
-		return false, false
-	}
+// ownedTypes merges the selected image types of every non-Kometa (MediUX) set for an item.
+// These types are AURA-managed: the import must neither upload them to Plex nor claim them
+// in the database.
+func ownedTypes(existingSets []models.DBSavedSet) models.SelectedTypes {
+	var owned models.SelectedTypes
 	for _, s := range existingSets {
 		if IsKometaSetID(s.ID) {
 			continue
 		}
-		if s.SelectedTypes.Poster {
-			selected.Poster = false
-		}
-		if s.SelectedTypes.Backdrop {
-			selected.Backdrop = false
-		}
-		if s.SelectedTypes.SeasonPoster {
-			selected.SeasonPoster = false
-		}
-		if s.SelectedTypes.SpecialSeasonPoster {
-			selected.SpecialSeasonPoster = false
-		}
-		if s.SelectedTypes.Titlecard {
-			selected.Titlecard = false
-		}
+		owned.Poster = owned.Poster || s.SelectedTypes.Poster
+		owned.Backdrop = owned.Backdrop || s.SelectedTypes.Backdrop
+		owned.SeasonPoster = owned.SeasonPoster || s.SelectedTypes.SeasonPoster
+		owned.SpecialSeasonPoster = owned.SpecialSeasonPoster || s.SelectedTypes.SpecialSeasonPoster
+		owned.Titlecard = owned.Titlecard || s.SelectedTypes.Titlecard
 	}
+	return owned
+}
 
+// typeOwned reports whether an asset's image type is claimed in the given selected types.
+func typeOwned(owned models.SelectedTypes, assetType string) bool {
+	switch assetType {
+	case "poster":
+		return owned.Poster
+	case "backdrop":
+		return owned.Backdrop
+	case "season_poster":
+		return owned.SeasonPoster
+	case "special_season_poster":
+		return owned.SpecialSeasonPoster
+	case "titlecard":
+		return owned.Titlecard
+	}
+	return false
+}
+
+// registerImportedItem writes a synthetic "Kometa Import" poster set for the item. The
+// caller (processItem) has already excluded AURA-owned types and ignored items, so
+// `selected` only contains types this import may claim.
+func registerImportedItem(ctx context.Context, item *models.MediaItem, folderName string, images []models.ImageFile, selected models.SelectedTypes) (registered bool) {
 	if !anySelected(selected) {
-		// Every uploaded type is owned by a MediUX set; leave AURA's records untouched.
-		return false, true
+		return false
 	}
 
 	now := time.Now()
@@ -240,9 +268,9 @@ func registerImportedItem(ctx context.Context, item *models.MediaItem, folderNam
 	}
 
 	if Err := database.UpsertSavedItem(ctx, dbItem); Err.Message != "" {
-		return false, false
+		return false
 	}
-	return true, false
+	return true
 }
 
 // processCollection uploads a folder's poster/background to a matched collection. Collection

--- a/backend/kometa/import.go
+++ b/backend/kometa/import.go
@@ -1,0 +1,279 @@
+package kometa
+
+import (
+	"aura/config"
+	"aura/database"
+	"aura/logging"
+	"aura/mediaserver"
+	"aura/mediaserver/plex"
+	"aura/models"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// StartImport kicks off a Kometa asset import in the background. It returns false if an
+// import is already running or if Kometa mode is not enabled/configured for Plex.
+func StartImport() (started bool) {
+	if !importEnabled() {
+		return false
+	}
+	if !tryStart() {
+		return false
+	}
+	go runImport()
+	return true
+}
+
+// importEnabled reports whether Kometa import can run given the current config.
+func importEnabled() bool {
+	k := config.Current.Images.Kometa
+	return k.Enabled && k.AssetDirectory != "" && config.Current.MediaServer.Type == "Plex"
+}
+
+// runImport performs the import synchronously against a background context and records the
+// result. It recovers from panics so a bad asset directory can never crash the process.
+func runImport() {
+	ctx, ld := logging.CreateLoggingContext(context.Background(), "Kometa Asset Import")
+	logAction := ld.AddAction("Import Kometa Assets", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	defer ld.Log()
+
+	result := &ImportResult{StartedAt: time.Now()}
+	defer func() {
+		if r := recover(); r != nil {
+			result.Error = fmt.Sprintf("panic during Kometa import: %v", r)
+			logging.LOGGER.Error().Timestamp().Interface("panic", r).Msg("Kometa import panicked")
+		}
+		result.FinishedAt = time.Now()
+		finish(result)
+	}()
+
+	assetDir := config.Current.Images.Kometa.AssetDirectory
+
+	// Refresh the library/collection cache so matching runs against current data.
+	mediaserver.GetAllLibrarySectionsAndItems(ctx, true)
+
+	folders, err := Scan(assetDir)
+	if err != nil {
+		result.Error = err.Error()
+		logAction.SetError("Failed to scan Kometa asset directory", "Ensure the asset directory is readable", map[string]any{"error": err.Error(), "path": assetDir})
+		return
+	}
+	result.FoldersScanned = len(folders)
+
+	plexClient := &plex.Plex{Config: config.Current.MediaServer}
+
+	for _, folder := range folders {
+		if len(folder.Assets) == 0 {
+			// No recognized assets in this folder; nothing to import.
+			continue
+		}
+
+		if items := matchFolderToItems(folder.Name); len(items) > 0 {
+			result.Matched++
+			for _, item := range items {
+				processItem(ctx, plexClient, assetDir, folder, item, result)
+			}
+			continue
+		}
+
+		if coll, ok := matchFolderToCollection(folder.Name); ok {
+			result.Collections++
+			processCollection(ctx, plexClient, assetDir, folder, coll, result)
+			continue
+		}
+
+		result.UnmatchedFolders++
+		result.Folders = append(result.Folders, FolderOutcome{
+			Folder:  folder.Name,
+			Outcome: "unmatched",
+			Detail:  "no matching media item or collection in the library",
+		})
+	}
+
+	logAction.AppendResult("folders_scanned", result.FoldersScanned)
+	logAction.AppendResult("images_uploaded", result.ImagesUploaded)
+	logAction.AppendResult("items_registered", result.ItemsRegistered)
+	logAction.AppendResult("unmatched_folders", result.UnmatchedFolders)
+}
+
+// processItem uploads a folder's assets to a single matched media item and registers them
+// in the database (subject to the precedence guard).
+func processItem(ctx context.Context, plexClient *plex.Plex, assetDir string, folder ScannedFolder, item *models.MediaItem, result *ImportResult) {
+	outcome := FolderOutcome{Folder: folder.Name, Outcome: "matched", Detail: item.LibraryTitle}
+
+	// Load full details so season/episode rating keys resolve (and to verify existence).
+	found, Err := mediaserver.GetMediaItemDetails(ctx, item)
+	if Err.Message != "" || !found {
+		outcome.Outcome = "error"
+		outcome.Detail = "failed to load media item details from Plex"
+		result.Folders = append(result.Folders, outcome)
+		return
+	}
+
+	var uploadedImages []models.ImageFile
+	var selected models.SelectedTypes
+
+	for _, asset := range folder.Assets {
+		imageFile := models.ImageFile{
+			ID:            imageIDForAsset(folder.Name, asset.FileName),
+			Type:          asset.Type,
+			Modified:      asset.ModTime,
+			ItemTMDB_ID:   item.TMDB_ID,
+			SeasonNumber:  asset.Season,
+			EpisodeNumber: asset.Episode,
+		}
+
+		ratingKey := plexClient.ResolveRatingKey(*item, imageFile)
+		if ratingKey == "" {
+			// Season/episode not present on the server; skip this asset.
+			outcome.ImagesFailed++
+			result.ImagesFailed++
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(assetDir, folder.Name, asset.FileName))
+		if err != nil {
+			outcome.ImagesFailed++
+			result.ImagesFailed++
+			continue
+		}
+
+		if uErr := plexClient.UploadImageBytes(ctx, ratingKey, asset.Type, data); uErr.Message != "" {
+			outcome.ImagesFailed++
+			result.ImagesFailed++
+			continue
+		}
+
+		outcome.ImagesUploaded++
+		result.ImagesUploaded++
+		uploadedImages = append(uploadedImages, imageFile)
+		markSelected(&selected, asset.Type)
+	}
+
+	if len(uploadedImages) == 0 {
+		outcome.Detail = "no images uploaded"
+		result.Folders = append(result.Folders, outcome)
+		return
+	}
+
+	registered, managed := registerImportedItem(ctx, item, folder.Name, uploadedImages, selected)
+	outcome.RegisteredInDB = registered
+	outcome.ManagedByAura = managed
+	if registered {
+		result.ItemsRegistered++
+	}
+	if managed {
+		result.SkippedManagedByAura++
+	}
+	result.Folders = append(result.Folders, outcome)
+}
+
+// registerImportedItem writes a synthetic "Kometa Import" poster set for the item. The
+// precedence guard clears any image type already owned by a non-Kometa (MediUX) set so an
+// import never overwrites the user's AURA selections; if nothing remains, registration is
+// skipped and the item is reported as managed by AURA.
+func registerImportedItem(ctx context.Context, item *models.MediaItem, folderName string, images []models.ImageFile, selected models.SelectedTypes) (registered, managed bool) {
+	_, _, existingSets, _ := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
+	for _, s := range existingSets {
+		if IsKometaSetID(s.ID) {
+			continue
+		}
+		if s.SelectedTypes.Poster {
+			selected.Poster = false
+		}
+		if s.SelectedTypes.Backdrop {
+			selected.Backdrop = false
+		}
+		if s.SelectedTypes.SeasonPoster {
+			selected.SeasonPoster = false
+		}
+		if s.SelectedTypes.SpecialSeasonPoster {
+			selected.SpecialSeasonPoster = false
+		}
+		if s.SelectedTypes.Titlecard {
+			selected.Titlecard = false
+		}
+	}
+
+	if !anySelected(selected) {
+		// Every uploaded type is owned by a MediUX set; leave AURA's records untouched.
+		return false, true
+	}
+
+	now := time.Now()
+	dbItem := models.DBSavedItem{
+		MediaItem: *item,
+		PosterSets: []models.DBPosterSetDetail{{
+			PosterSet: models.PosterSet{
+				BaseSetInfo: models.BaseSetInfo{
+					ID:          setIDForItem(item.TMDB_ID, item.LibraryTitle),
+					Title:       "Kometa Import: " + folderName,
+					Type:        item.Type,
+					UserCreated: "Kometa",
+					DateCreated: now,
+					DateUpdated: now,
+				},
+				Images: images,
+			},
+			SelectedTypes:  selected,
+			AutoDownload:   false,
+			LastDownloaded: now,
+		}},
+	}
+
+	if Err := database.UpsertSavedItem(ctx, dbItem); Err.Message != "" {
+		return false, false
+	}
+	return true, false
+}
+
+// processCollection uploads a folder's poster/background to a matched collection. Collection
+// assets are applied to Plex only (not recorded as AURA saved sets).
+func processCollection(ctx context.Context, plexClient *plex.Plex, assetDir string, folder ScannedFolder, coll *models.CollectionItem, result *ImportResult) {
+	outcome := FolderOutcome{Folder: folder.Name, Outcome: "collection", Detail: coll.LibraryTitle}
+
+	for _, asset := range folder.Assets {
+		// Collections only carry a poster and a background.
+		if asset.Type != "poster" && asset.Type != "backdrop" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(assetDir, folder.Name, asset.FileName))
+		if err != nil {
+			outcome.ImagesFailed++
+			result.ImagesFailed++
+			continue
+		}
+		if uErr := plexClient.UploadImageBytes(ctx, coll.RatingKey, asset.Type, data); uErr.Message != "" {
+			outcome.ImagesFailed++
+			result.ImagesFailed++
+			continue
+		}
+		outcome.ImagesUploaded++
+		result.ImagesUploaded++
+	}
+
+	result.Folders = append(result.Folders, outcome)
+}
+
+func markSelected(selected *models.SelectedTypes, assetType string) {
+	switch assetType {
+	case "poster":
+		selected.Poster = true
+	case "backdrop":
+		selected.Backdrop = true
+	case "season_poster":
+		selected.SeasonPoster = true
+	case "special_season_poster":
+		selected.SpecialSeasonPoster = true
+	case "titlecard":
+		selected.Titlecard = true
+	}
+}
+
+func anySelected(s models.SelectedTypes) bool {
+	return s.Poster || s.Backdrop || s.SeasonPoster || s.SpecialSeasonPoster || s.Titlecard
+}

--- a/backend/kometa/import.go
+++ b/backend/kometa/import.go
@@ -177,7 +177,21 @@ func processItem(ctx context.Context, plexClient *plex.Plex, assetDir string, fo
 // import never overwrites the user's AURA selections; if nothing remains, registration is
 // skipped and the item is reported as managed by AURA.
 func registerImportedItem(ctx context.Context, item *models.MediaItem, folderName string, images []models.ImageFile, selected models.SelectedTypes) (registered, managed bool) {
-	_, _, existingSets, _ := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
+	ignored, _, existingSets, logErr := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
+	if logErr.Message != "" {
+		// Without the existing sets the precedence guard cannot run; skip registration
+		// rather than risk clobbering MediUX-owned selections.
+		logging.LOGGER.Warn().Timestamp().
+			Str("tmdb_id", item.TMDB_ID).
+			Str("library", item.LibraryTitle).
+			Str("error", logErr.Message).
+			Msg("Kometa import: failed to load existing sets; skipping DB registration")
+		return false, false
+	}
+	if ignored {
+		// The user has explicitly ignored this item in AURA; don't create records for it.
+		return false, false
+	}
 	for _, s := range existingSets {
 		if IsKometaSetID(s.ID) {
 			continue

--- a/backend/kometa/kometa.go
+++ b/backend/kometa/kometa.go
@@ -61,12 +61,16 @@ func slug(s string) string {
 }
 
 // normalizeTitle mirrors the media-server cache's title comparison: lowercase with common
-// punctuation removed. Used to match Kometa asset folder names to collection titles.
+// punctuation removed. It also drops filesystem-illegal characters (/, \, <, >, ", |, *)
+// because on-disk asset folder names are sanitized while titles are not; without this a
+// collection like "Alien / Predator" could never match its folder "Alien  Predator".
+// Used to match Kometa asset folder names to collection titles.
 func normalizeTitle(input string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(input) {
 		switch r {
-		case '-', '_', '.', ',', ':', ';', '!', '?', '\'', '(', ')', '[', ']', '{', '}':
+		case '-', '_', '.', ',', ':', ';', '!', '?', '\'', '(', ')', '[', ']', '{', '}',
+			'/', '\\', '<', '>', '"', '|', '*':
 			continue
 		default:
 			b.WriteRune(r)

--- a/backend/kometa/kometa.go
+++ b/backend/kometa/kometa.go
@@ -1,0 +1,105 @@
+// Package kometa implements AURA's Kometa asset-directory integration: importing
+// existing Kometa assets from disk, uploading them to Plex, and registering them in the
+// database. The write side (saving downloaded images into the Kometa asset directory)
+// lives in the plex media-server package.
+package kometa
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// SetIDPrefix marks a PosterSet as a synthetic set created by a Kometa asset import.
+	// It is used to distinguish these sets from MediUX-sourced sets so that MediUX-only
+	// operations (re-fetching a set by ID, auto-download, force-check) skip them.
+	SetIDPrefix = "kometa-"
+
+	// ImageIDPrefix marks an ImageFile as a locally-imported Kometa asset. The remainder
+	// of the ID is "<assetFolder>/<fileName>" relative to the Kometa asset directory.
+	ImageIDPrefix = "kometa|"
+)
+
+// IsKometaSetID reports whether a poster set ID belongs to a Kometa import.
+func IsKometaSetID(id string) bool {
+	return strings.HasPrefix(id, SetIDPrefix)
+}
+
+// IsKometaImageID reports whether an image ID refers to a locally-imported Kometa asset.
+func IsKometaImageID(id string) bool {
+	return strings.HasPrefix(id, ImageIDPrefix)
+}
+
+// KometaImageRelPath returns the "<assetFolder>/<fileName>" path (relative to the asset
+// directory) encoded in a Kometa image ID, or "" if the ID is not a Kometa image ID.
+func KometaImageRelPath(id string) string {
+	if !IsKometaImageID(id) {
+		return ""
+	}
+	return strings.TrimPrefix(id, ImageIDPrefix)
+}
+
+// setIDForItem builds a deterministic synthetic set ID for a matched media item so that
+// re-running an import upserts the same set instead of creating duplicates.
+func setIDForItem(tmdbID, libraryTitle string) string {
+	return fmt.Sprintf("%s%s-%s", SetIDPrefix, tmdbID, slug(libraryTitle))
+}
+
+// imageIDForAsset builds the ImageFile ID for an imported asset.
+func imageIDForAsset(folderName, fileName string) string {
+	return ImageIDPrefix + folderName + "/" + fileName
+}
+
+var slugStripper = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// slug reduces a string to lowercase alphanumerics joined by dashes (used inside set IDs).
+func slug(s string) string {
+	s = strings.ToLower(s)
+	s = slugStripper.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+// normalizeTitle mirrors the media-server cache's title comparison: lowercase with common
+// punctuation removed. Used to match Kometa asset folder names to collection titles.
+func normalizeTitle(input string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(input) {
+		switch r {
+		case '-', '_', '.', ',', ':', ';', '!', '?', '\'', '(', ')', '[', ']', '{', '}':
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+var (
+	tmdbHintRegex  = regexp.MustCompile(`\{tmdb-(\d+)\}`)
+	titleYearRegex = regexp.MustCompile(`^(.*?)\s*\((\d{4})\)`)
+)
+
+// parseTMDBHint extracts a TMDB ID from a "{tmdb-12345}" hint in a folder name, if present.
+func parseTMDBHint(folderName string) (string, bool) {
+	m := tmdbHintRegex.FindStringSubmatch(folderName)
+	if len(m) == 2 {
+		return m[1], true
+	}
+	return "", false
+}
+
+// parseTitleYear extracts the title and year from a "Title (Year)" folder name. Returns
+// ok=false when no "(YYYY)" is present.
+func parseTitleYear(folderName string) (title string, year int, ok bool) {
+	m := titleYearRegex.FindStringSubmatch(folderName)
+	if len(m) != 3 {
+		return "", 0, false
+	}
+	title = strings.TrimSpace(m[1])
+	// m[2] is always 4 digits, so this parse cannot fail.
+	for _, r := range m[2] {
+		year = year*10 + int(r-'0')
+	}
+	return title, year, true
+}

--- a/backend/kometa/match.go
+++ b/backend/kometa/match.go
@@ -1,0 +1,54 @@
+package kometa
+
+import (
+	"aura/cache"
+	"aura/models"
+)
+
+// matchFolderToItems resolves a Kometa asset folder name to media items in the library
+// cache. It tries, in order: a {tmdb-NNN} hint, then a "Title (Year)" parse. Because a
+// shared asset directory can serve multiple libraries (e.g. HD and 4K), all matching items
+// across sections are returned.
+func matchFolderToItems(folderName string) []*models.MediaItem {
+	sections := cache.LibraryStore.GetAllSectionsSortedByTitle()
+
+	if tmdbID, ok := parseTMDBHint(folderName); ok {
+		var matches []*models.MediaItem
+		for _, section := range sections {
+			if item, found := cache.LibraryStore.GetMediaItemFromSectionByTMDBID(section.Title, tmdbID); found {
+				matches = append(matches, item)
+			}
+		}
+		if len(matches) > 0 {
+			return matches
+		}
+	}
+
+	if title, year, ok := parseTitleYear(folderName); ok {
+		var matches []*models.MediaItem
+		for _, section := range sections {
+			if item, found := cache.LibraryStore.GetMediaItemFromSectionByTitleAndYear(section.Title, title, year); found {
+				matches = append(matches, item)
+			}
+		}
+		return matches
+	}
+
+	return nil
+}
+
+// matchFolderToCollection resolves a Kometa asset folder name to a media-server collection
+// by normalized title comparison.
+func matchFolderToCollection(folderName string) (*models.CollectionItem, bool) {
+	target := normalizeTitle(folderName)
+	if target == "" {
+		return nil, false
+	}
+	for _, collection := range cache.CollectionsStore.GetAllCollections() {
+		if normalizeTitle(collection.Title) == target {
+			c := collection
+			return &c, true
+		}
+	}
+	return nil, false
+}

--- a/backend/kometa/scan.go
+++ b/backend/kometa/scan.go
@@ -1,0 +1,111 @@
+package kometa
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ScannedAsset is a single recognized asset file within a Kometa asset folder.
+type ScannedAsset struct {
+	FileName string    // base file name, e.g. "poster.jpg"
+	Type     string    // internal image type: poster, backdrop, season_poster, special_season_poster, titlecard
+	Season   *int      // set for season_poster, special_season_poster, titlecard
+	Episode  *int      // set for titlecard
+	ModTime  time.Time // file modification time
+}
+
+// ScannedFolder is one depth-1 directory in the asset directory and its recognized assets.
+type ScannedFolder struct {
+	Name         string         // folder base name (the Kometa ASSET_NAME)
+	Assets       []ScannedAsset // recognized asset files
+	Unrecognized int            // count of files that did not match any known asset name
+}
+
+// asset-name classification regexes (case-insensitive; extension validated separately).
+var (
+	kometaExtensions = map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".webp": true}
+
+	rePoster     = regexp.MustCompile(`(?i)^poster$`)
+	reBackground = regexp.MustCompile(`(?i)^background$`)
+	reSeason     = regexp.MustCompile(`(?i)^season(\d{1,3})$`)
+	reEpisode    = regexp.MustCompile(`(?i)^s(\d{1,3})e(\d{1,3})$`)
+)
+
+// Scan walks the asset directory one level deep and classifies the recognized asset files
+// in each folder. It reads only names and modification times; image bytes are read later,
+// one file at a time, during upload.
+func Scan(assetDir string) ([]ScannedFolder, error) {
+	entries, err := os.ReadDir(assetDir)
+	if err != nil {
+		return nil, err
+	}
+
+	folders := make([]ScannedFolder, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		folder := ScannedFolder{Name: entry.Name()}
+
+		files, err := os.ReadDir(filepath.Join(assetDir, entry.Name()))
+		if err != nil {
+			// Unreadable subfolder: record it as having no assets and move on.
+			folders = append(folders, folder)
+			continue
+		}
+
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			asset, ok := classifyAsset(file.Name())
+			if !ok {
+				folder.Unrecognized++
+				continue
+			}
+			if info, err := file.Info(); err == nil {
+				asset.ModTime = info.ModTime()
+			}
+			folder.Assets = append(folder.Assets, asset)
+		}
+
+		folders = append(folders, folder)
+	}
+
+	return folders, nil
+}
+
+// classifyAsset maps a file name to an internal asset type, or ok=false if it is not a
+// recognized Kometa asset file.
+func classifyAsset(fileName string) (ScannedAsset, bool) {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	if !kometaExtensions[ext] {
+		return ScannedAsset{}, false
+	}
+	base := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+
+	switch {
+	case rePoster.MatchString(base):
+		return ScannedAsset{FileName: fileName, Type: "poster"}, true
+	case reBackground.MatchString(base):
+		return ScannedAsset{FileName: fileName, Type: "backdrop"}, true
+	case reSeason.MatchString(base):
+		n, _ := strconv.Atoi(reSeason.FindStringSubmatch(base)[1])
+		season := n
+		if n == 0 {
+			return ScannedAsset{FileName: fileName, Type: "special_season_poster", Season: &season}, true
+		}
+		return ScannedAsset{FileName: fileName, Type: "season_poster", Season: &season}, true
+	case reEpisode.MatchString(base):
+		m := reEpisode.FindStringSubmatch(base)
+		s, _ := strconv.Atoi(m[1])
+		e, _ := strconv.Atoi(m[2])
+		return ScannedAsset{FileName: fileName, Type: "titlecard", Season: &s, Episode: &e}, true
+	default:
+		return ScannedAsset{}, false
+	}
+}

--- a/backend/kometa/status.go
+++ b/backend/kometa/status.go
@@ -7,13 +7,14 @@ import (
 
 // FolderOutcome captures what happened to a single asset folder during an import.
 type FolderOutcome struct {
-	Folder         string `json:"folder"`
-	Outcome        string `json:"outcome"` // matched, unmatched, collection, error
-	Detail         string `json:"detail,omitempty"`
-	ImagesUploaded int    `json:"images_uploaded"`
-	ImagesFailed   int    `json:"images_failed"`
-	RegisteredInDB bool   `json:"registered_in_db"`
-	ManagedByAura  bool   `json:"managed_by_aura"` // matched but DB registration skipped to protect MediUX selections
+	Folder             string `json:"folder"`
+	Outcome            string `json:"outcome"` // matched, unmatched, collection, skipped, error
+	Detail             string `json:"detail,omitempty"`
+	ImagesUploaded     int    `json:"images_uploaded"`
+	ImagesFailed       int    `json:"images_failed"`
+	ImagesSkippedOwned int    `json:"images_skipped_owned"` // assets not uploaded because a MediUX set owns their image type
+	RegisteredInDB     bool   `json:"registered_in_db"`
+	ManagedByAura      bool   `json:"managed_by_aura"` // one or more image types were skipped to protect MediUX selections
 }
 
 // ImportResult is the summary of the most recent import run.
@@ -26,8 +27,9 @@ type ImportResult struct {
 	UnmatchedFolders     int             `json:"unmatched_folders"`
 	ImagesUploaded       int             `json:"images_uploaded"`
 	ImagesFailed         int             `json:"images_failed"`
+	ImagesSkippedOwned   int             `json:"images_skipped_owned"` // assets not uploaded because a MediUX set owns their image type
 	ItemsRegistered      int             `json:"items_registered"`
-	SkippedManagedByAura int             `json:"skipped_managed_by_aura"`
+	SkippedManagedByAura int             `json:"skipped_managed_by_aura"` // items where at least one image type was protected
 	Error                string          `json:"error,omitempty"`
 	Folders              []FolderOutcome `json:"folders,omitempty"`
 }

--- a/backend/kometa/status.go
+++ b/backend/kometa/status.go
@@ -1,0 +1,65 @@
+package kometa
+
+import (
+	"sync"
+	"time"
+)
+
+// FolderOutcome captures what happened to a single asset folder during an import.
+type FolderOutcome struct {
+	Folder         string `json:"folder"`
+	Outcome        string `json:"outcome"` // matched, unmatched, collection, error
+	Detail         string `json:"detail,omitempty"`
+	ImagesUploaded int    `json:"images_uploaded"`
+	ImagesFailed   int    `json:"images_failed"`
+	RegisteredInDB bool   `json:"registered_in_db"`
+	ManagedByAura  bool   `json:"managed_by_aura"` // matched but DB registration skipped to protect MediUX selections
+}
+
+// ImportResult is the summary of the most recent import run.
+type ImportResult struct {
+	StartedAt            time.Time       `json:"started_at"`
+	FinishedAt           time.Time       `json:"finished_at"`
+	FoldersScanned       int             `json:"folders_scanned"`
+	Matched              int             `json:"matched"`
+	Collections          int             `json:"collections"`
+	UnmatchedFolders     int             `json:"unmatched_folders"`
+	ImagesUploaded       int             `json:"images_uploaded"`
+	ImagesFailed         int             `json:"images_failed"`
+	ItemsRegistered      int             `json:"items_registered"`
+	SkippedManagedByAura int             `json:"skipped_managed_by_aura"`
+	Error                string          `json:"error,omitempty"`
+	Folders              []FolderOutcome `json:"folders,omitempty"`
+}
+
+var (
+	statusMu   sync.Mutex
+	running    bool
+	lastResult *ImportResult
+)
+
+// Status returns whether an import is currently running and the most recent result (if any).
+func Status() (isRunning bool, result *ImportResult) {
+	statusMu.Lock()
+	defer statusMu.Unlock()
+	return running, lastResult
+}
+
+// tryStart marks an import as running. It returns false if one is already in progress.
+func tryStart() bool {
+	statusMu.Lock()
+	defer statusMu.Unlock()
+	if running {
+		return false
+	}
+	running = true
+	return true
+}
+
+// finish records the result and clears the running flag.
+func finish(result *ImportResult) {
+	statusMu.Lock()
+	defer statusMu.Unlock()
+	running = false
+	lastResult = result
+}

--- a/backend/mediaserver/plex/image_apply_collection.go
+++ b/backend/mediaserver/plex/image_apply_collection.go
@@ -56,5 +56,16 @@ func (p *Plex) ApplyCollectionImage(ctx context.Context, collectionItem *models.
 	}
 	defer resp.Body.Close()
 
+	// If Kometa mode is enabled, also write the collection image into the Kometa asset
+	// directory. This is non-fatal: a failure to write the asset must not fail the apply.
+	if config.Current.Images.Kometa.Enabled {
+		imageData, _, imgErr := mediux.GetImage(ctx, imageFile.ID, imageFile.Modified.Format("20060102150405"), mediux.ImageQualityOriginal)
+		if imgErr.Message != "" {
+			logAction.AppendWarning("kometa_save_failed", map[string]any{"error": imgErr.Message})
+		} else if kometaErr := SaveCollectionImageKometa(ctx, collectionItem, imageFile, imageData); kometaErr.Message != "" {
+			logAction.AppendWarning("kometa_save_failed", map[string]any{"error": kometaErr.Message})
+		}
+	}
+
 	return Err
 }

--- a/backend/mediaserver/plex/image_download.go
+++ b/backend/mediaserver/plex/image_download.go
@@ -33,8 +33,12 @@ func (p *Plex) DownloadApplyImageToMediaItem(ctx context.Context, item *models.M
 	}
 	logAction.AppendResult("image_rating_key", itemRatingKey)
 
-	// If SaveImageLocally is disabled, skip downloading the image
-	if !config.Current.Images.SaveImagesLocally.Enabled {
+	localEnabled := config.Current.Images.SaveImagesLocally.Enabled
+	kometaEnabled := config.Current.Images.Kometa.Enabled
+
+	// If neither local save nor Kometa mode is enabled, skip downloading the image bytes
+	// and apply it directly to Plex via the MediUX URL.
+	if !localEnabled && !kometaEnabled {
 		return applyImageToMediaItemViaMediuxURL(ctx, item, itemRatingKey, imageFile)
 	}
 
@@ -46,25 +50,26 @@ func (p *Plex) DownloadApplyImageToMediaItem(ctx context.Context, item *models.M
 		return Err
 	}
 
-	// Before we download and save the image locally, we need to get a list of the current posters in Plex
-	// This is to handle the case where the image is already set in Plex, and we need to replace it
-	// with the new image after saving it locally
-	// currentImages, logErr := getAllImages(ctx, item, itemRatingKey, "Current", imageFile.Type)
-	// if logErr.Message != "" {
-	// 	return logErr
-	// }
-
-	// Save the Image Locally
-	_, Err = saveImageLocally(ctx, p, item, imageFile, imageData)
-	if Err.Message != "" {
-		return Err
+	// Save the Image Locally (Plex Local Media Assets naming, next to content)
+	if localEnabled {
+		_, Err = saveImageLocally(ctx, p, item, imageFile, imageData)
+		if Err.Message != "" {
+			return Err
+		}
 	}
 
-	// If Save Image Next to Content is enabled and the Path is set, set the poster in Plex via the MediUX URL
-	// When the Path is set, the image is saved in a different location than Plex expects it to be.
-	// So we need to upload the image to Plex via the MediUX URL.
-	// if isCustomLocalPath {
-	applyImageToMediaItemViaMediuxURL(ctx, item, itemRatingKey, imageFile)
+	// Save the Image into the Kometa asset directory (Kometa naming conventions).
+	// This is non-fatal: a failure to write the asset must never block applying the image to Plex.
+	if kometaEnabled {
+		if kometaErr := saveImageKometa(ctx, p, item, imageFile, imageData); kometaErr.Message != "" {
+			logAction.AppendWarning("kometa_save_failed", map[string]any{
+				"error": kometaErr.Message,
+			})
+		}
+	}
+
+	// Apply the image to Plex via the MediUX URL (preserves existing immediate-apply behavior).
+	Err = applyImageToMediaItemViaMediuxURL(ctx, item, itemRatingKey, imageFile)
 	if Err.Message != "" {
 		return Err
 	}

--- a/backend/mediaserver/plex/image_kometa.go
+++ b/backend/mediaserver/plex/image_kometa.go
@@ -1,0 +1,241 @@
+package plex
+
+import (
+	"aura/config"
+	"aura/logging"
+	"aura/models"
+	"aura/utils"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// kometaAssetExtension is the on-disk extension AURA writes for Kometa assets.
+// MediUX originals are JPEG, and Kometa does not validate content type against the
+// extension, so a fixed ".jpg" keeps the folder-per-item layout unambiguous.
+const kometaAssetExtension = ".jpg"
+
+// kometaAssetBaseNames are the file base names (without extension) AURA may write for a
+// given media item folder. Used to clear stale same-name assets with other extensions
+// so Kometa's "<name>.*" glob resolves to exactly one file.
+var kometaKnownBaseNames = []string{"poster", "background"}
+
+// illegalFilesystemChars matches characters that are unsafe in a directory name across
+// the platforms AURA supports. Used when deriving an asset folder from a title (collections).
+var illegalFilesystemChars = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1f]`)
+
+// saveImageKometa writes a downloaded media-item image into the Kometa asset directory
+// using Kometa's folder-per-item (asset_folders: true) naming conventions:
+//
+//	<AssetDirectory>/<ASSET_NAME>/poster.jpg
+//	<AssetDirectory>/<ASSET_NAME>/background.jpg
+//	<AssetDirectory>/<ASSET_NAME>/Season##.jpg   (Season00 for specials)
+//	<AssetDirectory>/<ASSET_NAME>/S##E##.jpg      (episode title cards)
+//
+// where ASSET_NAME is the exact name of the folder the movie file lives in, or the show's
+// folder name. It is intentionally non-fatal to the caller: any error is returned so the
+// apply flow can log a warning and continue.
+func saveImageKometa(ctx context.Context, p *Plex, item *models.MediaItem, imageFile models.ImageFile, imageData []byte) logging.LogErrorInfo {
+	ctx, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf(
+		"Plex: Saving Kometa Asset %s for %s",
+		utils.GetFileDownloadName(item.Title, imageFile), utils.MediaItemInfo(*item),
+	), logging.LevelDebug)
+	defer logAction.Complete()
+
+	assetName, Err := kometaAssetName(ctx, p, item)
+	if Err.Message != "" {
+		return Err
+	}
+
+	fileName, ok := kometaFileName(imageFile)
+	if !ok {
+		logAction.SetError(
+			fmt.Sprintf("Unsupported image type '%s' for Kometa asset", imageFile.Type),
+			"Only poster, backdrop, season_poster, special_season_poster and titlecard are written as Kometa assets",
+			map[string]any{"image_type": imageFile.Type},
+		)
+		return *logAction.Error
+	}
+
+	assetDir := path.Join(config.Current.Images.Kometa.AssetDirectory, assetName)
+	logAction.AppendResult("kometa_asset_dir", assetDir)
+	logAction.AppendResult("kometa_file_name", fileName)
+
+	return writeKometaAsset(assetDir, fileName, imageData, logAction)
+}
+
+// kometaAssetName derives the Kometa ASSET_NAME (the media item's folder name) for a
+// movie or show. For movies it is the parent directory of the movie file; for shows it is
+// the base name of the series location.
+func kometaAssetName(ctx context.Context, p *Plex, item *models.MediaItem) (string, logging.LogErrorInfo) {
+	switch item.Type {
+	case "movie":
+		// Fetch full movie details if the file path is not yet populated (mirrors saveImageLocally).
+		if item.Movie == nil {
+			if _, Err := p.GetMediaItemDetails(ctx, item); Err.Message != "" {
+				return "", Err
+			}
+		}
+		if item.Movie == nil || item.Movie.File.Path == "" {
+			return "", kometaAssetNameError(item, "movie file path unavailable")
+		}
+		// Convert first so path.Base sees forward slashes when running against Windows paths.
+		filePath := convertWindowsPathToDockerPath(item.Movie.File.Path)
+		assetName := path.Base(path.Dir(filePath))
+		if assetName == "" || assetName == "." || assetName == "/" {
+			return "", kometaAssetNameError(item, "could not determine movie asset folder name")
+		}
+		return assetName, logging.LogErrorInfo{}
+	case "show":
+		if item.Series == nil || item.Series.Location == "" {
+			return "", kometaAssetNameError(item, "series location unavailable")
+		}
+		location := convertWindowsPathToDockerPath(item.Series.Location)
+		assetName := path.Base(location)
+		if assetName == "" || assetName == "." || assetName == "/" {
+			return "", kometaAssetNameError(item, "could not determine show asset folder name")
+		}
+		return assetName, logging.LogErrorInfo{}
+	default:
+		return "", kometaAssetNameError(item, "unsupported media item type")
+	}
+}
+
+func kometaAssetNameError(item *models.MediaItem, reason string) logging.LogErrorInfo {
+	return logging.LogErrorInfo{
+		Message: fmt.Sprintf("Failed to determine Kometa asset folder for %s: %s", item.Title, reason),
+		Help:    "Ensure the media item has been fully loaded from Plex and has a valid file path",
+		Detail:  map[string]any{"title": item.Title, "type": item.Type, "reason": reason},
+	}
+}
+
+// kometaFileName returns the Kometa asset file name for a given image type, or ok=false if
+// the image type is not written as a Kometa asset.
+func kometaFileName(imageFile models.ImageFile) (string, bool) {
+	switch imageFile.Type {
+	case "poster":
+		return "poster" + kometaAssetExtension, true
+	case "backdrop":
+		return "background" + kometaAssetExtension, true
+	case "season_poster":
+		if imageFile.SeasonNumber == nil {
+			return "", false
+		}
+		return fmt.Sprintf("Season%02d%s", *imageFile.SeasonNumber, kometaAssetExtension), true
+	case "special_season_poster":
+		return "Season00" + kometaAssetExtension, true
+	case "titlecard":
+		if imageFile.SeasonNumber == nil || imageFile.EpisodeNumber == nil {
+			return "", false
+		}
+		return fmt.Sprintf("S%02dE%02d%s", *imageFile.SeasonNumber, *imageFile.EpisodeNumber, kometaAssetExtension), true
+	default:
+		return "", false
+	}
+}
+
+// writeKometaAsset creates the asset folder if needed, removes any stale same-base-name
+// files with a different extension (so Kometa's glob is unambiguous), and writes the file,
+// overwriting an existing asset of the same name.
+func writeKometaAsset(assetDir, fileName string, imageData []byte, logAction *logging.LogAction) logging.LogErrorInfo {
+	if err := os.MkdirAll(assetDir, os.ModePerm); err != nil {
+		logAction.SetError("Failed to create Kometa asset directory", "Ensure the Kometa asset directory is writable",
+			map[string]any{"error": err.Error(), "path": assetDir})
+		return *logAction.Error
+	}
+
+	removeConflictingExtensions(assetDir, fileName)
+
+	savedFilePath := path.Join(assetDir, fileName)
+	if err := os.WriteFile(savedFilePath, imageData, 0o644); err != nil {
+		logAction.SetError("Failed to write Kometa asset file", "Ensure the Kometa asset directory is writable",
+			map[string]any{"error": err.Error(), "path": savedFilePath})
+		return *logAction.Error
+	}
+	logAction.AppendResult("kometa_saved_file_path", savedFilePath)
+	return logging.LogErrorInfo{}
+}
+
+// removeConflictingExtensions deletes sibling files that share fileName's base name but use
+// a different extension (e.g. removes poster.png when writing poster.jpg). Best-effort.
+func removeConflictingExtensions(assetDir, fileName string) {
+	base := strings.TrimSuffix(fileName, path.Ext(fileName))
+	for _, ext := range []string{".jpg", ".jpeg", ".png", ".webp"} {
+		if ext == kometaAssetExtension {
+			continue
+		}
+		conflict := path.Join(assetDir, base+ext)
+		if _, err := os.Stat(conflict); err == nil {
+			_ = os.Remove(conflict)
+		}
+	}
+}
+
+// sanitizeForFilesystem turns an arbitrary title into a safe single-segment folder name.
+// Used for collections, which have no on-disk folder to borrow a name from.
+func sanitizeForFilesystem(name string) string {
+	cleaned := illegalFilesystemChars.ReplaceAllString(name, "")
+	cleaned = strings.TrimSpace(cleaned)
+	cleaned = strings.Trim(cleaned, ".")
+	return strings.TrimSpace(cleaned)
+}
+
+// SaveCollectionImageKometa writes a collection poster/background into the Kometa asset
+// directory as <AssetDirectory>/<Collection Name>/poster.jpg or background.jpg. Non-fatal.
+func SaveCollectionImageKometa(ctx context.Context, collectionItem *models.CollectionItem, imageFile models.ImageFile, imageData []byte) logging.LogErrorInfo {
+	ctx, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf(
+		"Plex: Saving Kometa Collection Asset for %s", collectionItem.Title,
+	), logging.LevelDebug)
+	defer logAction.Complete()
+
+	assetName := sanitizeForFilesystem(collectionItem.Title)
+	if assetName == "" {
+		logAction.SetError("Failed to determine Kometa asset folder for collection",
+			"Collection title is empty after sanitization",
+			map[string]any{"title": collectionItem.Title})
+		return *logAction.Error
+	}
+
+	fileName := "poster" + kometaAssetExtension
+	if imageFile.Type == "collection_backdrop" || imageFile.Type == "backdrop" {
+		fileName = "background" + kometaAssetExtension
+	}
+
+	assetDir := path.Join(config.Current.Images.Kometa.AssetDirectory, assetName)
+	logAction.AppendResult("kometa_asset_dir", assetDir)
+	logAction.AppendResult("kometa_file_name", fileName)
+
+	return writeKometaAsset(assetDir, fileName, imageData, logAction)
+}
+
+// UploadImageBytes uploads raw image bytes directly to a Plex item (used by the Kometa
+// asset importer, which reads images from disk rather than downloading from MediUX).
+// imageType selects the Plex endpoint: "backdrop"/"collection_backdrop" -> /arts, everything
+// else -> /posters.
+func (p *Plex) UploadImageBytes(ctx context.Context, ratingKey string, imageType string, data []byte) logging.LogErrorInfo {
+	ctx, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf(
+		"Plex: Uploading %s image bytes to rating key %s", imageType, ratingKey), logging.LevelDebug)
+	defer logAction.Complete()
+
+	endpoint := "posters"
+	if imageType == "backdrop" || imageType == "collection_backdrop" {
+		endpoint = "arts"
+	}
+
+	url := fmt.Sprintf("%s/library/metadata/%s/%s", config.Current.MediaServer.URL, ratingKey, endpoint)
+	_, _, Err := makeRequest(ctx, config.Current.MediaServer, url, "POST", data)
+	if Err.Message != "" {
+		return Err
+	}
+	return logging.LogErrorInfo{}
+}
+
+// ResolveRatingKey exposes the internal rating-key resolution for a given media item and
+// image file (posters use the item key; season/episode assets resolve to the season/episode
+// rating key). Returns "" when the target does not exist on the server.
+func (p *Plex) ResolveRatingKey(item models.MediaItem, imageFile models.ImageFile) string {
+	return getItemRatingKeyFromImageFile(item, imageFile)
+}

--- a/backend/mediaserver/plex/image_kometa.go
+++ b/backend/mediaserver/plex/image_kometa.go
@@ -5,8 +5,10 @@ import (
 	"aura/logging"
 	"aura/models"
 	"aura/utils"
+	"aura/utils/httpx"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -17,11 +19,6 @@ import (
 // MediUX originals are JPEG, and Kometa does not validate content type against the
 // extension, so a fixed ".jpg" keeps the folder-per-item layout unambiguous.
 const kometaAssetExtension = ".jpg"
-
-// kometaAssetBaseNames are the file base names (without extension) AURA may write for a
-// given media item folder. Used to clear stale same-name assets with other extensions
-// so Kometa's "<name>.*" glob resolves to exactly one file.
-var kometaKnownBaseNames = []string{"poster", "background"}
 
 // illegalFilesystemChars matches characters that are unsafe in a directory name across
 // the platforms AURA supports. Used when deriving an asset folder from a title (collections).
@@ -225,10 +222,23 @@ func (p *Plex) UploadImageBytes(ctx context.Context, ratingKey string, imageType
 		endpoint = "arts"
 	}
 
+	// makeRequest defaults a missing Content-Type to application/json, which is wrong for
+	// raw image bytes; label the payload with its detected image MIME type instead.
+	headers := AddPlexHeaders(config.Current.MediaServer, map[string]string{
+		"Content-Type": http.DetectContentType(data),
+	})
+
 	url := fmt.Sprintf("%s/library/metadata/%s/%s", config.Current.MediaServer.URL, ratingKey, endpoint)
-	_, _, Err := makeRequest(ctx, config.Current.MediaServer, url, "POST", data)
+	resp, respBody, Err := httpx.MakeHTTPRequest(ctx, url, "POST", headers, 60, data, "Plex")
 	if Err.Message != "" {
 		return Err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logAction.SetError(fmt.Sprintf("Plex Server returned a %d status code", resp.StatusCode),
+			"Check the response from the server for more details",
+			map[string]any{"status_code": resp.StatusCode, "error_body": string(respBody)})
+		return *logAction.Error
 	}
 	return logging.LogErrorInfo{}
 }

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -136,6 +136,10 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 		jobs.StartAutoDownloadJob()
 	}
 
+	if imagesChanged {
+		jobs.StartKometaImportJob()
+	}
+
 	if mediaServerChanged {
 		autodownload.StartOrRestartPlexWebSocketClient()
 	}
@@ -415,6 +419,36 @@ func checkConfigDifferences_Images(ctx context.Context, oldImages config.Config_
 				Str("old_episode_naming_convention", oldImages.SaveImagesLocally.EpisodeNamingConvention).
 				Str("new_episode_naming_convention", newImages.SaveImagesLocally.EpisodeNamingConvention).
 				Msg("Images.SaveImagesLocally.EpisodeNamingConvention changed")
+			changed = true
+		}
+
+		if oldImages.Kometa.Enabled != newImages.Kometa.Enabled {
+			logAction.AppendResult("Images.Kometa.Enabled changed", fmt.Sprintf("from '%v' to '%v'", oldImages.Kometa.Enabled, newImages.Kometa.Enabled))
+			logging.LOGGER.Info().
+				Timestamp().
+				Bool("old_enabled", oldImages.Kometa.Enabled).
+				Bool("new_enabled", newImages.Kometa.Enabled).
+				Msg("Images.Kometa.Enabled changed")
+			changed = true
+		}
+
+		if oldImages.Kometa.AssetDirectory != newImages.Kometa.AssetDirectory {
+			logAction.AppendResult("Images.Kometa.AssetDirectory changed", fmt.Sprintf("from '%s' to '%s'", oldImages.Kometa.AssetDirectory, newImages.Kometa.AssetDirectory))
+			logging.LOGGER.Info().
+				Timestamp().
+				Str("old_asset_directory", oldImages.Kometa.AssetDirectory).
+				Str("new_asset_directory", newImages.Kometa.AssetDirectory).
+				Msg("Images.Kometa.AssetDirectory changed")
+			changed = true
+		}
+
+		if oldImages.Kometa.ImportCron != newImages.Kometa.ImportCron {
+			logAction.AppendResult("Images.Kometa.ImportCron changed", fmt.Sprintf("from '%s' to '%s'", oldImages.Kometa.ImportCron, newImages.Kometa.ImportCron))
+			logging.LOGGER.Info().
+				Timestamp().
+				Str("old_import_cron", oldImages.Kometa.ImportCron).
+				Str("new_import_cron", newImages.Kometa.ImportCron).
+				Msg("Images.Kometa.ImportCron changed")
 			changed = true
 		}
 	}

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -137,7 +137,9 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if imagesChanged {
-		jobs.StartKometaImportJob()
+		if err := jobs.StartKometaImportJob(); err != nil {
+			logging.LOGGER.Error().Timestamp().Err(err).Msg("Failed to reschedule Kometa Asset Import cron job after config update")
+		}
 	}
 
 	if mediaServerChanged {

--- a/backend/routing/database/autodownload_force_check.go
+++ b/backend/routing/database/autodownload_force_check.go
@@ -2,6 +2,7 @@ package routes_db
 
 import (
 	autodownload "aura/download/auto"
+	"aura/kometa"
 	"aura/logging"
 	"aura/mediaserver"
 	"aura/mediux"
@@ -91,6 +92,10 @@ func AutoDownloadForceCheck(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, posterSet := range req.Item.PosterSets {
+			// Kometa-imported sets have no MediUX set to re-fetch; skip them.
+			if kometa.IsKometaSetID(posterSet.ID) {
+				continue
+			}
 			switch posterSet.Type {
 			case "show":
 				showSet, _, Err := mediux.GetShowSetByID(ctx, posterSet.ID, req.Item.MediaItem.LibraryTitle)

--- a/backend/routing/images/kometa.go
+++ b/backend/routing/images/kometa.go
@@ -15,7 +15,7 @@ import (
 // @Summary      Get Kometa Asset Image
 // @Description  Serve a locally-imported Kometa asset by its image ID (kometa|<folder>/<file>) from the configured asset directory.
 // @Tags         Images
-// @Produce      image/jpeg
+// @Produce      image/jpeg,image/png,image/webp
 // @Param        asset_id   query     string  true  "Kometa image ID (kometa|<folder>/<file>)"
 // @Success      200  {string}  string "Image data"
 // @Failure      500  {object}  httpx.JSONResponse "Internal Server Error"
@@ -61,9 +61,22 @@ func GetKometaImage(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the path and ensure it stays within the asset directory (prevents traversal).
 	cleanBase := filepath.Clean(assetDir)
-	fullPath := filepath.Clean(filepath.Join(cleanBase, folder, file))
+	folderPath := filepath.Clean(filepath.Join(cleanBase, folder))
+	fullPath := filepath.Clean(filepath.Join(folderPath, file))
 	if !strings.HasPrefix(fullPath, cleanBase+string(os.PathSeparator)) {
 		logAction.SetError("Invalid Kometa asset path", "Resolved path escapes the asset directory", map[string]any{"asset_id": assetID})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	// Prevent symlink escapes: do not allow the folder or file to be symlinks.
+	if info, err := os.Lstat(folderPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		logAction.SetError("Invalid Kometa asset path", "Kometa asset folders must not be symlinks", map[string]any{"path": folderPath})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+	if info, err := os.Lstat(fullPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		logAction.SetError("Invalid Kometa asset path", "Kometa asset files must not be symlinks", map[string]any{"path": fullPath})
 		httpx.SendResponse(w, ld, nil)
 		return
 	}

--- a/backend/routing/images/kometa.go
+++ b/backend/routing/images/kometa.go
@@ -1,0 +1,72 @@
+package routes_images
+
+import (
+	"aura/config"
+	"aura/kometa"
+	"aura/logging"
+	"aura/utils/httpx"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetKometaImage godoc
+// @Summary      Get Kometa Asset Image
+// @Description  Serve a locally-imported Kometa asset by its image ID (kometa|<folder>/<file>) from the configured asset directory.
+// @Tags         Images
+// @Produce      image/jpeg
+// @Param        asset_id   query     string  true  "Kometa image ID (kometa|<folder>/<file>)"
+// @Success      200  {string}  string "Image data"
+// @Failure      500  {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/images/kometa/item [get]
+func GetKometaImage(w http.ResponseWriter, r *http.Request) {
+	_, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Get Kometa Image", logging.LevelInfo)
+
+	assetID := r.URL.Query().Get("asset_id")
+	rel := kometa.KometaImageRelPath(assetID)
+	if rel == "" {
+		logAction.SetError("Invalid Kometa asset ID", "asset_id must be a Kometa image ID (kometa|<folder>/<file>)", map[string]any{"asset_id": assetID})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	assetDir := config.Current.Images.Kometa.AssetDirectory
+	if assetDir == "" {
+		logAction.SetError("Kometa asset directory not configured", "Set the Kometa asset directory in the configuration", nil)
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	// Resolve the path and ensure it stays within the asset directory (prevents traversal).
+	cleanBase := filepath.Clean(assetDir)
+	fullPath := filepath.Clean(filepath.Join(cleanBase, filepath.FromSlash(rel)))
+	if fullPath != cleanBase && !strings.HasPrefix(fullPath, cleanBase+string(os.PathSeparator)) {
+		logAction.SetError("Invalid Kometa asset path", "Resolved path escapes the asset directory", map[string]any{"asset_id": assetID})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		logAction.SetError("Failed to read Kometa asset", "The asset file could not be read", map[string]any{"error": err.Error(), "path": fullPath})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", kometaContentType(filepath.Ext(fullPath)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+}
+
+func kometaContentType(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	default:
+		return "image/jpeg"
+	}
+}

--- a/backend/routing/images/kometa.go
+++ b/backend/routing/images/kometa.go
@@ -32,6 +32,26 @@ func GetKometaImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Kometa image IDs always encode exactly "<folder>/<file>"; reject anything deeper,
+	// shallower, or containing relative segments before touching the filesystem.
+	folder, file, ok := strings.Cut(rel, "/")
+	if !ok || folder == "" || file == "" || strings.Contains(file, "/") ||
+		folder == "." || folder == ".." || file == "." || file == ".." ||
+		strings.ContainsRune(folder, os.PathSeparator) || strings.ContainsRune(file, os.PathSeparator) {
+		logAction.SetError("Invalid Kometa asset path", "asset_id must encode exactly <folder>/<file>", map[string]any{"asset_id": assetID})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
+	// Only serve known image types; this endpoint must not expose arbitrary files.
+	switch strings.ToLower(filepath.Ext(file)) {
+	case ".jpg", ".jpeg", ".png", ".webp":
+	default:
+		logAction.SetError("Invalid Kometa asset extension", "Only jpg, jpeg, png and webp assets are served", map[string]any{"asset_id": assetID})
+		httpx.SendResponse(w, ld, nil)
+		return
+	}
+
 	assetDir := config.Current.Images.Kometa.AssetDirectory
 	if assetDir == "" {
 		logAction.SetError("Kometa asset directory not configured", "Set the Kometa asset directory in the configuration", nil)
@@ -41,8 +61,8 @@ func GetKometaImage(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the path and ensure it stays within the asset directory (prevents traversal).
 	cleanBase := filepath.Clean(assetDir)
-	fullPath := filepath.Clean(filepath.Join(cleanBase, filepath.FromSlash(rel)))
-	if fullPath != cleanBase && !strings.HasPrefix(fullPath, cleanBase+string(os.PathSeparator)) {
+	fullPath := filepath.Clean(filepath.Join(cleanBase, folder, file))
+	if !strings.HasPrefix(fullPath, cleanBase+string(os.PathSeparator)) {
 		logAction.SetError("Invalid Kometa asset path", "Resolved path escapes the asset directory", map[string]any{"asset_id": assetID})
 		httpx.SendResponse(w, ld, nil)
 		return

--- a/backend/routing/kometa/import.go
+++ b/backend/routing/kometa/import.go
@@ -1,0 +1,77 @@
+package routes_kometa
+
+import (
+	"aura/config"
+	"aura/kometa"
+	"aura/logging"
+	"aura/utils/httpx"
+	"net/http"
+)
+
+type importResponse struct {
+	Message string               `json:"message"`
+	Running bool                 `json:"running"`
+	Result  *kometa.ImportResult `json:"result,omitempty"`
+}
+
+// TriggerKometaImport godoc
+// @Summary      Trigger Kometa Asset Import
+// @Description  Scan the configured Kometa asset directory, upload matching assets to Plex, and record them in the database. Runs asynchronously; poll GET /api/kometa/import for progress.
+// @Tags         Kometa
+// @Accept       json
+// @Produce      json
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200  {object}  httpx.JSONResponse{data=routes_kometa.importResponse}
+// @Failure      500  {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/kometa/import [post]
+func TriggerKometaImport(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Trigger Kometa Import", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	var response importResponse
+
+	if !config.Current.Images.Kometa.Enabled || config.Current.MediaServer.Type != "Plex" {
+		logAction.SetError("Kometa mode is not enabled", "Enable Kometa mode (Plex only) before importing assets", nil)
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	if started := kometa.StartImport(); !started {
+		response.Running = true
+		response.Message = "A Kometa import is already running"
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	response.Running = true
+	response.Message = "Kometa asset import started"
+	httpx.SendResponse(w, ld, response)
+}
+
+// GetKometaImportStatus godoc
+// @Summary      Get Kometa Asset Import Status
+// @Description  Return whether a Kometa asset import is currently running and the result of the most recent run.
+// @Tags         Kometa
+// @Produce      json
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200  {object}  httpx.JSONResponse{data=routes_kometa.importResponse}
+// @Failure      500  {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/kometa/import [get]
+func GetKometaImportStatus(w http.ResponseWriter, r *http.Request) {
+	_, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	ld.AddAction("Get Kometa Import Status", logging.LevelTrace)
+
+	running, result := kometa.Status()
+	response := importResponse{Running: running, Result: result}
+	if running {
+		response.Message = "A Kometa import is currently running"
+	} else if result != nil {
+		response.Message = "Last Kometa import result"
+	} else {
+		response.Message = "No Kometa import has run yet"
+	}
+
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/kometa/import.go
+++ b/backend/routing/kometa/import.go
@@ -37,6 +37,14 @@ func TriggerKometaImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if config.Current.Images.Kometa.AssetDirectory == "" {
+		logAction.SetError("Kometa asset directory is not configured", "Set the Kometa asset directory before importing assets", nil)
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	// With enablement and configuration checked above, a false return from StartImport
+	// can only mean an import is already in flight.
 	if started := kometa.StartImport(); !started {
 		response.Running = true
 		response.Message = "A Kometa import is already running"

--- a/backend/routing/mediux/get_set_by_id.go
+++ b/backend/routing/mediux/get_set_by_id.go
@@ -1,6 +1,7 @@
 package routes_mediux
 
 import (
+	"aura/kometa"
 	"aura/logging"
 	"aura/mediux"
 	"aura/models"
@@ -52,6 +53,13 @@ func GetSetByID(w http.ResponseWriter, r *http.Request) {
 				"set_type":         setType,
 				"valid_item_types": []string{"show", "movie", "collection"},
 			})
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+	// Kometa-imported sets are stored on disk, not on MediUX; there is nothing to fetch.
+	if kometa.IsKometaSetID(setID) {
+		actionGetQueryParams.SetError("Kometa-imported set", "Kometa-imported sets are local assets and have no MediUX set to retrieve",
+			map[string]any{"set_id": setID})
 		httpx.SendResponse(w, ld, response)
 		return
 	}

--- a/backend/routing/routes.go
+++ b/backend/routing/routes.go
@@ -10,6 +10,7 @@ import (
 	routes_download "aura/routing/download"
 	routes_images "aura/routing/images"
 	routes_jobs "aura/routing/jobs"
+	routes_kometa "aura/routing/kometa"
 	routes_labels_tags "aura/routing/labels-tags"
 	routes_logging "aura/routing/logging"
 	routes_ms "aura/routing/mediaserver"
@@ -112,6 +113,7 @@ func AddRoutes(r *chi.Mux) {
 				r.Get("/media/collection", routes_images.GetCollectionItemImage)
 				r.Get("/mediux/item", routes_images.GetMediuxImage)
 				r.Get("/mediux/avatar", routes_images.GetMediuxAvatarImage)
+				r.Get("/kometa/item", routes_images.GetKometaImage)
 				r.Delete("/temp", routes_images.DeleteTempImages)
 			})
 
@@ -119,6 +121,12 @@ func AddRoutes(r *chi.Mux) {
 			r.Route("/jobs", func(r chi.Router) {
 				r.Get("/", routes_jobs.GetAllJobs)
 				r.Post("/", routes_jobs.RunJob)
+			})
+
+			// Kometa Routes
+			r.Route("/kometa", func(r chi.Router) {
+				r.Post("/import", routes_kometa.TriggerKometaImport)
+				r.Get("/import", routes_kometa.GetKometaImportStatus)
 			})
 
 			// Labels & Tags Route

--- a/backend/routing/sonarr-radarr/webhook_sonarr.go
+++ b/backend/routing/sonarr-radarr/webhook_sonarr.go
@@ -3,6 +3,7 @@ package routes_sonarr_radarr
 import (
 	"aura/cache"
 	"aura/database"
+	"aura/kometa"
 	"aura/logging"
 	"aura/mediaserver"
 	"aura/mediux"
@@ -276,6 +277,11 @@ func processSonarrDownloadEvent(ctx context.Context, payload SonarrWebHookOnUpgr
 
 	for _, dbSet := range dbItem.PosterSets {
 		if !dbSet.SelectedTypes.SeasonPoster && !dbSet.SelectedTypes.SpecialSeasonPoster && !dbSet.SelectedTypes.Titlecard {
+			continue
+		}
+
+		// Kometa-imported sets have no MediUX set to re-fetch; skip them.
+		if kometa.IsKometaSetID(dbSet.ID) {
 			continue
 		}
 

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -166,6 +166,11 @@ func runWarmup() (success bool) {
 	config.AppLoadingStep = "Starting Background Jobs"
 	jobs.StartAutoDownloadJob()
 
+	// Cronjob: Kometa Asset Import (only schedules if enabled + ImportCron set)
+	if err := jobs.StartKometaImportJob(); err != nil {
+		logging.LOGGER.Error().Timestamp().Err(err).Msg("Failed to schedule Kometa Asset Import cron job")
+	}
+
 	// Cronjob: Download Queue Processing
 	err := jobs.StartDownloadQueueJob()
 	if err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -233,6 +233,10 @@ Images:
     Path: ""
     EpisodeNamingConvention: "match"
     RunningOnWindows: false
+  Kometa:
+    Enabled: false
+    AssetDirectory: ""
+    ImportCron: ""
 ```
 
 ## CacheImages.Enabled
@@ -283,6 +287,62 @@ Images:
   - If `true`, file paths will use Windows-style backslashes (`\`) and handle file permissions accordingly.
   - If `false`, file paths will use Unix-style forward slashes (`/`) and handle file permissions for Unix-based systems.
 - **Note:** This option is only applicable when using Plex as the Media Server and `SaveImagesLocally.Enabled` is `true`. It helps ensure that file paths and permissions are correctly handled based on the operating system you are running the application on.
+
+## Kometa (Plex Only)
+
+Kometa mode makes aura play nicely with [Kometa](https://kometa.wiki/). When enabled, images that aura downloads are also written into Kometa's asset directory using Kometa's folder-per-item conventions (`asset_folders: true`), in addition to being applied to Plex immediately. aura can also import assets already in that directory. This is a Plex-exclusive feature and is independent of `SaveImagesLocally` (they write to different places for different consumers).
+
+The folder-per-item layout aura writes and imports:
+
+```
+<AssetDirectory>/<Item Folder Name>/poster.jpg
+<AssetDirectory>/<Item Folder Name>/background.jpg
+<AssetDirectory>/<Item Folder Name>/Season01.jpg      # Season00 for specials
+<AssetDirectory>/<Item Folder Name>/S01E01.jpg        # episode title cards
+<AssetDirectory>/<Collection Name>/poster.jpg
+```
+
+`Item Folder Name` is the exact name of the folder the movie file lives in, or the show's folder — the same value Kometa uses to look up assets.
+
+### Kometa.Enabled
+
+- **Default:** `false`
+- **Options:** `true` or `false`
+- **Description:** Whether to write downloaded images into the Kometa asset directory and enable importing existing Kometa assets. Plex only.
+
+### Kometa.AssetDirectory
+
+- **Default:** `""` (empty string)
+- **Options:** Any valid directory path
+- **Description:** The directory Kometa reads assets from (its `asset_directory`).
+- **Details:**
+  - Must be mounted into the aura container at this exact path and be writable.
+  - Required when `Kometa.Enabled` is `true`.
+
+### Kometa.ImportCron
+
+- **Default:** `""` (empty string)
+- **Options:** A valid cron expression, or empty
+- **Description:** Optional schedule for automatically importing existing Kometa assets.
+- **Details:**
+  - When set, aura periodically scans the asset directory, uploads matching assets to Plex, and records them.
+  - Leave empty to only import manually via the **Import Existing Kometa Assets** button in Settings (or `POST /api/kometa/import`).
+
+### Importing existing Kometa assets
+
+An import scans `AssetDirectory`, matches each folder to a Plex media item (by `Title (Year)`, a `{tmdb-12345}` hint, or a collection title), uploads the images to Plex, and records them as a "Kometa Import" set so they appear in the aura UI. Items already managed by an aura (MediUX) set keep their existing selections — the import never overwrites them in the database, though the image is still pushed to Plex.
+
+### Migrating from `SaveImagesLocally` to Kometa
+
+If you previously used `SaveImagesLocally`, the `scripts/kometa_migrate.py` helper copies your existing assets (`poster.jpg`, `season01-poster.jpg`, `<episode>-thumb.jpg`, `S01E01.jpg`, …) into the Kometa folder-per-item layout. It runs as a dry-run by default:
+
+```bash
+# Preview the plan
+python3 scripts/kometa_migrate.py --source /data/media --dest /assets
+
+# Perform the migration (copy). Add --move to move instead of copy.
+python3 scripts/kometa_migrate.py --source /data/media --dest /assets --apply
+```
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -330,7 +330,7 @@ The folder-per-item layout aura writes and imports:
 
 ### Importing existing Kometa assets
 
-An import scans `AssetDirectory`, matches each folder to a Plex media item (by `Title (Year)`, a `{tmdb-12345}` hint, or a collection title), uploads the images to Plex, and records them as a "Kometa Import" set so they appear in the aura UI. Items already managed by an aura (MediUX) set keep their existing selections — the import never overwrites them in the database, though the image is still pushed to Plex.
+An import scans `AssetDirectory`, matches each folder to a Plex media item (by `Title (Year)`, a `{tmdb-12345}` hint, or a collection title), uploads the images to Plex, and records them as a "Kometa Import" set so they appear in the aura UI. Items already managed by an aura (MediUX) set take precedence: any image type a MediUX set owns is skipped entirely — neither pushed to Plex nor recorded in the database — and items you have ignored in aura are skipped altogether. Skipped assets are reported in the import result.
 
 ### Migrating from `SaveImagesLocally` to Kometa
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -53,6 +53,7 @@ type SectionDirty<S extends ObjectSectionKeys = ObjectSectionKeys> = S extends "
 interface ImagesDirty {
   cache_images?: { enabled?: boolean };
   save_images_locally?: { enabled?: boolean; path?: string };
+  kometa?: { enabled?: boolean; asset_directory?: string; import_cron?: string };
 }
 
 type NotificationsDirty = {
@@ -561,6 +562,19 @@ const SettingsPage: React.FC = () => {
                                   typeof dirty.images.save_images_locally.path === "string"
                                     ? !!dirty.images.save_images_locally.path
                                     : dirty.images.save_images_locally.path,
+                              }
+                            : undefined,
+                          kometa: dirty.images.kometa
+                            ? {
+                                ...dirty.images.kometa,
+                                asset_directory:
+                                  typeof dirty.images.kometa.asset_directory === "string"
+                                    ? !!dirty.images.kometa.asset_directory
+                                    : dirty.images.kometa.asset_directory,
+                                import_cron:
+                                  typeof dirty.images.kometa.import_cron === "string"
+                                    ? !!dirty.images.kometa.import_cron
+                                    : dirty.images.kometa.import_cron,
                               }
                             : undefined,
                         }

--- a/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
@@ -140,6 +140,12 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
       }
     }
 
+    // Kometa mode is Plex-only; if it stays enabled after a server-type change the backend
+    // rejects the save, so tell the user how to resolve it.
+    if (mediaServerType !== "Plex" && value.kometa.enabled) {
+      errs.kometa = "Kometa mode only supports Plex. Disable it or switch the media server type back to Plex.";
+    }
+
     // If Kometa mode is enabled (Plex only), an asset directory is required.
     if (mediaServerType === "Plex" && value.kometa.enabled && !value.kometa.asset_directory) {
       errs.kometa = "Kometa asset directory is required when Kometa mode is enabled.";
@@ -322,8 +328,10 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
         </div>
       )}
 
-      {/* Kometa Mode (Plex only) */}
-      {mediaServerType === "Plex" && (
+      {/* Kometa Mode (Plex only). Stays visible while enabled on a non-Plex server so the
+          user can still turn it off — otherwise the save is rejected (Kometa is Plex-only)
+          with no visible switch to clear it. */}
+      {(mediaServerType === "Plex" || value.kometa.enabled) && (
         <div
           className={cn(
             "border rounded-md p-3 transition",
@@ -414,8 +422,8 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
                     <p className="text-sm text-muted-foreground">
                       Last import: {kometaResult.images_uploaded} images uploaded, {kometaResult.items_registered} items
                       tracked, {kometaResult.unmatched_folders} unmatched
-                      {kometaResult.skipped_managed_by_aura > 0 &&
-                        `, ${kometaResult.skipped_managed_by_aura} kept as AURA-managed`}
+                      {kometaResult.images_skipped_owned > 0 &&
+                        `, ${kometaResult.images_skipped_owned} skipped (AURA-managed)`}
                       {kometaResult.error && ` — error: ${kometaResult.error}`}
                     </p>
                   )}

--- a/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
@@ -82,6 +82,21 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
     }
   };
 
+  // On mount, sync with any import that was started elsewhere (cron or direct API call)
+  // so the button state and last result are accurate before the user interacts.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const response = await GetKometaImportStatus();
+      if (cancelled || response.status === "error" || !response.data) return;
+      if (response.data.result) setKometaResult(response.data.result);
+      if (response.data.running) setKometaImporting(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Poll import status while an import is running so the UI reflects progress and results.
   useEffect(() => {
     if (!kometaImporting) return;

--- a/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionImages.tsx
@@ -2,12 +2,14 @@
 
 import { ReturnErrorMessage } from "@/services/api-error-return";
 import { DeleteTempImages } from "@/services/images/api-images-actions";
+import { GetKometaImportStatus, type KometaImportResult, TriggerKometaImport } from "@/services/kometa/import";
 import { toast } from "sonner";
 
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { ConfirmDestructiveDialogActionButton } from "@/components/shared/dialog-destructive-action";
 import { PopoverHelp } from "@/components/shared/popover-help";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -38,6 +40,11 @@ interface ConfigSectionImagesProps {
       path?: boolean;
       episode_naming_convention?: boolean;
     };
+    kometa?: {
+      enabled?: boolean;
+      asset_directory?: boolean;
+      import_cron?: boolean;
+    };
   };
   onChange: <K extends keyof AppConfigImages, F extends keyof AppConfigImages[K]>(
     group: K,
@@ -58,6 +65,9 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
 }) => {
   const prevErrorsRef = useRef<string>("{}");
 
+  const [kometaImporting, setKometaImporting] = useState(false);
+  const [kometaResult, setKometaResult] = useState<KometaImportResult | null>(null);
+
   const clearTempImagesFolder = async () => {
     try {
       const response = await DeleteTempImages();
@@ -70,6 +80,35 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
       const errorResponse = ReturnErrorMessage<void>(error);
       toast.error(errorResponse.error?.message || "An unexpected error occurred");
     }
+  };
+
+  // Poll import status while an import is running so the UI reflects progress and results.
+  useEffect(() => {
+    if (!kometaImporting) return;
+    let cancelled = false;
+    const interval = setInterval(async () => {
+      const response = await GetKometaImportStatus();
+      if (cancelled || response.status === "error" || !response.data) return;
+      if (response.data.result) setKometaResult(response.data.result);
+      if (!response.data.running) {
+        setKometaImporting(false);
+        toast.success("Kometa asset import finished");
+      }
+    }, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [kometaImporting]);
+
+  const runKometaImport = async () => {
+    const response = await TriggerKometaImport();
+    if (response.status === "error") {
+      toast.error(response.error?.message || "Failed to start Kometa import");
+      return;
+    }
+    setKometaImporting(true);
+    toast.info("Kometa asset import started");
   };
 
   const errors = React.useMemo<Partial<Record<keyof AppConfigImages, string>>>(() => {
@@ -86,8 +125,19 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
       }
     }
 
+    // If Kometa mode is enabled (Plex only), an asset directory is required.
+    if (mediaServerType === "Plex" && value.kometa.enabled && !value.kometa.asset_directory) {
+      errs.kometa = "Kometa asset directory is required when Kometa mode is enabled.";
+    }
+
     return errs;
-  }, [mediaServerType, value.save_images_locally.enabled, value.save_images_locally.episode_naming_convention]);
+  }, [
+    mediaServerType,
+    value.save_images_locally.enabled,
+    value.save_images_locally.episode_naming_convention,
+    value.kometa.enabled,
+    value.kometa.asset_directory,
+  ]);
 
   // Emit errors upward
   useEffect(() => {
@@ -252,6 +302,110 @@ export const ConfigSectionImages: React.FC<ConfigSectionImagesProps> = ({
                   <SelectScrollDownButton />
                 </SelectContent>
               </Select>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Kometa Mode (Plex only) */}
+      {mediaServerType === "Plex" && (
+        <div
+          className={cn(
+            "border rounded-md p-3 transition",
+            "border-muted",
+            dirtyFields.kometa?.enabled && "border-amber-500"
+          )}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <Label className="mr-2">Kometa Mode</Label>
+            <div className="flex items-center gap-2">
+              <Switch
+                disabled={!editing}
+                checked={!!value.kometa.enabled}
+                onCheckedChange={(v) => onChange("kometa", "enabled", v)}
+              />
+              {editing && (
+                <PopoverHelp ariaLabel="help-images-kometa">
+                  <p>
+                    Write downloaded images into your Kometa asset directory using Kometa&apos;s folder-per-item naming
+                    (<span className="font-mono">poster.jpg</span>, <span className="font-mono">background.jpg</span>,{" "}
+                    <span className="font-mono">Season01.jpg</span>, <span className="font-mono">S01E01.jpg</span>).
+                    Images are still applied to Plex immediately. Plex only.
+                  </p>
+                </PopoverHelp>
+              )}
+            </div>
+          </div>
+
+          {value.kometa.enabled && (
+            <div className="mt-2 space-y-4">
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <Label className="mr-2">Asset Directory</Label>
+                  {editing && (
+                    <PopoverHelp ariaLabel="help-images-kometa-asset-dir">
+                      <p>
+                        The directory Kometa reads assets from (its <span className="font-mono">asset_directory</span>).
+                        Must be mounted into the Aura container at this exact path.
+                      </p>
+                    </PopoverHelp>
+                  )}
+                </div>
+                <Input
+                  type="text"
+                  disabled={!editing}
+                  value={value.kometa.asset_directory || ""}
+                  onChange={(e) => onChange("kometa", "asset_directory", e.target.value)}
+                  className={cn(
+                    "w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 transition",
+                    (dirtyFields.kometa?.asset_directory || errors.kometa) && "border-amber-500"
+                  )}
+                  placeholder="/assets"
+                />
+                {errors.kometa && <p className="text-sm text-destructive mt-1">{errors.kometa}</p>}
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <Label className="mr-2">Import Schedule (Cron)</Label>
+                  {editing && (
+                    <PopoverHelp ariaLabel="help-images-kometa-cron">
+                      <p>
+                        Optional cron expression to periodically import existing Kometa assets. Leave blank to only
+                        import manually with the button below.
+                      </p>
+                    </PopoverHelp>
+                  )}
+                </div>
+                <Input
+                  type="text"
+                  disabled={!editing}
+                  value={value.kometa.import_cron || ""}
+                  onChange={(e) => onChange("kometa", "import_cron", e.target.value)}
+                  className={cn(
+                    "w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 transition",
+                    dirtyFields.kometa?.import_cron && "border-amber-500"
+                  )}
+                  placeholder="0 3 * * * (optional)"
+                />
+              </div>
+
+              {!editing && (
+                <div className="flex flex-col gap-2">
+                  <Button type="button" variant="outline" onClick={runKometaImport} disabled={kometaImporting}>
+                    {kometaImporting ? "Importing…" : "Import Existing Kometa Assets"}
+                  </Button>
+                  {kometaResult && (
+                    <p className="text-sm text-muted-foreground">
+                      Last import: {kometaResult.images_uploaded} images uploaded, {kometaResult.items_registered} items
+                      tracked, {kometaResult.unmatched_folders} unmatched
+                      {kometaResult.skipped_managed_by_aura > 0 &&
+                        `, ${kometaResult.skipped_managed_by_aura} kept as AURA-managed`}
+                      {kometaResult.error && ` — error: ${kometaResult.error}`}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -16,6 +16,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 import { cn } from "@/lib/cn";
 import { type AspectRatio, getAspectRatioClass, getImageSizes } from "@/lib/image-sizes";
+import { isKometaImageId, kometaImageSrc } from "@/lib/kometa";
 import { log } from "@/lib/logger";
 import { useUserPreferencesStore } from "@/lib/stores/global-user-preferences";
 
@@ -106,7 +107,10 @@ export function AssetImage({
   if (imageType === "url") {
     imageSrc = image as string;
   } else if (imageType === "mediux") {
-    imageSrc = `/api/images/mediux/item?asset_id=${(image as ImageFile).id}&modified_date=${(image as ImageFile).modified}`;
+    const assetId = (image as ImageFile).id;
+    imageSrc = isKometaImageId(assetId)
+      ? kometaImageSrc(assetId)
+      : `/api/images/mediux/item?asset_id=${assetId}&modified_date=${(image as ImageFile).modified}`;
   } else if (imageType === "item") {
     imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}`;
   } else if (imageType === "collection") {

--- a/frontend/src/components/shared/saved-sets-shared.tsx
+++ b/frontend/src/components/shared/saved-sets-shared.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dialog";
 
 import { cn } from "@/lib/cn";
+import { isKometaSetId } from "@/lib/kometa";
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
@@ -60,6 +61,10 @@ export const refreshPosterSet = async ({
     await Promise.all(
       editSets.map(async (set) => {
         if (set.id === "ignore") {
+          return;
+        }
+        // Kometa-imported sets are local assets with no MediUX counterpart to refresh.
+        if (isKometaSetId(set.id)) {
           return;
         }
 

--- a/frontend/src/components/shared/show-full-set.tsx
+++ b/frontend/src/components/shared/show-full-set.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { H1, Lead } from "@/components/ui/typography";
 
+import { isKometaSetId } from "@/lib/kometa";
 import { log } from "@/lib/logger";
 import { useOnboardingStore } from "@/lib/stores/global-store-onboarding";
 import { useUserPreferencesStore } from "@/lib/stores/global-user-preferences";
@@ -538,15 +539,17 @@ const ShowFullSetDetails: React.FC<{
             </Avatar>
             {baseSetInfo.user_created}
           </Badge>
-          <Badge
-            className="flex items-center text-sm hover:text-white transition-colors hover:brightness-120 cursor-pointer active:scale-95"
-            onClick={(e) => {
-              e.stopPropagation();
-              window.open(`${mediuxURL}`, "_blank");
-            }}
-          >
-            View on MediUX
-          </Badge>
+          {!isKometaSetId(baseSetInfo.id) && (
+            <Badge
+              className="flex items-center text-sm hover:text-white transition-colors hover:brightness-120 cursor-pointer active:scale-95"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(`${mediuxURL}`, "_blank");
+              }}
+            >
+              View on MediUX
+            </Badge>
+          )}
         </div>
 
         {/* Season/Episode Information */}

--- a/frontend/src/lib/kometa.ts
+++ b/frontend/src/lib/kometa.ts
@@ -1,0 +1,20 @@
+// Identifiers for Kometa-imported saved sets and locally-imported asset images.
+// These mirror the backend prefixes in backend/kometa/kometa.go.
+
+const KOMETA_SET_ID_PREFIX = "kometa-";
+const KOMETA_IMAGE_ID_PREFIX = "kometa|";
+
+// isKometaSetId reports whether a poster set ID belongs to a Kometa asset import.
+export function isKometaSetId(id: string | undefined | null): boolean {
+  return !!id && id.startsWith(KOMETA_SET_ID_PREFIX);
+}
+
+// isKometaImageId reports whether an image ID refers to a locally-imported Kometa asset.
+export function isKometaImageId(id: string | undefined | null): boolean {
+  return !!id && id.startsWith(KOMETA_IMAGE_ID_PREFIX);
+}
+
+// kometaImageSrc builds the URL that serves a locally-imported Kometa asset image.
+export function kometaImageSrc(id: string): string {
+  return `/api/images/kometa/item?asset_id=${encodeURIComponent(id)}`;
+}

--- a/frontend/src/services/kometa/import.ts
+++ b/frontend/src/services/kometa/import.ts
@@ -1,0 +1,61 @@
+import apiClient from "@/services/api-client";
+import { ReturnErrorMessage } from "@/services/api-error-return";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+
+export interface KometaImportFolderOutcome {
+  folder: string;
+  outcome: string; // matched | unmatched | collection | error
+  detail?: string;
+  images_uploaded: number;
+  images_failed: number;
+  registered_in_db: boolean;
+  managed_by_aura: boolean;
+}
+
+export interface KometaImportResult {
+  started_at: string;
+  finished_at: string;
+  folders_scanned: number;
+  matched: number;
+  collections: number;
+  unmatched_folders: number;
+  images_uploaded: number;
+  images_failed: number;
+  items_registered: number;
+  skipped_managed_by_aura: number;
+  error?: string;
+  folders?: KometaImportFolderOutcome[];
+}
+
+export interface KometaImport_Response {
+  message: string;
+  running: boolean;
+  result?: KometaImportResult;
+}
+
+// TriggerKometaImport starts an asynchronous import of existing Kometa assets.
+export const TriggerKometaImport = async (): Promise<APIResponse<KometaImport_Response>> => {
+  log("INFO", "API - Settings", "Kometa Import", "Triggering Kometa asset import");
+  try {
+    const response = await apiClient.post<APIResponse<KometaImport_Response>>(`/kometa/import`);
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error triggering Kometa import");
+    }
+    return response.data;
+  } catch (error) {
+    return ReturnErrorMessage<KometaImport_Response>(error);
+  }
+};
+
+// GetKometaImportStatus returns whether an import is running plus the last result.
+export const GetKometaImportStatus = async (): Promise<APIResponse<KometaImport_Response>> => {
+  try {
+    const response = await apiClient.get<APIResponse<KometaImport_Response>>(`/kometa/import`);
+    return response.data;
+  } catch (error) {
+    return ReturnErrorMessage<KometaImport_Response>(error);
+  }
+};

--- a/frontend/src/services/kometa/import.ts
+++ b/frontend/src/services/kometa/import.ts
@@ -7,10 +7,11 @@ import type { APIResponse } from "@/types/api/api-response";
 
 export interface KometaImportFolderOutcome {
   folder: string;
-  outcome: string; // matched | unmatched | collection | error
+  outcome: string; // matched | unmatched | collection | skipped | error
   detail?: string;
   images_uploaded: number;
   images_failed: number;
+  images_skipped_owned: number; // assets not uploaded because a MediUX set owns their image type
   registered_in_db: boolean;
   managed_by_aura: boolean;
 }
@@ -24,6 +25,7 @@ export interface KometaImportResult {
   unmatched_folders: number;
   images_uploaded: number;
   images_failed: number;
+  images_skipped_owned: number; // assets not uploaded because a MediUX set owns their image type
   items_registered: number;
   skipped_managed_by_aura: number;
   error?: string;

--- a/frontend/src/types/config/config-default-app.ts
+++ b/frontend/src/types/config/config-default-app.ts
@@ -33,6 +33,11 @@ export const defaultAppConfig = (): AppConfig =>
         path: "",
         episode_naming_convention: "",
       },
+      kometa: {
+        enabled: false,
+        asset_directory: "",
+        import_cron: "",
+      },
     },
     tmdb: {
       api_token: "",

--- a/frontend/src/types/config/config.ts
+++ b/frontend/src/types/config/config.ts
@@ -51,6 +51,7 @@ export interface AppConfigAutoDownload {
 export interface AppConfigImages {
   cache_images: AppConfigCacheImages;
   save_images_locally: AppConfigSaveImagesLocally;
+  kometa: AppConfigKometa;
 }
 
 export interface AppConfigCacheImages {
@@ -61,6 +62,12 @@ export interface AppConfigSaveImagesLocally {
   enabled: boolean; // Whether to save images locally.
   path: string; // Path to save images locally. If empty, images will be saved next to content.
   episode_naming_convention: string; // Naming convention for episode images.
+}
+
+export interface AppConfigKometa {
+  enabled: boolean; // Whether to write downloaded images into the Kometa asset directory (Plex only).
+  asset_directory: string; // Path to the Kometa asset directory (folder-per-item layout).
+  import_cron: string; // Optional cron for importing existing Kometa assets. Empty = manual only.
 }
 
 export interface AppConfigTMDB {

--- a/scripts/kometa_migrate.py
+++ b/scripts/kometa_migrate.py
@@ -194,7 +194,8 @@ def main(argv=None):
     if failed:
         print("  failed            : %d" % failed)
     if collisions:
-        print("  collisions        : %d (multiple sources map to the same asset; last wins)" % len(collisions))
+        winner = "last wins" if args.overwrite else "first wins (later sources skipped unless --overwrite)"
+        print("  collisions        : %d (multiple sources map to the same asset; %s)" % (len(collisions), winner))
         for a, b in collisions:
             print("    %s  and  %s  ->  %s/%s" % (a, b.src, b.asset_name, b.dest_name))
     if unrecognized_thumbs:

--- a/scripts/kometa_migrate.py
+++ b/scripts/kometa_migrate.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Migrate AURA "save images locally" assets to the Kometa asset directory layout.
+
+AURA's local-save feature (Images.SaveImagesLocally) writes Plex Local-Media-Assets
+names either next to content or under a custom path that mirrors the library structure:
+
+    <item folder>/poster.jpg
+    <item folder>/backdrop.jpg
+    <show folder>/season01-poster.jpg
+    <show folder>/season-specials-poster.jpg
+    <show folder>/<Season XX>/<episode base>-thumb.jpg   (episode_naming_convention: match)
+    <show folder>/<Season XX>/S01E01.jpg                 (episode_naming_convention: static)
+
+Kometa's asset directory (asset_folders: true) uses a folder per item, named after the
+item's media folder, containing:
+
+    <asset dir>/<ASSET_NAME>/poster.<ext>
+    <asset dir>/<ASSET_NAME>/background.<ext>
+    <asset dir>/<ASSET_NAME>/Season01.<ext>      (Season00 for specials)
+    <asset dir>/<ASSET_NAME>/S01E01.<ext>
+
+ASSET_NAME is the exact name of the item's media folder: for posters/backdrops/season
+posters it is the file's parent folder; for episode title cards (which AURA stores inside
+a season subfolder) it is the show folder (the grandparent of the file).
+
+This script walks a source tree, maps each recognized AURA asset to its Kometa
+destination, and copies (default) or moves it. It runs in dry-run mode unless --apply is
+given, so you can preview the plan first.
+
+Examples:
+    # Preview what would happen (nothing is written):
+    python3 kometa_migrate.py --source /data/media --dest /assets
+
+    # Actually copy the assets into the Kometa asset directory:
+    python3 kometa_migrate.py --source /data/media --dest /assets --apply
+
+    # Move instead of copy (removes the originals), for a custom SaveImagesLocally path:
+    python3 kometa_migrate.py --source /local/aura-images --dest /assets --apply --move
+"""
+
+import argparse
+import os
+import re
+import shutil
+import sys
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp"}
+
+# AURA local-save file-name patterns (case-insensitive), matched against the base name
+# (without extension).
+RE_POSTER = re.compile(r"^poster$", re.IGNORECASE)
+RE_BACKDROP = re.compile(r"^backdrop$", re.IGNORECASE)
+RE_SEASON_POSTER = re.compile(r"^season(\d{1,3})-poster$", re.IGNORECASE)
+RE_SPECIAL_SEASON = re.compile(r"^season-specials-poster$", re.IGNORECASE)
+# Static title card, e.g. "S01E02"
+RE_STATIC_TITLECARD = re.compile(r"^s(\d{1,3})e(\d{1,3})$", re.IGNORECASE)
+# "match" title card, e.g. "Show - S01E02 - Title-thumb"; extract SxxEyy anywhere before -thumb.
+RE_MATCH_TITLECARD = re.compile(r"^(?P<base>.+)-thumb$", re.IGNORECASE)
+RE_SXXEYY_ANYWHERE = re.compile(r"s(\d{1,3})e(\d{1,3})", re.IGNORECASE)
+
+
+class Plan:
+    """A single file's planned migration."""
+
+    def __init__(self, src, asset_name, dest_name):
+        self.src = src
+        self.asset_name = asset_name
+        self.dest_name = dest_name
+
+    def dest_path(self, dest_root):
+        return os.path.join(dest_root, self.asset_name, self.dest_name)
+
+
+def classify(path):
+    """Return a Plan for an AURA asset file, or None if the file is not recognized."""
+    directory, filename = os.path.split(path)
+    base, ext = os.path.splitext(filename)
+    ext_lower = ext.lower()
+    if ext_lower not in IMAGE_EXTS:
+        return None
+
+    parent_name = os.path.basename(directory)
+    grandparent_name = os.path.basename(os.path.dirname(directory))
+
+    # Posters / backdrops / season posters live directly in the item folder.
+    if RE_POSTER.match(base):
+        return Plan(path, parent_name, "poster" + ext_lower)
+    if RE_BACKDROP.match(base):
+        return Plan(path, parent_name, "background" + ext_lower)
+
+    m = RE_SEASON_POSTER.match(base)
+    if m:
+        season = int(m.group(1))
+        return Plan(path, parent_name, "Season%02d%s" % (season, ext_lower))
+    if RE_SPECIAL_SEASON.match(base):
+        return Plan(path, parent_name, "Season00" + ext_lower)
+
+    # Title cards live inside a season subfolder; the ASSET_NAME is the show folder.
+    m = RE_STATIC_TITLECARD.match(base)
+    if m:
+        season, episode = int(m.group(1)), int(m.group(2))
+        return Plan(path, grandparent_name, "S%02dE%02d%s" % (season, episode, ext_lower))
+
+    m = RE_MATCH_TITLECARD.match(base)
+    if m:
+        se = RE_SXXEYY_ANYWHERE.search(m.group("base"))
+        if se:
+            season, episode = int(se.group(1)), int(se.group(2))
+            return Plan(path, grandparent_name, "S%02dE%02d%s" % (season, episode, ext_lower))
+        # A -thumb file we cannot map (no SxxEyy in the name) is reported by the caller.
+        return None
+
+    return None
+
+
+def build_plans(source):
+    plans = []
+    unrecognized_thumbs = []
+    for root, _dirs, files in os.walk(source):
+        for name in files:
+            full = os.path.join(root, name)
+            plan = classify(full)
+            if plan is not None:
+                plans.append(plan)
+            elif name.lower().endswith(("-thumb.jpg", "-thumb.jpeg", "-thumb.png", "-thumb.webp")):
+                unrecognized_thumbs.append(full)
+    return plans, unrecognized_thumbs
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Migrate AURA local-save assets to the Kometa asset directory layout.",
+    )
+    parser.add_argument("--source", required=True, help="Root to scan for AURA assets (media library or SaveImagesLocally path).")
+    parser.add_argument("--dest", required=True, help="Kometa asset directory to write folder-per-item assets into.")
+    parser.add_argument("--apply", action="store_true", help="Actually copy/move files. Without this, runs a dry-run.")
+    parser.add_argument("--move", action="store_true", help="Move files instead of copying them (removes originals).")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing files in the destination.")
+    args = parser.parse_args(argv)
+
+    source = os.path.abspath(args.source)
+    dest = os.path.abspath(args.dest)
+
+    if not os.path.isdir(source):
+        print("error: --source is not a directory: %s" % source, file=sys.stderr)
+        return 2
+    if os.path.commonpath([source, dest]) == source and dest != source:
+        # dest inside source would be re-scanned on repeat runs; warn but allow.
+        print("warning: --dest is inside --source; re-running may re-scan migrated files", file=sys.stderr)
+
+    plans, unrecognized_thumbs = build_plans(source)
+
+    # Detect destination collisions (two sources mapping to the same target).
+    seen = {}
+    collisions = []
+    for p in plans:
+        key = (p.asset_name, p.dest_name)
+        if key in seen:
+            collisions.append((seen[key], p))
+        else:
+            seen[key] = p.src
+
+    copied = skipped = failed = 0
+    action = "MOVE" if args.move else "COPY"
+
+    for p in plans:
+        target = p.dest_path(dest)
+        rel_target = os.path.relpath(target, dest)
+        if os.path.exists(target) and not args.overwrite:
+            print("SKIP (exists)  %s" % rel_target)
+            skipped += 1
+            continue
+
+        print("%s  %s  ->  %s" % (action, p.src, rel_target))
+        if not args.apply:
+            continue
+
+        try:
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            if args.move:
+                shutil.move(p.src, target)
+            else:
+                shutil.copy2(p.src, target)
+            copied += 1
+        except OSError as exc:
+            print("  ERROR: %s" % exc, file=sys.stderr)
+            failed += 1
+
+    print("")
+    print("Summary:")
+    print("  recognized assets : %d" % len(plans))
+    print("  %-16s: %d" % ("applied" if args.apply else "would apply", copied if args.apply else len(plans) - skipped))
+    print("  skipped (exists)  : %d" % skipped)
+    if failed:
+        print("  failed            : %d" % failed)
+    if collisions:
+        print("  collisions        : %d (multiple sources map to the same asset; last wins)" % len(collisions))
+        for a, b in collisions:
+            print("    %s  and  %s  ->  %s/%s" % (a, b.src, b.asset_name, b.dest_name))
+    if unrecognized_thumbs:
+        print("  unmapped -thumb   : %d (no SxxEyy in the file name; skipped)" % len(unrecognized_thumbs))
+        for t in unrecognized_thumbs:
+            print("    %s" % t)
+    if not args.apply:
+        print("")
+        print("Dry run only. Re-run with --apply to perform the migration.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a **Plex-only Kometa mode** so AURA can share [Kometa](https://kometa.wiki/)'s asset directory and naming conventions, and import assets Kometa (or a previous tool) already wrote. Enabled via a new `Images.Kometa` config block; fully independent of `SaveImagesLocally`.

## Write path (when `Images.Kometa.Enabled`)

Images AURA downloads are written into the Kometa asset directory using the folder-per-item layout, **in addition to** the existing immediate apply to Plex:

- `<AssetDir>/<Item Folder>/poster.jpg`, `background.jpg`
- `Season01.jpg` … (`Season00.jpg` for specials), `S01E01.jpg`
- Collections: `<AssetDir>/<Collection>/poster.jpg` / `background.jpg`

Existing files are overwritten; write failures are non-fatal (they warn, the Plex apply still succeeds).

## Import

`POST /api/kometa/import` (plus a manual button in Settings and an optional `ImportCron` job) scans the asset directory, matches folders to Plex items, uploads the bytes to Plex, and records synthetic `kometa-*` sets so imports surface in the UI.

- **Matching order:** `{tmdb-N}` hint → `Title (Year)` → collection title. Multi-library matches apply to all.
- **DB precedence guard (key correctness detail):** any image type already owned by a MediUX set is never overwritten in the DB — imports only claim types no MediUX set owns. Prevents `clearSelectedTypesOnOtherSets`/`deleteEmptySavedItemLinks` from destroying a user's MediUX selections. If nothing remains to claim, the upload still happens but DB registration is skipped ("managed by AURA").
- Runs async, single-flight, with a polled status endpoint (`GET /api/kometa/import`).

## Guards

`kometa-*` set IDs are skipped everywhere set IDs flow to MediUX (auto-download, force-check, Sonarr webhook, `get_set_by_id`), so synthetic sets never trigger MediUX lookups.

## Frontend

Kometa settings block (enable / asset dir / import cron / import button + live status), config types & defaults, `kometa|` image IDs served from `/api/images/kometa/item`, and MediUX-only affordances hidden for Kometa sets.

## Migration script

`scripts/kometa_migrate.py` — dependency-free, dry-run-by-default tool that maps the old AURA local-save names (`poster.jpg`, `season01-poster.jpg`, `<episode>-thumb.jpg`, `S01E01.jpg`) into the Kometa layout, including the season-subfolder → show-folder remap for title cards. Reports collisions and unmapped files.

## Scope note

Imported **collections are applied to Plex but not recorded in AURA's DB** — collection DB records hang off a member item's TMDB ID, which is fragile. Documented in `docs/config.md`. Can be added if wanted.

## Verification

- Backend: `go build ./...`, `go vet ./...`, gofmt clean; swagger regenerated (new endpoints + `Config_Kometa`).
- Frontend: `tsc --noEmit`, `eslint`, `next build` all pass.
- Migration script: dry-run + apply + idempotent re-run verified against a synthetic tree.

https://claude.ai/code/session_01Vo5DBWC9QEc5665MfjDd3e