### PR TITLE
ci: adopt homelab CI setup and publish to own GHCR

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Declare the repo-scoped self-hosted ARC runner label so actionlint recognizes
+# it. This runner hosts the privileged, cluster-facing half of the
+# Dependency-Track workflows (see docs/ci.md).
+self-hosted-runner:
+  labels:
+    - arc-oss-aura

--- a/.github/workflows/aura-beta.yml
+++ b/.github/workflows/aura-beta.yml
@@ -1,68 +1,82 @@
-name: Docker Image CI and Release for aura Beta
+name: Release aura beta image
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - "master"
-            - "beta*"
-        paths:
-            - "backend/**"
-            - "frontend/**"
-            - "VERSION.txt"
+  workflow_dispatch:
+  push:
+    branches:
+      - "beta*"
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "VERSION.txt"
+
+permissions:
+  contents: read
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Extract version
+        id: version
+        run: |
+          if [[ -f VERSION.txt ]]; then
+            echo "APP_VERSION=$(cat VERSION.txt)-beta" >> "$GITHUB_ENV"
+          else
+            echo "APP_VERSION=dev-beta" >> "$GITHUB_ENV"
+          fi
 
-            - name: Docker info
-              run: docker info
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: linux/amd64,linux/arm64
 
-            - name: Log in to GitHub Container Registry
-              uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-            - name: Log in to Docker Hub
-              uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Build and push image
+        id: image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/aura:beta
+            ghcr.io/${{ github.repository_owner }}/aura:${{ env.APP_VERSION }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
 
-            - name: Extract Version
-              id: extract_version
-              run: |
-                  if [[ -f VERSION.txt ]]; then
-                    APP_VERSION=$(cat VERSION.txt)
-                    if [[ "${{ github.ref_name }}" == beta* ]]; then
-                      APP_VERSION="${APP_VERSION}-beta"
-                    fi
-                    echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
-                  else
-                    echo "APP_VERSION=dev" >> $GITHUB_ENV
-                  fi
-
-            - name: Build Docker image
-              run: |
-                  docker buildx build . \
-                    --platform linux/amd64,linux/arm64 \
-                    --build-arg APP_VERSION=${{ env.APP_VERSION }} \
-                    --tag ghcr.io/mediux-team/aura:beta \
-                    --tag docker.io/mediux/aura:beta \
-                    --tag docker.io/${{ secrets.DOCKERHUB_USERNAME }}/aura:beta \
-                    --tag ghcr.io/mediux-team/aura:${{ env.APP_VERSION }} \
-                    --tag docker.io/mediux/aura:${{ env.APP_VERSION }} \
-                    --tag docker.io/${{ secrets.DOCKERHUB_USERNAME }}/aura:${{ env.APP_VERSION }} \
-                    --push
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build-push-action produced no digest; cannot sign image" >&2
+            exit 1
+          fi
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/aura@${DIGEST}"

--- a/.github/workflows/aura.yml
+++ b/.github/workflows/aura.yml
@@ -1,62 +1,87 @@
-name: Docker Image CI and Release for aura
+name: Release aura image
 
 on:
-    workflow_dispatch:
-    push:
-        branches: ["master"]
-        paths:
-            - "backend/**"
-            - "frontend/**"
-            - "VERSION.txt"
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "VERSION.txt"
+
+permissions:
+  contents: read
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Extract version
+        id: version
+        run: |
+          if [[ -f VERSION.txt ]]; then
+            echo "APP_VERSION=$(cat VERSION.txt)" >> "$GITHUB_ENV"
+          else
+            echo "APP_VERSION=dev" >> "$GITHUB_ENV"
+          fi
 
-            - name: Docker info
-              run: docker info
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: linux/amd64,linux/arm64
 
-            - name: Log in to GitHub Container Registry
-              uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-            - name: Log in to Docker Hub
-              uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Build and push image
+        id: image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/aura:latest
+            ghcr.io/${{ github.repository_owner }}/aura:${{ env.APP_VERSION }}
+          # Attach a CycloneDX SBOM + max provenance as OCI referrers on the image
+          # (inspect: `docker buildx imagetools inspect --format '{{json .SBOM}}' <img>`).
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign binary (not just the installer) so signature/bundle
+          # format stays stable and Kyverno verification is reproducible.
+          cosign-release: 'v3.1.1'
 
-            - name: Extract Version
-              id: extract_version
-              run: |
-                  if [[ -f VERSION.txt ]]; then
-                    echo "APP_VERSION=$(cat VERSION.txt)" >> $GITHUB_ENV
-                  else
-                    echo "APP_VERSION=dev" >> $GITHUB_ENV
-                  fi
-
-            - name: Build Docker image
-              run: |
-                  docker buildx build . \
-                    --platform linux/amd64,linux/arm64 \
-                    --build-arg APP_VERSION=${{ env.APP_VERSION }} \
-                    --tag ghcr.io/mediux-team/aura:latest \
-                    --tag docker.io/mediux/aura:latest \
-                    --tag docker.io/${{ secrets.DOCKERHUB_USERNAME }}/aura:latest \
-                    --tag ghcr.io/mediux-team/aura:${{ env.APP_VERSION }} \
-                    --tag docker.io/mediux/aura:${{ env.APP_VERSION }} \
-                    --tag docker.io/${{ secrets.DOCKERHUB_USERNAME }}/aura:${{ env.APP_VERSION }} \
-                    --push
+      # Keyless (Fulcio/rekor) signature over the pushed digest so the homelab
+      # Kyverno verify-ghcr-images policy can verify this image.
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build-push-action produced no digest; cannot sign image" >&2
+            exit 1
+          fi
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/aura@${DIGEST}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    # master = post-merge run. renovate/** lets Renovate's branch-automerge
+    # updates (which never open a PR) run CI on the branch so the default-branch
+    # ruleset can fast-forward master once the branch is green.
+    branches: [master, 'renovate/**']
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      # mattn/go-sqlite3 is a cgo package; the backend does not build without it.
+      CGO_ENABLED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "${unformatted}" ]; then
+            echo "::error::gofmt found unformatted files:"
+            echo "${unformatted}"
+            exit 1
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+  frontend:
+    name: Frontend (Next.js)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+---
+name: 'CodeQL Advanced'
+on:
+  push:
+    branches: ['master', 'beta']
+  pull_request:
+    branches: ['master', 'beta']
+  schedule:
+    - cron: '25 22 * * 5'
+
+jobs:
+  # AURA is multi-language: analyze Go and TypeScript separately. build-mode
+  # 'none' scans source without a build, so the backend/ subdir module and its
+  # cgo/sqlite dependency do not need to compile under CodeQL.
+  analyze-go:
+    uses: jabrown93/.github/.github/workflows/codeql.yml@646fa5ec406b9d4ee20498512d6748135f4a6206 # v1.1.0
+    with:
+      language: go
+      build-mode: none
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+  analyze-typescript:
+    uses: jabrown93/.github/.github/workflows/codeql.yml@646fa5ec406b9d4ee20498512d6748135f4a6206 # v1.1.0
+    with:
+      language: javascript-typescript
+      build-mode: none
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,15 @@ on:
     - cron: '25 22 * * 5'
 
 jobs:
-  # AURA is multi-language: analyze Go and TypeScript separately. build-mode
-  # 'none' scans source without a build, so the backend/ subdir module and its
-  # cgo/sqlite dependency do not need to compile under CodeQL.
+  # AURA is multi-language: analyze Go and TypeScript separately. Go has no
+  # buildless mode ("Go does not support the none build mode"), so it uses
+  # autobuild — the autobuilder finds the backend/ module and compiles it with
+  # cgo/sqlite on the gcc-equipped hosted runner. TypeScript uses build-mode none.
   analyze-go:
     uses: jabrown93/.github/.github/workflows/codeql.yml@646fa5ec406b9d4ee20498512d6748135f4a6206 # v1.1.0
     with:
       language: go
-      build-mode: none
+      build-mode: autobuild
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -1,0 +1,89 @@
+---
+# Upload a CycloneDX SBOM of this repo's resolved dependencies (Go modules + npm)
+# to the homelab Dependency-Track instance.
+#
+# Two jobs, because only one of them may touch the cluster:
+#   sbom   - hosted runner (UNTRUSTED): scan the repo with syft and emit
+#            sbom.cdx.json. Tooling runs here, never on the in-cluster runner.
+#   upload - in-cluster arc-oss-aura runner: exchange this run's GitHub OIDC
+#            token for the Dependency-Track CI key via OpenBao (vault-action),
+#            then POST the SBOM. Project identity is taken from trusted GitHub
+#            context (github.repository / github.sha), NOT from anything the sbom
+#            job produced, so a compromised build can't inject values executed on
+#            the cluster runner. The runner is egress-locked to a few in-cluster
+#            services, so OpenBao and DT are addressed by their in-cluster Service
+#            DNS names, not the public gateway. The set is REPO-scoped
+#            (arc-oss-aura). See github.com/jabrown93/homelab -> docs/dependency-track.md.
+#
+# push-to-master + manual only: never runs on pull_request, so fork PR code can't
+# reach the in-cluster runner. DT is visibility-only, so there is no PR gate to
+# lose by not scanning PRs.
+name: Dependency-Track SBOM
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          if-no-files-found: error
+          path: sbom.cdx.json
+
+  upload:
+    needs: sbom
+    runs-on: arc-oss-aura
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-sbom-upload
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/ci/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload SBOM to Dependency-Track
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST http://dependency-track-api-server.dependency-track.svc.cluster.local:8080/api/v1/bom \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "isLatest=true" \
+            -F "bom=@sbom.cdx.json"

--- a/.github/workflows/pr-license-check.yml
+++ b/.github/workflows/pr-license-check.yml
@@ -1,0 +1,43 @@
+---
+# Producer half of the advisory PR license check (consumer: pr-license-comment.yml).
+#
+# SECURITY BOUNDARY: a `pull_request` build runs the PR's OWN copy of this file
+# plus the PR's (untrusted) build, so it holds NO secrets and never reaches the
+# cluster. It only builds the SBOM and hands it to the trusted consumer as an
+# artifact. The privileged upload-to-DT + PR comment runs in pr-license-comment.yml,
+# a `workflow_run` workflow that always executes the master-branch definition, with
+# the OpenBao role pinned to that file @refs/heads/master. This is the
+# GitHub-recommended pattern for giving secrets to PR-triggered automation without
+# exposing them to PR-controlled code.
+#
+# Public repo -> hosted ubuntu-latest is free/unlimited and has no cluster reach.
+name: PR License Check (Dependency-Track)
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          if-no-files-found: error
+          path: sbom.cdx.json

--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -1,0 +1,182 @@
+---
+# Consumer half of the advisory PR license check (producer: pr-license-check.yml).
+#
+# `workflow_run` always runs THIS file from the default branch (master), never the
+# PR's version -- that is the trust boundary. The untrusted PR-context producer
+# holds no secrets and only builds the SBOM; the Dependency-Track CI key is
+# exposed only here, to trusted master-pinned code. The OpenBao role `dt-pr-license`
+# is bound to this file @refs/heads/master (job_workflow_ref), so a same-repo PR
+# that rewrites the producer cannot mint the key. Advisory only: it never fails
+# anything, it posts a comment.
+#
+# Same-repo PRs only: `workflow_run.pull_requests` is populated for branches in
+# this repo and empty for forks (which also get no token). See
+# github.com/jabrown93/homelab -> docs/dependency-track.md.
+#
+# NOTE: workflow_run uses the master-branch copy of this file, so the PR that first
+# adds it gets no comment; it activates for PRs opened after this merges to master.
+name: PR License Comment (Dependency-Track)
+
+on:
+  workflow_run:
+    workflows:
+      - PR License Check (Dependency-Track)
+    types:
+      - completed
+
+permissions:
+  actions: read           # download-artifact run-id mode (cross-run) needs this
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  # Suffix by conclusion so a failed/skipped producer's (no-op) consumer run can't
+  # cancel an in-flight successful evaluation; successful runs still supersede each
+  # other (newest wins).
+  group: pr-license-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: evaluate
+    runs-on: arc-oss-aura
+    # Only same-repo pull_request producer runs that succeeded. Forks have no
+    # token access and an empty pull_requests array.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.pull_requests[0] != null
+    steps:
+      - name: Resolve PR number from the trigger event
+        id: meta
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]] || { echo "bad PR number"; exit 1; }
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Download SBOM from the producer run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-pr-license
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/ci/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload PR SBOM and collect license policy violations
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: pr-${{ steps.meta.outputs.pr_number }}
+        run: |
+          set -uo pipefail
+          DT=http://dependency-track-api-server.dependency-track.svc.cluster.local:8080
+          # Advisory: never fail. Emit a status + violations.json for the renderer.
+          echo '[]' > violations.json
+          echo 'unavailable:000' > status.txt
+          # Upload the PR SBOM (no isLatest -> the master version stays canonical).
+          # Use -f so an HTTP error is caught here rather than silently falling
+          # through to a STALE pre-existing pr-<n> project on lookup.
+          resp=$(curl -fsS -H "X-Api-Key: ${DT_API_KEY}" -X POST "$DT/api/v1/bom" \
+            -F autoCreate=true \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "bom=@sbom.cdx.json") || { echo 'upload-failed' > status.txt; echo "upload failed"; exit 0; }
+          token=$(printf '%s' "$resp" | sed -n 's/.*"token"[^"]*"\([^"]*\)".*/\1/p')
+          if [ -z "${token}" ]; then echo 'upload-failed' > status.txt; echo "no token"; exit 0; fi
+          # Poll until BOM ingestion finishes (cap ~5 min); track whether it did.
+          processed=false
+          for _ in $(seq 1 60); do
+            if curl -fsS -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/bom/token/${token}" \
+                 | grep -q '"processing"[[:space:]]*:[[:space:]]*false'; then
+              processed=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "${processed}" != "true" ]; then echo 'processing' > status.txt; echo "still processing after cap"; exit 0; fi
+          sleep 5  # brief settle for policy evaluation after ingestion
+          # Resolve the project UUID for this PR version (needs VIEW_PORTFOLIO).
+          uuid=$(curl -fsSG -H "X-Api-Key: ${DT_API_KEY}" "$DT/api/v1/project/lookup" \
+            --data-urlencode "name=${PROJECT_NAME}" \
+            --data-urlencode "version=${PROJECT_VERSION}" \
+            | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' \
+            | grep -oiE '[0-9a-f-]{36}' | head -n1)
+          if [ -z "${uuid}" ]; then echo 'no-project' > status.txt; echo "no uuid"; exit 0; fi
+          # Fetch policy violations (needs VIEW_POLICY_VIOLATION).
+          code=$(curl -sS -H "X-Api-Key: ${DT_API_KEY}" -o violations.json -w '%{http_code}' \
+            "$DT/api/v1/violation/project/${uuid}?suppressed=false&pageSize=1000") || code=000
+          echo "Violations HTTP: ${code}"
+          if [ "${code}" = "200" ]; then
+            echo 'ok' > status.txt
+          else
+            echo "unavailable:${code}" > status.txt
+            echo '[]' > violations.json
+          fi
+          echo "done"
+
+      - name: Render and post advisory license comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- dt-license-check -->';
+            const dtUi = 'https://dependency-track.jaredbrown.io';
+            const prNum = Number(process.env.PR_NUMBER);
+            let status = 'unavailable:000';
+            try { status = fs.readFileSync('status.txt', 'utf8').trim(); } catch (e) {}
+            const esc = (s) => String(s).replace(/[|`\\]/g, '\\$&').replace(/\r?\n/g, ' ');
+            let body;
+            if (status === 'ok') {
+              let data = [];
+              try { data = JSON.parse(fs.readFileSync('violations.json', 'utf8')); } catch (e) {}
+              const all = Array.isArray(data) ? data : (data.violations || []);
+              const lic = all.filter(v => String(v.type || '').toUpperCase() === 'LICENSE');
+              if (lic.length === 0) {
+                body = `${marker}\n### ✅ Dependency-Track license check\n\nNo license policy violations for \`pr-${prNum}\`.\n\n_Advisory only — reflects the GitOps DT license policies. Vulnerabilities are not gated here. [Open in DT](${dtUi})._`;
+              } else {
+                const rows = lic.map((v) => {
+                  const c = v.component || {};
+                  const coord = c.purl || `${c.group ? c.group + ':' : ''}${c.name || '?'}@${c.version || '?'}`;
+                  const pol = (v.policyCondition && v.policyCondition.policy && v.policyCondition.policy.name) || 'license policy';
+                  const rl = c.resolvedLicense || {};
+                  const lname = rl.name || rl.licenseId || c.license || '—';
+                  return `| \`${esc(coord)}\` | ${esc(lname)} | ${esc(pol)} |`;
+                }).join('\n');
+                body = `${marker}\n### ⚠️ Dependency-Track license check — ${lic.length} finding(s)\n\n| Component | License | Policy |\n|---|---|---|\n${rows}\n\n_Advisory only (non-blocking). Review at ${dtUi}. Source of truth: the GitOps DT license policies._`;
+              }
+            } else if (status.startsWith('unavailable:')) {
+              const code = status.slice('unavailable:'.length);
+              body = `${marker}\n### ℹ️ Dependency-Track license check — evaluation unavailable\n\nDT returned HTTP \`${code}\` reading policy violations for \`pr-${prNum}\`.\n\n- \`403\` → grant the **Automation** team \`VIEW_POLICY_VIOLATION\` in DT (Administration → Access Management → Teams).\n\n_Advisory only — not blocking._`;
+            } else if (status === 'processing') {
+              body = `${marker}\n### ⏳ Dependency-Track license check — inconclusive\n\nDT was still processing the SBOM for \`pr-${prNum}\` after the poll window; no verdict this run. Re-runs on the next push.\n\n_Advisory only — not blocking._`;
+            } else if (status === 'upload-failed') {
+              body = `${marker}\n### ℹ️ Dependency-Track license check — SBOM upload failed\n\nThe SBOM upload to DT did not succeed for \`pr-${prNum}\` (DT unreachable or rejected the BOM).\n\n_Advisory only — not blocking._`;
+            } else {
+              body = `${marker}\n### ℹ️ Dependency-Track license check — inconclusive\n\nCould not evaluate \`pr-${prNum}\` (project lookup returned no result).\n\n_Advisory only — not blocking._`;
+            }
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNum });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNum, body });
+            }

--- a/backend/routing/database/add.go
+++ b/backend/routing/database/add.go
@@ -14,11 +14,11 @@ import (
 )
 
 type addItemRequest struct {
-	Complete    bool                     `json:"complete"`
-	MediaItem   models.MediaItem         `json:"media_item"`
-	PosterSet   models.DBPosterSetDetail `json:"poster_set"`
-	AddToDBOnly bool                     `json:"add_to_db_only"` // If true, the item will be added to the database but not have any labels or tags applied. This is for users who want to manage labels and tags manually.
-	AutoAddNewCollectionItems bool       `json:"auto_add_new_collection_items"`
+	Complete                  bool                     `json:"complete"`
+	MediaItem                 models.MediaItem         `json:"media_item"`
+	PosterSet                 models.DBPosterSetDetail `json:"poster_set"`
+	AddToDBOnly               bool                     `json:"add_to_db_only"` // If true, the item will be added to the database but not have any labels or tags applied. This is for users who want to manage labels and tags manually.
+	AutoAddNewCollectionItems bool                     `json:"auto_add_new_collection_items"`
 }
 
 type addItemResponse struct {

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,59 @@
+# CI / GitHub Actions
+
+This fork's workflows follow the same conventions as the rest of `jabrown93/*`:
+actions pinned by commit SHA (Renovate keeps them current via
+`renovate.json` → `jabrown93/.github:renovate-config`), least-privilege
+`permissions`, and a split between untrusted hosted builds and privileged
+in-cluster jobs.
+
+## Workflows
+
+| Workflow | Trigger | What it does | Needs infra? |
+|---|---|---|---|
+| `ci.yml` | PR → `master`, push → `master`/`renovate/**` | Backend `go build`/`vet`/`test` + gofmt gate; frontend `npm ci`/`lint`/`build`. | No |
+| `codeql.yml` | push/PR → `master`/`beta`, weekly | CodeQL for `go` and `javascript-typescript` (build-mode `none`) via the reusable `jabrown93/.github` workflow. | No |
+| `aura.yml` | push → `master` (paths), manual | Multi-arch build + push `ghcr.io/<owner>/aura:latest` + `:<VERSION.txt>`, SBOM + provenance, cosign keyless sign. | No |
+| `aura-beta.yml` | push → `beta*` (paths), manual | Same, `:beta` + `:<VERSION>-beta`. | No |
+| `dt-sbom.yml` | push → `master`, manual | syft SBOM (Go + npm) → upload to Dependency-Track (`isLatest`). | **Yes** |
+| `pr-license-check.yml` | PR → `master` (same-repo) | Untrusted producer: build SBOM, upload as artifact. No secrets. | No |
+| `pr-license-comment.yml` | `workflow_run` of the check | Trusted consumer: upload PR SBOM to DT, post advisory license comment. | **Yes** |
+| `jekyll-gh-pages.yml` | push → `master` (`docs/**`), manual | Publish `docs/` to GitHub Pages. | Pages setting |
+
+## Images
+
+Images publish to **`ghcr.io/<owner>/aura`** using the built-in `GITHUB_TOKEN`
+(`packages: write`) — no registry secrets to configure. They carry a CycloneDX
+SBOM + max provenance and are keyless-signed (Fulcio/rekor) by digest so the
+homelab Kyverno `verify-ghcr-images` policy can verify them.
+
+## Homelab prerequisites (Dependency-Track workflows)
+
+`dt-sbom.yml` and `pr-license-comment.yml` run their privileged half on an
+in-cluster ARC runner and pull the DT API key from OpenBao via GitHub OIDC.
+They stay red until this infra exists:
+
+1. **ARC runner set `arc-oss-aura`** — a repo-scoped Actions Runner Controller
+   set for `jabrown93/AURA`, egress-locked to the in-cluster OpenBao and
+   Dependency-Track Services.
+2. **OpenBao JWT roles** under the `github-actions` mount, bound to this repo:
+   - `dt-sbom-upload` — used by `dt-sbom.yml`.
+   - `dt-pr-license` — used by `pr-license-comment.yml`; bind it to
+     `job_workflow_ref` `jabrown93/AURA/.github/workflows/pr-license-comment.yml@refs/heads/master`
+     so a PR that rewrites the producer cannot mint the key.
+   Both map `secret/data/ci/dependency-track/ci-api-key`.
+3. **Dependency-Track** — reachable at
+   `dependency-track-api-server.dependency-track.svc.cluster.local:8080`; the CI
+   key's **Automation** team needs `BOM_UPLOAD`, `VIEW_PORTFOLIO`, and
+   `VIEW_POLICY_VIOLATION`. Projects are auto-created (`github.com/jabrown93/AURA`,
+   version `<sha>` for master and `pr-<n>` for PRs).
+
+See `github.com/jabrown93/homelab → docs/dependency-track.md` for the shared
+setup these mirror.
+
+## Notes
+
+- **GitHub Pages** (`jekyll-gh-pages.yml`) fails until Pages is enabled on the
+  fork: Settings → Pages → Build and deployment → Source = "GitHub Actions".
+  If you don't want to publish docs from the fork, delete that workflow instead.
+- The backend has no Go tests yet; `go test ./...` is a no-op gate that will
+  start enforcing as tests land.


### PR DESCRIPTION
## Summary

Reworks this fork's GitHub Actions to follow the `jabrown93/*` conventions (from `k8s-leader-elector` + `jabrown93/.github`) and fixes the currently-failing release runs. Every release/beta run on the fork fails today at `docker/login-action` with *"Username and password required"* because the workflows push to `ghcr.io/mediux-team` / `docker.io/mediux` using mediux secrets the fork doesn't have. This retargets everything to **`ghcr.io/${{ github.repository_owner }}/aura`** via the built-in `GITHUB_TOKEN` (no new secrets) and adds the CI/security tooling the repo was missing.

Fork-only; not intended to PR upstream.

## What changed

| Workflow | Trigger | Purpose | Infra? |
|---|---|---|---|
| **`ci.yml`** (new) | PR→master, push→master/`renovate/**` | backend `go build`/`vet`/`test` + gofmt gate (cgo+sqlite); frontend `npm ci`/`lint`/`build` | No |
| **`codeql.yml`** (new) | push/PR→master/beta, weekly | reusable `jabrown93/.github` CodeQL for `go` + `javascript-typescript` (build-mode `none`) | No |
| **`aura.yml`** (rewrite) | push→master, manual | multi-arch build+push `:latest` + `:<VERSION.txt>`, SBOM + provenance, cosign keyless sign | No |
| **`aura-beta.yml`** (rewrite) | push→`beta*`, manual | same, `:beta` + `:<VERSION>-beta` | No |
| **`dt-sbom.yml`** (new) | push→master, manual | syft SBOM (Go+npm) → Dependency-Track | **Yes** |
| **`pr-license-check.yml`** (new) | PR→master (same-repo) | untrusted producer: build SBOM artifact, no secrets | No |
| **`pr-license-comment.yml`** (new) | `workflow_run` | trusted consumer: upload PR SBOM to DT, post advisory license comment | **Yes** |

Plus `.github/actionlint.yaml` (declares the `arc-oss-aura` self-hosted label), `docs/ci.md`, and a gofmt-only fix to the pre-existing `backend/routing/database/add.go` so the new gofmt gate is green.

## Works immediately (zero new secrets)
`ci.yml`, `codeql.yml`, `aura.yml`, `aura-beta.yml` — GHCR publish uses `GITHUB_TOKEN` with `packages: write`; images carry a CycloneDX SBOM + max provenance and are keyless-signed by digest for the Kyverno verify policy.

## ⚠️ Requires homelab infra before going green
The Dependency-Track workflows (`dt-sbom.yml`, `pr-license-comment.yml`) run their privileged half on an in-cluster ARC runner and pull the DT key from OpenBao via OIDC. They stay red until:
1. an **`arc-oss-aura`** repo-scoped ARC runner set exists,
2. OpenBao JWT roles **`dt-sbom-upload`** and **`dt-pr-license`** exist (the latter bound to `pr-license-comment.yml@refs/heads/master`),
3. Dependency-Track is reachable and the CI key's Automation team has `BOM_UPLOAD` / `VIEW_PORTFOLIO` / `VIEW_POLICY_VIOLATION`.

Details in `docs/ci.md`.

## Notes
- `jekyll-gh-pages.yml` (also failing) is a repo setting, not a workflow bug — enable Settings → Pages → Source = "GitHub Actions", or delete that workflow. Left untouched here.
- All workflows pass `actionlint` clean.

## Verification
- `actionlint` clean across all workflows.
- Backend `go build ./...` OK after the gofmt fix; `gofmt -l backend` empty.

https://claude.ai/code/session_01Vo5DBWC9QEc5665MfjDd3e