### PR TITLE
build(docker): use shellless/rootless DHI node for the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 ############################################################################
 ##### Stage 1: Build the backend application
 ############################################################################
-FROM golang:alpine AS backend-builder
+FROM dhi.io/golang:1.26-alpine3.24-dev AS backend-builder
 
-# Install required dependencies for cgo
-RUN apk add --no-cache gcc musl-dev
+# cgo build deps (gcc, musl-dev) plus ca-certificates + tzdata, which are copied
+# into the shellless runtime image (which has no package manager of its own).
+RUN apk add --no-cache gcc musl-dev ca-certificates tzdata
 
 # Set the working directory
 WORKDIR /backend
@@ -21,14 +22,14 @@ COPY backend/ ./
 # Get the version from build arguments/environment variables
 ARG APP_VERSION=dev
 
-# Enable CGO and build the application 
+# Enable CGO and build the application
 ENV CGO_ENABLED=1
 RUN go build -ldflags="-s -w -X main.APP_VERSION=$APP_VERSION" -o main .
 
 ############################################################################
 ##### Stage 2: Build the frontend application
 ############################################################################
-FROM node:alpine AS frontend-builder
+FROM dhi.io/node:26.4.0-alpine3.24-dev AS frontend-builder
 
 # Set the working directory
 WORKDIR /frontend
@@ -52,46 +53,51 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Build the application
 RUN npm run build || (echo "Build failed" && cat /frontend/.next/build-diagnostics.json 2>/dev/null || true && exit 1)
 
+# Normalize runtime-readable permissions for static assets before they are copied
+# into the shellless runtime image, which has no shell to run chmod. Local git
+# checkouts can carry restrictive modes (for example from a 077 umask) that COPY
+# would otherwise preserve.
+RUN find /frontend/public -type d -exec chmod 755 {} + \
+	&& find /frontend/public -type f -exec chmod 644 {} + \
+	&& find /frontend/.next/static -type d -exec chmod 755 {} + \
+	&& find /frontend/.next/static -type f -exec chmod 644 {} +
+
 ############################################################################
 ##### Stage 3: Build the final image
 ############################################################################
-FROM node:alpine AS final
+FROM dhi.io/node:26.4.0-alpine3.24 AS final
 
 # Set the working directory
 WORKDIR /app
 
-# Install CA certificates and tzdata for timezone support
-RUN apk update && apk add --no-cache ca-certificates tzdata
+# CA certificates (the Go backend makes HTTPS calls) and tzdata (cron/timezone
+# support) come from the -dev builder stage: this runtime image is shellless and
+# rootless, so there is no apk to install them here.
+COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=backend-builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy the backend application from the builder stage
-COPY --from=backend-builder /backend/main .
+COPY --from=backend-builder /backend/main /app/main
 
-# Copy the frontend build from the builder stage
+# Copy the frontend build from the builder stage (permissions were normalized in
+# the frontend-builder stage, since there is no shell here to run chmod).
 COPY --from=frontend-builder /frontend/.next/standalone /app/
 COPY --from=frontend-builder /frontend/.next/static /app/.next/static
 COPY --from=frontend-builder /frontend/public /app/public
 
-# Normalize runtime-readable permissions for static assets. Local git checkouts can
-# carry restrictive modes (for example from a 077 umask), and COPY preserves them.
-RUN find /app/public -type d -exec chmod 755 {} + \
-	&& find /app/public -type f -exec chmod 644 {} + \
-	&& find /app/.next/static -type d -exec chmod 755 {} + \
-	&& find /app/.next/static -type f -exec chmod 644 {} +
-
-# Get the version from build arguments/environment variables
-ARG APP_VERSION=dev
+# Process supervisor: node spawns and watches both the Go backend and the Next
+# server. A shellless image can't run `sh -c "./main & node server.js"`, so node
+# (the image's runtime) does the job instead.
+COPY docker/launcher.mjs /app/launcher.mjs
 
 # Set environment variables
 ENV NODE_ENV=production
 ENV HOME=/tmp
 ENV XDG_CACHE_HOME=/tmp/.cache
-ENV GOCACHE=/tmp/.cache/go-build
-ENV GOMODCACHE=/tmp/.cache/go-mod
 
 # Expose the ports for both the backend and frontend
 EXPOSE 3000
 EXPOSE 8888
 
-# Command to run both the backend and frontend
-#CMD ["sh", "-c", "./main & NODE_ENV=production npm start --prefix /frontend"]
-CMD ["sh", "-c", "./main & node server.js"]
+# Run both processes under the node supervisor (shellless, so no `sh -c`).
+ENTRYPOINT ["node", "/app/launcher.mjs"]

--- a/docker/launcher.mjs
+++ b/docker/launcher.mjs
@@ -1,0 +1,84 @@
+// Process supervisor for the aura container.
+//
+// The runtime image (Docker Hardened Image, shellless + rootless) has no shell,
+// so the two long-running processes can't be started with `sh -c "./main & node
+// server.js"`. Instead node — the image's runtime — supervises both:
+//
+//   * the Go REST API backend  (/app/main, port 8888)
+//   * the Next.js standalone UI (/app/server.js, port 3000)
+//
+// If either child exits, we tear the other down and exit non-zero so the
+// container orchestrator (`restart: unless-stopped`) restarts the whole thing,
+// rather than leaving a half-dead container serving a broken UI or a dead API.
+
+import { spawn } from "node:child_process";
+
+const SHUTDOWN_GRACE_MS = 10_000;
+
+/** @type {{name: string, child: import("node:child_process").ChildProcess}[]} */
+const procs = [];
+let shuttingDown = false;
+
+/**
+ * Terminate every still-running child, then exit. Idempotent: the first caller
+ * wins and later triggers (a second child dying, a second signal) are ignored.
+ * @param {number} code
+ */
+function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  for (const { child } of procs) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+    }
+  }
+
+  // Backstop: if a child ignores SIGTERM, force it and exit anyway.
+  const force = setTimeout(() => {
+    for (const { child } of procs) child.kill("SIGKILL");
+    process.exit(code);
+  }, SHUTDOWN_GRACE_MS);
+  force.unref();
+
+  Promise.all(
+    procs.map(
+      ({ child }) =>
+        new Promise((resolve) =>
+          child.exitCode !== null || child.signalCode !== null
+            ? resolve()
+            : child.once("exit", resolve),
+        ),
+    ),
+  ).then(() => process.exit(code));
+}
+
+/**
+ * @param {string} name
+ * @param {string} command
+ * @param {string[]} args
+ */
+function start(name, command, args) {
+  const child = spawn(command, args, { cwd: "/app", stdio: "inherit" });
+  procs.push({ name, child });
+
+  child.on("error", (err) => {
+    console.error(`[launcher] failed to start ${name}: ${err.message}`);
+    shutdown(1);
+  });
+
+  child.on("exit", (exitCode, signal) => {
+    if (shuttingDown) return;
+    console.error(
+      `[launcher] ${name} exited (code=${exitCode}, signal=${signal}); stopping container`,
+    );
+    // Any child exiting is treated as fatal so the container restarts cleanly.
+    shutdown(exitCode === 0 ? 1 : exitCode ?? 1);
+  });
+}
+
+process.on("SIGTERM", () => shutdown(0));
+process.on("SIGINT", () => shutdown(0));
+
+start("backend", "/app/main", []);
+start("frontend", process.execPath, ["/app/server.js"]);


### PR DESCRIPTION
## What

Completes the Docker Hardened Image migration by moving the **final runtime stage** to `dhi.io/node:26.4.0-alpine3.24` — the **shellless, rootless** variant. The builder stages already used the `-dev` variants; this adapts everything in the final stage that relied on a shell or root.

## Why it's more than a `FROM` swap

A shellless/rootless runtime image can't `RUN apk add …`, can't `RUN find … chmod`, and can't `CMD ["sh", "-c", …]` — and it runs as a non-root user. Each of those had to move or change:

| Concern | Before | After |
| --- | --- | --- |
| CA certs + tzdata | `apk add` in the final stage | Installed in `backend-builder`; cert bundle + `/usr/share/zoneinfo` `COPY`ed into runtime |
| Static-asset perms | `find … chmod` in the final stage | Same `find … chmod` moved to `frontend-builder` (has a shell); `COPY` preserves world-readable modes |
| Two processes | `CMD ["sh", "-c", "./main & node server.js"]` | `ENTRYPOINT ["node", "/app/launcher.mjs"]` — a node process supervisor |

### Process supervisor (`docker/launcher.mjs`)

Since there's no shell to background one process, node (the image's runtime) supervises both. It spawns and watches the Go backend and the Next server, forwards `SIGTERM`/`SIGINT`, and **exits non-zero if either child dies** so `restart: unless-stopped` restarts the whole container instead of leaving it half-dead (a dead API behind a live UI, or vice-versa).

This is a behavior change from the old `sh -c` form, where a backend crash left the frontend up and the container never restarted. Chosen deliberately.

## Also

- Dropped the runtime-meaningless `GOCACHE`/`GOMODCACHE` env vars and the unused `ARG APP_VERSION` from the final stage.

## Verification

- `node --check docker/launcher.mjs` passes.
- Drove the supervisor algorithm against dummy children (standalone harness): crash → other child torn down + exit code propagated; clean exit → still fatal (mapped to 1); external SIGTERM → both stopped, exit 0. All pass.
- **Not** verified here (no `dhi.io` registry / Docker access in this environment): a real `docker build` + run.

## Confirm on first real build/run

1. **`/tmp` writability** — `HOME=/tmp` / `XDG_CACHE_HOME=/tmp/.cache`. If the hardened image doesn't ship a writable `/tmp`, node/Next cache writes fail and there's no shell to `mkdir` it. Fix if needed: `COPY --chmod=1777` an empty dir to `/tmp` from a builder stage.
2. **Rootless `/config` ownership** — compose forces `user: "${PUID}:${PGID}"`, so `/config` must be writable by that UID (already true today). Running the image **without** `user:` falls back to the DHI nonroot UID (65532), which must own/write `/config`. Worth a README/compose note.

https://claude.ai/code/session_01UkPKZFz9vn7L4WD2zXgSVR
