### PR TITLE
fix(ci): drop release notes from release commit message (E2BIG)

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -46,7 +46,11 @@ module.exports = {
       "@semantic-release/git",
       {
         assets: ["VERSION.txt", "version.json", "frontend/public/CHANGELOG.md"],
-        message: "chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        // Keep the release notes OUT of the commit message: the first release
+        // rolls up ~1800 commits (~130 KB of notes), and inlining that via
+        // `git commit -m` overruns the OS argument limit (E2BIG). The full notes
+        // still land in CHANGELOG.md and the GitHub Release body.
+        message: "chore(release): v${nextRelease.version} [skip ci]",
       },
     ],
     ["@semantic-release/github", { successComment: false, failComment: false }],


### PR DESCRIPTION
## Problem

The **Release** workflow on `main` is failing ([run 28695442094](https://github.com/jabrown93/AURA/actions/runs/28695442094)):

```
##[error]Error: Command failed with E2BIG: git commit -m chore(release): v1.0.0 [skip ci]
```

`E2BIG` = "Argument list too long". semantic-release computed the fork's first release (`v1.0.0`) from **1787 commits**, generating ~130 KB of release notes. The `@semantic-release/git` plugin's message template inlined those notes:

```js
message: "chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
```

so it ran `git commit -m "<130 KB of notes>"`, blowing past the OS `ARG_MAX` limit. Every prior step (version compute, `VERSION.txt`/`version.json`/`CHANGELOG.md` writes) succeeded — it only died on the release commit.

## Fix

Drop `${nextRelease.notes}` from the commit message; keep just the one-line subject. The full notes still land in `frontend/public/CHANGELOG.md` (committed as an asset) and in the GitHub Release body. This also avoids stuffing the entire changelog into git history on every release, not just the first.

https://claude.ai/code/session_01UkPKZFz9vn7L4WD2zXgSVR