### PR TITLE
ci: cap oversized release body (HTTP 422) + add manual tag republish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,10 @@ jobs:
     name: semantic-release
     runs-on: ubuntu-latest
     # Skip semantic-release for a manual tag (re)publish; otherwise skip only on
-    # our own [skip ci] version-bump commits.
+    # our own [skip ci] version-bump commits. github.event.inputs.* reads empty on
+    # non-dispatch events, so this is safe on push/schedule.
     if: >-
-      inputs.publish_tag == '' &&
+      github.event.inputs.publish_tag == '' &&
       (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     permissions:
       contents: write # push the version-bump commit, create the tag + GitHub Release
@@ -82,7 +83,7 @@ jobs:
       !cancelled() &&
       needs.release.result != 'failure' &&
       (
-        inputs.publish_tag != '' ||
+        github.event.inputs.publish_tag != '' ||
         needs.release.outputs.published == 'true' ||
         (github.event_name == 'push' && github.ref_name == 'main')
       )
@@ -95,8 +96,21 @@ jobs:
       PUBLISHED: ${{ needs.release.outputs.published }}
       VERSION: ${{ needs.release.outputs.version }}
       CHANNEL: ${{ needs.release.outputs.channel }}
-      PUBLISH_TAG: ${{ inputs.publish_tag }}
+      PUBLISH_TAG: ${{ github.event.inputs.publish_tag }}
     steps:
+      - name: Validate publish_tag
+        if: env.PUBLISH_TAG != ''
+        run: |
+          # Reject anything that isn't a clean vX.Y.Z[-suffix] tag before it is
+          # written to $GITHUB_OUTPUT / used as a checkout ref or Docker tag.
+          # The anchored pattern also rejects newlines (output-injection) and any
+          # char illegal in a Docker tag (e.g. '+', '/', whitespace). Existence
+          # of the tag is enforced by the checkout step below.
+          if [[ ! "${PUBLISH_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::publish_tag '${PUBLISH_TAG}' must be a vX.Y.Z[-suffix] tag" >&2
+            exit 1
+          fi
+
       - name: Plan checkout ref
         id: plan
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC — weekly dependency roll-up release
   workflow_dispatch:
+    inputs:
+      publish_tag:
+        description: >-
+          Existing git tag to (re)build and publish as a stable release image
+          (e.g. v1.0.0) — tags it :latest and :v<version>. Skips semantic-release
+          and does not move :edge. Leave empty for a normal automated release.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -28,7 +37,11 @@ jobs:
   release:
     name: semantic-release
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
+    # Skip semantic-release for a manual tag (re)publish; otherwise skip only on
+    # our own [skip ci] version-bump commits.
+    if: >-
+      inputs.publish_tag == '' &&
+      (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     permissions:
       contents: write # push the version-bump commit, create the tag + GitHub Release
     outputs:
@@ -60,11 +73,19 @@ jobs:
     name: Build & push image
     needs: release
     runs-on: ubuntu-latest
-    # Every main push publishes :edge; releases (main or beta) publish their tags.
-    # Beta pushes without a release, and empty weekly runs, build nothing.
+    # Every main push publishes :edge; releases (main or beta) publish their tags;
+    # a manual publish_tag dispatch (re)publishes an existing tag. Beta pushes
+    # without a release, and empty weekly runs, build nothing. !cancelled() lets
+    # this run when the release job is skipped (manual publish_tag), while a
+    # failed release still blocks the image.
     if: >-
-      needs.release.outputs.published == 'true' ||
-      (github.event_name == 'push' && github.ref_name == 'main')
+      !cancelled() &&
+      needs.release.result != 'failure' &&
+      (
+        inputs.publish_tag != '' ||
+        needs.release.outputs.published == 'true' ||
+        (github.event_name == 'push' && github.ref_name == 'main')
+      )
     permissions:
       contents: read
       packages: write
@@ -74,13 +95,17 @@ jobs:
       PUBLISHED: ${{ needs.release.outputs.published }}
       VERSION: ${{ needs.release.outputs.version }}
       CHANNEL: ${{ needs.release.outputs.channel }}
+      PUBLISH_TAG: ${{ inputs.publish_tag }}
     steps:
       - name: Plan checkout ref
         id: plan
         run: |
-          # On a release, build the tag so the baked CHANGELOG/VERSION files match
-          # the release; otherwise build the pushed commit for the rolling :edge.
-          if [[ "${PUBLISHED}" == "true" ]]; then
+          # Manual publish_tag: build that exact tag. On a release, build the tag
+          # so the baked CHANGELOG/VERSION files match the release; otherwise build
+          # the pushed commit for the rolling :edge.
+          if [[ -n "${PUBLISH_TAG}" ]]; then
+            echo "ref=${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"
+          elif [[ "${PUBLISHED}" == "true" ]]; then
             echo "ref=v${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
@@ -99,7 +124,13 @@ jobs:
           # APP_VERSION describe the commit actually baked into the image. On a
           # release run that's the semantic-release bump commit, not GITHUB_SHA.
           head_sha="$(git rev-parse --short=7 HEAD)"
-          if [[ "${PUBLISHED}" == "true" ]]; then
+          if [[ -n "${PUBLISH_TAG}" ]]; then
+            # Manual (re)publish of an existing tag as a stable release image.
+            # Does NOT move :edge — that tracks main's HEAD, which may be newer.
+            ver="${PUBLISH_TAG#v}"
+            app_version="v${ver}"
+            tags="${IMAGE}:latest,${IMAGE}:v${ver}"
+          elif [[ "${PUBLISHED}" == "true" ]]; then
             app_version="v${VERSION}"
             if [[ "${CHANNEL}" == "beta" ]]; then
               tags="${IMAGE}:beta,${IMAGE}:v${VERSION}"

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -21,6 +21,24 @@ const depReleaseRules = releaseDeps
     ]
   : [];
 
+// GitHub rejects a Release body over 125,000 characters (HTTP 422). Normal
+// automated releases are far below that, but a first release with no prior tag
+// rolls up the entire history and can blow past it — which wedged v1.0.0 here.
+// Cap ONLY the Release body: @semantic-release/changelog still writes the full
+// notes to CHANGELOG.md. This is a Lodash template (@semantic-release/github
+// v11+): `<% %>` runs JS, `<%= %>` inserts the value raw (no HTML escaping).
+const RELEASE_BODY_MAX = 120000; // headroom under GitHub's 125,000 hard cap
+const releaseBodyTemplate =
+  "<% var notes = nextRelease.notes || ''; %>" +
+  `<% if (notes.length <= ${RELEASE_BODY_MAX}) { %>` +
+  "<%= notes %>" +
+  "<% } else { %>" +
+  `<%= notes.slice(0, ${RELEASE_BODY_MAX}) %>` +
+  "\n\n---\n\n**Release notes truncated** — the full list exceeded GitHub's " +
+  "125,000-character limit. Full changelog: " +
+  "https://github.com/jabrown93/AURA/blob/v<%= nextRelease.version %>/frontend/public/CHANGELOG.md" +
+  "<% } %>";
+
 module.exports = {
   branches: ["main", { name: "beta", prerelease: true }],
   tagFormat: "v${version}",
@@ -53,6 +71,9 @@ module.exports = {
         message: "chore(release): v${nextRelease.version} [skip ci]",
       },
     ],
-    ["@semantic-release/github", { successComment: false, failComment: false }],
+    [
+      "@semantic-release/github",
+      { successComment: false, failComment: false, releaseBodyTemplate },
+    ],
   ],
 };

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -27,6 +27,13 @@ const depReleaseRules = releaseDeps
 // Cap ONLY the Release body: @semantic-release/changelog still writes the full
 // notes to CHANGELOG.md. This is a Lodash template (@semantic-release/github
 // v11+): `<% %>` runs JS, `<%= %>` inserts the value raw (no HTML escaping).
+//
+// Build the "full changelog" link from the runner's repo env so it survives a
+// repo rename/transfer (falls back to the canonical URL for local dry-runs).
+const repoBaseUrl =
+  process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+    ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
+    : "https://github.com/jabrown93/AURA";
 const RELEASE_BODY_MAX = 120000; // headroom under GitHub's 125,000 hard cap
 const releaseBodyTemplate =
   "<% var notes = nextRelease.notes || ''; %>" +
@@ -36,7 +43,8 @@ const releaseBodyTemplate =
   `<%= notes.slice(0, ${RELEASE_BODY_MAX}) %>` +
   "\n\n---\n\n**Release notes truncated** — the full list exceeded GitHub's " +
   "125,000-character limit. Full changelog: " +
-  "https://github.com/jabrown93/AURA/blob/v<%= nextRelease.version %>/frontend/public/CHANGELOG.md" +
+  `${repoBaseUrl}/blob/` +
+  "<%= nextRelease.gitTag %>/frontend/public/CHANGELOG.md" +
   "<% } %>";
 
 module.exports = {


### PR DESCRIPTION
## Background

Follow-up to #10. After #10 fixed the `E2BIG` commit-message failure, semantic-release got further on `v1.0.0` — it created the tag and version-bump commit — then **failed on `@semantic-release/github`** with HTTP 422:

```
body is too long (maximum is 125000 characters)
```

The fork's first release rolls up **~1800 commits** (~130 KB of notes), which exceeds GitHub's 125,000-char Release-body cap. Because the `release` job failed, the `image` job (which has `needs: release`) was **skipped**, so `v1.0.0` has:

- ✅ tag `v1.0.0` + version-bump commit + full `CHANGELOG.md`
- ❌ no GitHub Release object
- ❌ no `:v1.0.0` / `:latest` image

`main` is already unstuck going forward (the `v1.0.0` tag is now semantic-release's baseline, so future releases produce small notes). This PR (1) guards against the body-size class of failure and (2) adds the mechanism to backfill the missing `v1.0.0` artifacts.

## Changes

**`.releaserc.js` — cap the GitHub Release body**
Adds a `releaseBodyTemplate` (Lodash) to `@semantic-release/github`:
- notes ≤ 120 KB → passed through unchanged (raw, not HTML-escaped)
- notes > 120 KB → truncated to 120 KB + a link to `CHANGELOG.md`

This caps **only** the Release body; `@semantic-release/changelog` still writes the full notes to the file. Verified both branches render correctly (small notes pass through byte-identical; large notes truncate to 120,184 chars < 125,000 with the changelog link).

**`.github/workflows/release.yml` — manual tag republish**
Adds a `workflow_dispatch` input `publish_tag`. When set, semantic-release is skipped and the existing `image` job checks out that tag and publishes it as a stable release image (`:latest` + `:v<version>`), reusing the same buildx + cosign-keyless steps (so the OIDC signer identity matches normal releases). It does **not** move `:edge` (that tracks main's HEAD). The image job's `if` switches to `!cancelled() && needs.release.result != 'failure' && (...)` so it still runs when the release job is skipped, while a *failed* release continues to block the image. Also reusable for base-image security rebuilds of an existing tag.

Commit typed `ci:` so it does not itself trigger a release.

## After merge (backfill `v1.0.0`)

1. Dispatch `release.yml` with `publish_tag=v1.0.0` → builds/pushes/signs `:v1.0.0` + `:latest`.
2. `gh release create v1.0.0` with a short body linking to the changelog.

https://claude.ai/code/session_01UkPKZFz9vn7L4WD2zXgSVR