### PR TITLE
ci: push releases via GitHub App token and run CI on beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, beta]
   push:
-    # main = post-merge run. renovate/** lets Renovate's branch-automerge
+    # main/beta = post-merge run. renovate/** lets Renovate's branch-automerge
     # updates (which never open a PR) run CI on the branch so the default-branch
-    # ruleset can fast-forward main once the branch is green.
-    branches: [main, 'renovate/**']
+    # ruleset can fast-forward the target branch once the branch is green.
+    branches: [main, beta, 'renovate/**']
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,26 @@ jobs:
       version: ${{ steps.semantic.outputs.new_release_version }}
       channel: ${{ steps.semantic.outputs.new_release_channel }}
     steps:
+      # Mint a token for the release GitHub App. semantic-release pushes the
+      # version-bump commit + tag AS this app, and the branch ruleset grants that
+      # app (and only it) bypass — so the unsigned bump commit clears required
+      # signatures / status checks while ordinary contributors stay gated.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history + tags so semantic-release can determine the last release.
           fetch-depth: 0
+          # Persist the app token so @semantic-release/git pushes the bump commit
+          # + tag as the app (the ruleset bypass actor).
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Semantic Release
         id: semantic
@@ -66,7 +80,9 @@ jobs:
           extra_plugins: |
             @semantic-release/exec@7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token (not the default GITHUB_TOKEN) so the tag + GitHub Release
+          # are created by the app that the branch ruleset allows to bypass.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # The weekly scheduled run promotes dependency bumps to a patch release.
           RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
 


### PR DESCRIPTION
## What

Prep for a `default-branch-protection` ruleset on `main` + `beta` (modeled on `homebridge-philips-hue-sync-box` and `k8s-leader-elector`): block deletion, block force-push, require signed commits, and strict required status checks (`Backend (Go)` + `Frontend (Next.js)`). Two workflow changes must land **before** the ruleset so protection doesn't wedge releases or beta PRs.

### `release.yml` — push releases via the release GitHub App
- Mints a token with `actions/create-github-app-token` and uses it for **both** the checkout credentials (so `@semantic-release/git` pushes the version-bump commit + tag **as the app**) and the `GITHUB_TOKEN` env (so the tag + GitHub Release are created by the app).
- The ruleset will grant that app — and only it — bypass, so the unsigned bump commit clears required signatures / status checks while ordinary contributors stay gated. Same release-app pattern as the other repos.

### `ci.yml` — run CI on `beta`
- Adds `beta` to the `pull_request` + `push` triggers so the ruleset's required checks can actually pass on the beta channel. Without this, beta PRs would hang forever waiting on checks that never run.

## Required before this can merge / before the ruleset goes on

- [ ] Add repo secrets **`APP_ID`** and **`APP_PRIVATE_KEY`** (same values as the other repos).
- [ ] Confirm the release app is **installed on this repo** with **Contents: write**.

## Follow-up (not in this PR)

Once the secrets are in and this is merged, the `default-branch-protection` ruleset gets created via API with the app (integration `3857914`) as the sole non-admin bypass actor.

https://claude.ai/code/session_01MZCgbqN6sSZgSVz1FSWaPP
