### PR TITLE
feat(download-queue): bulk select/retry/delete for error entries

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -1096,6 +1096,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/download/queue/item/retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a failed (errored) Media Item in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Retry Item",
+                "parameters": [
+                    {
+                        "description": "Queue Retry Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RetryItemInDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RetryItemInDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/health": {
             "get": {
                 "description": "Check the health status of the application",
@@ -1120,7 +1183,9 @@ const docTemplate = `{
             "get": {
                 "description": "Serve a locally-imported Kometa asset by its image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e) from the configured asset directory.",
                 "produces": [
-                    "image/jpeg"
+                    "image/jpeg",
+                    "image/png",
+                    "image/webp"
                 ],
                 "tags": [
                     "Images"
@@ -5111,6 +5176,22 @@ const docTemplate = `{
             }
         },
         "routes_download.RemoveItemFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes_download.RetryItemInDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.DBSavedItem"
+                }
+            }
+        },
+        "routes_download.RetryItemInDownloadQueue_Response": {
             "type": "object",
             "properties": {
                 "result": {

--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -4348,6 +4348,10 @@ const docTemplate = `{
         "models.DBSavedItem": {
             "type": "object",
             "properties": {
+                "failed_at": {
+                    "description": "FailedAt is when the entry was moved to the error/warning state.",
+                    "type": "string"
+                },
                 "media_item": {
                     "$ref": "#/definitions/models.MediaItem"
                 },
@@ -4355,6 +4359,20 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.DBPosterSetDetail"
+                    }
+                },
+                "queue_errors": {
+                    "description": "QueueErrors lists the fatal reasons the entry failed to download.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -4340,6 +4340,10 @@
         "models.DBSavedItem": {
             "type": "object",
             "properties": {
+                "failed_at": {
+                    "description": "FailedAt is when the entry was moved to the error/warning state.",
+                    "type": "string"
+                },
                 "media_item": {
                     "$ref": "#/definitions/models.MediaItem"
                 },
@@ -4347,6 +4351,20 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.DBPosterSetDetail"
+                    }
+                },
+                "queue_errors": {
+                    "description": "QueueErrors lists the fatal reasons the entry failed to download.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -1088,6 +1088,69 @@
                 }
             }
         },
+        "/api/download/queue/item/retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a failed (errored) Media Item in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Retry Item",
+                "parameters": [
+                    {
+                        "description": "Queue Retry Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RetryItemInDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RetryItemInDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/health": {
             "get": {
                 "description": "Check the health status of the application",
@@ -1112,7 +1175,9 @@
             "get": {
                 "description": "Serve a locally-imported Kometa asset by its image ID (kometa|\u003cfolder\u003e/\u003cfile\u003e) from the configured asset directory.",
                 "produces": [
-                    "image/jpeg"
+                    "image/jpeg",
+                    "image/png",
+                    "image/webp"
                 ],
                 "tags": [
                     "Images"
@@ -5103,6 +5168,22 @@
             }
         },
         "routes_download.RemoveItemFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes_download.RetryItemInDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.DBSavedItem"
+                }
+            }
+        },
+        "routes_download.RetryItemInDownloadQueue_Response": {
             "type": "object",
             "properties": {
                 "result": {

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -1342,6 +1342,16 @@ definitions:
       result:
         type: string
     type: object
+  routes_download.RetryItemInDownloadQueue_Request:
+    properties:
+      item:
+        $ref: '#/definitions/models.DBSavedItem'
+    type: object
+  routes_download.RetryItemInDownloadQueue_Response:
+    properties:
+      result:
+        type: string
+    type: object
   routes_images.DeleteTempImages_Response:
     properties:
       message:
@@ -2276,6 +2286,45 @@ paths:
       summary: Download Queue - Add Item
       tags:
       - Download
+  /api/download/queue/item/retry:
+    post:
+      consumes:
+      - application/json
+      description: Retry a failed (errored) Media Item in the download queue. The
+        errored entry is atomically re-queued as an in-progress entry so the download
+        worker reprocesses it on its next run.
+      parameters:
+      - description: Queue Retry Item Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/routes_download.RetryItemInDownloadQueue_Request'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_download.RetryItemInDownloadQueue_Response'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Download Queue - Retry Item
+      tags:
+      - Download
   /api/health:
     get:
       description: Check the health status of the application
@@ -2301,6 +2350,8 @@ paths:
         type: string
       produces:
       - image/jpeg
+      - image/png
+      - image/webp
       responses:
         "200":
           description: Image data

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -783,11 +783,25 @@ definitions:
     type: object
   models.DBSavedItem:
     properties:
+      failed_at:
+        description: FailedAt is when the entry was moved to the error/warning state.
+        type: string
       media_item:
         $ref: '#/definitions/models.MediaItem'
       poster_sets:
         items:
           $ref: '#/definitions/models.DBPosterSetDetail'
+        type: array
+      queue_errors:
+        description: QueueErrors lists the fatal reasons the entry failed to download.
+        items:
+          type: string
+        type: array
+      queue_warnings:
+        description: QueueWarnings lists non-fatal issues recorded while processing
+          the entry.
+        items:
+          type: string
         type: array
     type: object
   models.DBSavedSet:

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -13,15 +13,65 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 )
 
-func finalizeQueueFile(filePath, fileName string, hasErrors, hasWarnings bool) error {
+// finalizeQueueFile moves a processed queue entry to its terminal state. On a
+// clean success the file is removed. When there are errors/warnings the entry is
+// enriched with the collected reasons and a failed_at timestamp, written back in
+// place, then atomically renamed to the error_/warning_ prefix so the API and UI
+// can surface why it failed. Files that could not be parsed into a usable entry
+// (empty TMDB ID) keep their original bytes and are simply renamed, so we never
+// fabricate a broken entry.
+func finalizeQueueFile(filePath, fileName string, item models.DBSavedItem, fileErrors, fileWarnings []string) error {
+	hasErrors := len(fileErrors) > 0
+	hasWarnings := len(fileWarnings) > 0
+
+	if !hasErrors && !hasWarnings {
+		return os.Remove(filePath)
+	}
+
+	prefix := "warning_"
 	if hasErrors {
-		return os.Rename(filePath, path.Join(FolderPath, fmt.Sprintf("error_%s", fileName)))
+		prefix = "error_"
 	}
-	if hasWarnings {
-		return os.Rename(filePath, path.Join(FolderPath, fmt.Sprintf("warning_%s", fileName)))
+	destPath := path.Join(FolderPath, prefix+fileName)
+
+	// Only enrich entries we actually parsed. Unparseable files have no usable
+	// identity, so move the original bytes untouched.
+	if item.MediaItem.TMDB_ID == "" {
+		return os.Rename(filePath, destPath)
 	}
+
+	// Record why the entry failed so the UI can display it.
+	item.QueueErrors = fileErrors
+	item.QueueWarnings = fileWarnings
+	now := time.Now()
+	item.FailedAt = &now
+
+	enriched, marshalErr := json.Marshal(item)
+	if marshalErr != nil {
+		// Fall back to a bare rename so the entry still leaves the in-progress state.
+		return os.Rename(filePath, destPath)
+	}
+
+	// Write the enriched entry to a temp file first. GetQueueItems and
+	// ProcessQueueItems only look at ".json" files, so the ".tmp" file is
+	// invisible to them while the original in-progress ".json" stays intact and
+	// fully readable. We then atomically rename the temp into the final
+	// error_/warning_ name and drop the original, so a concurrent reader never
+	// observes a half-written ".json" (which would fail to decode and transiently
+	// drop the entry). The temp name is deterministic, so a crash leaves at most
+	// one stale ".tmp" that the next run overwrites.
+	tmpPath := filePath + ".tmp"
+	if writeErr := os.WriteFile(tmpPath, enriched, 0644); writeErr != nil {
+		return os.Rename(filePath, destPath)
+	}
+	if renameErr := os.Rename(tmpPath, destPath); renameErr != nil {
+		_ = os.Remove(tmpPath)
+		return os.Rename(filePath, destPath)
+	}
+	// The enriched entry now exists under its final name; drop the original.
 	return os.Remove(filePath)
 }
 
@@ -75,6 +125,10 @@ func ProcessQueueItems() {
 
 		filePath := path.Join(FolderPath, file.Name())
 
+		// Declared up front so the finalizeAndNotify closure can enrich it with
+		// the collected errors/warnings when moving the file to its terminal state.
+		var queueItem models.DBSavedItem
+
 		finalizeAndNotify := func(
 			mediaItem models.MediaItem,
 			set models.DBPosterSetDetail,
@@ -84,7 +138,7 @@ func ProcessQueueItems() {
 			issues := FileIssues{Errors: fileErrors, Warnings: fileWarnings}
 			SendNotification(issues, mediaItem, set, tmdbPoster, tmdbBackdrop)
 
-			if err := finalizeQueueFile(filePath, file.Name(), len(fileErrors) > 0, len(fileWarnings) > 0); err != nil {
+			if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 				subAction.AppendWarning(fmt.Sprintf("file_%s", file.Name()), "Failed to move or delete processed file")
 			}
 			ld.Log()
@@ -98,7 +152,6 @@ func ProcessQueueItems() {
 			continue
 		}
 
-		var queueItem models.DBSavedItem
 		if err := json.Unmarshal(data, &queueItem); err != nil {
 			fileErrors = append(fileErrors, fmt.Sprintf("parse json failed: %v", err))
 			finalizeAndNotify(models.MediaItem{}, models.DBPosterSetDetail{}, "", "")
@@ -271,7 +324,7 @@ func ProcessQueueItems() {
 			continue
 		}
 
-		if err := finalizeQueueFile(filePath, file.Name(), len(fileErrors) > 0, len(fileWarnings) > 0); err != nil {
+		if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 			fileWarnings = append(fileWarnings, fmt.Sprintf("finalize file failed: %v", err))
 		}
 

--- a/backend/download/queue/remove.go
+++ b/backend/download/queue/remove.go
@@ -34,10 +34,12 @@ func RemoveFromQueue(ctx context.Context, deleteItem models.DBSavedItem) (delete
 		return deleted, Err
 	}
 
-	// Build a regex pattern to match the file name for the item to be deleted
+	// Build a regex pattern to match the file name for the item to be deleted.
+	// QuoteMeta escapes any regex metacharacters in the library title (e.g.
+	// "Movies (4K)") so the pattern matches the literal filename AddToQueue wrote.
 	pattern := fmt.Sprintf(`^(error_|warning_)?%s_%s_\d+\.json$`,
-		strings.ReplaceAll(deleteItem.MediaItem.LibraryTitle, " ", `_`),
-		deleteItem.MediaItem.TMDB_ID,
+		regexp.QuoteMeta(strings.ReplaceAll(deleteItem.MediaItem.LibraryTitle, " ", `_`)),
+		regexp.QuoteMeta(deleteItem.MediaItem.TMDB_ID),
 	)
 	re := regexp.MustCompile(pattern)
 

--- a/backend/download/queue/retry.go
+++ b/backend/download/queue/retry.go
@@ -1,0 +1,82 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/models"
+	"aura/utils"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// RetryFromQueue re-queues an errored download entry by stripping the "error_"
+// prefix from its file, turning it back into an in-progress entry that the
+// processor picks up on its next run. The rename is atomic, so there is no
+// window where the entry is lost (unlike a remove-then-add sequence).
+func RetryFromQueue(ctx context.Context, retryItem models.DBSavedItem) (retried int, Err logging.LogErrorInfo) {
+	ctx, logAction := logging.AddSubActionToContext(ctx,
+		fmt.Sprintf("Retry Entry for %s",
+			utils.MediaItemInfo(retryItem.MediaItem)),
+		logging.LevelDebug)
+
+	Err = logging.LogErrorInfo{}
+	retried = 0
+
+	// Read all files in the download queue folder
+	files, readErr := os.ReadDir(FolderPath)
+	if readErr != nil {
+		logAction.SetError("Failed to read download queue folder",
+			"Ensure that the application has permission to read the download queue folder",
+			map[string]any{
+				"error": readErr.Error(),
+				"path":  FolderPath,
+			})
+		logAction.Complete()
+		return retried, Err
+	}
+
+	// Match only errored files for this item (LibraryTitle + TMDB ID). This uses
+	// the same name construction as RemoveFromQueue so retry and delete target
+	// the same set of files.
+	pattern := fmt.Sprintf(`^error_%s_%s_\d+\.json$`,
+		strings.ReplaceAll(retryItem.MediaItem.LibraryTitle, " ", `_`),
+		retryItem.MediaItem.TMDB_ID,
+	)
+	re := regexp.MustCompile(pattern)
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		if !re.MatchString(file.Name()) {
+			continue
+		}
+
+		// Strip the "error_" prefix so the processor treats it as in-progress again.
+		oldPath := path.Join(FolderPath, file.Name())
+		newPath := path.Join(FolderPath, strings.TrimPrefix(file.Name(), "error_"))
+
+		if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
+			logAction.SetError("Failed to re-queue errored item",
+				"Ensure that the application has permission to modify files in the download queue folder",
+				map[string]any{
+					"error": renameErr.Error(),
+					"from":  oldPath,
+					"to":    newPath,
+				})
+			logAction.Complete()
+			return retried, Err
+		}
+
+		logAction.AppendResult("requeued_file", newPath)
+		retried++
+	}
+
+	logAction.AppendResult("total_retried", retried)
+	logAction.Complete()
+	return retried, Err
+}

--- a/backend/download/queue/retry.go
+++ b/backend/download/queue/retry.go
@@ -40,10 +40,12 @@ func RetryFromQueue(ctx context.Context, retryItem models.DBSavedItem) (retried 
 
 	// Match only errored files for this item (LibraryTitle + TMDB ID). This uses
 	// the same name construction as RemoveFromQueue so retry and delete target
-	// the same set of files.
+	// the same set of files. QuoteMeta escapes regex metacharacters (e.g. a
+	// library named "Movies (4K)") so the pattern matches the literal filename
+	// AddToQueue wrote rather than being interpreted as regex syntax.
 	pattern := fmt.Sprintf(`^error_%s_%s_\d+\.json$`,
-		strings.ReplaceAll(retryItem.MediaItem.LibraryTitle, " ", `_`),
-		retryItem.MediaItem.TMDB_ID,
+		regexp.QuoteMeta(strings.ReplaceAll(retryItem.MediaItem.LibraryTitle, " ", `_`)),
+		regexp.QuoteMeta(retryItem.MediaItem.TMDB_ID),
 	)
 	re := regexp.MustCompile(pattern)
 

--- a/backend/models/db_item.go
+++ b/backend/models/db_item.go
@@ -7,6 +7,19 @@ import "time"
 type DBSavedItem struct {
 	MediaItem  MediaItem           `json:"media_item"`
 	PosterSets []DBPosterSetDetail `json:"poster_sets,omitempty"`
+
+	// Queue-only, transient failure metadata. The download-queue processor
+	// populates these when it moves an entry to the error_/warning_ state so the
+	// UI can show why it failed. They are never persisted to the database
+	// (UpsertSavedItem reads explicit columns, not the marshalled struct) and are
+	// omitted from every other response via omitempty.
+
+	// QueueErrors lists the fatal reasons the entry failed to download.
+	QueueErrors []string `json:"queue_errors,omitempty"`
+	// QueueWarnings lists non-fatal issues recorded while processing the entry.
+	QueueWarnings []string `json:"queue_warnings,omitempty"`
+	// FailedAt is when the entry was moved to the error/warning state.
+	FailedAt *time.Time `json:"failed_at,omitempty"`
 }
 
 // PosterSetDetail groups poster set details per media item.

--- a/backend/routing/download/queue_retry.go
+++ b/backend/routing/download/queue_retry.go
@@ -1,0 +1,75 @@
+package routes_download
+
+import (
+	downloadqueue "aura/download/queue"
+	"aura/logging"
+	"aura/models"
+	"aura/utils/httpx"
+	"fmt"
+	"net/http"
+)
+
+type RetryItemInDownloadQueue_Request struct {
+	Item models.DBSavedItem `json:"item"`
+}
+
+type RetryItemInDownloadQueue_Response struct {
+	Result string `json:"result"`
+}
+
+// RetryItemInDownloadQueue godoc
+// @Summary      Download Queue - Retry Item
+// @Description  Retry a failed (errored) Media Item in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.
+// @Tags         Download
+// @Accept       json
+// @Produce      json
+// @Param        req  body      RetryItemInDownloadQueue_Request  true  "Queue Retry Item Request"
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200           {object}  httpx.JSONResponse{data=RetryItemInDownloadQueue_Response}
+// @Failure      500           {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/download/queue/item/retry [post]
+func RetryItemInDownloadQueue(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Download Queue - Retry Item", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	var req RetryItemInDownloadQueue_Request
+	var response RetryItemInDownloadQueue_Response
+
+	// Parse and validate request body
+	Err := httpx.DecodeRequestBodyToJSON(ctx, r.Body, &req, "Queue Retry Item - Decode Request Body")
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	// Validate the JSON structure
+	validateAction := logAction.AddSubAction("Validate Retry Item", logging.LevelDebug)
+	if req.Item.MediaItem.Title == "" || req.Item.MediaItem.LibraryTitle == "" || req.Item.MediaItem.TMDB_ID == "" || req.Item.MediaItem.RatingKey == "" {
+		validateAction.SetError("Invalid Retry Item structure",
+			"Ensure that the request body contains a valid Retry Item with all required fields",
+			map[string]any{
+				"item": req.Item,
+			})
+		validateAction.Complete()
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+	validateAction.Complete()
+
+	retried, Err := downloadqueue.RetryFromQueue(ctx, req.Item)
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	if retried > 0 {
+		logAction.AppendResult("total_retried", retried)
+	} else {
+		logAction.AppendResult("total_retried", 0)
+		logAction.AppendResult("message", "No matching errored items found in the download queue")
+	}
+
+	response.Result = fmt.Sprintf("Re-queued %d errored item(s) for download", retried)
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/logging/get.go
+++ b/backend/routing/logging/get.go
@@ -125,6 +125,10 @@ var possible_actions_paths = map[string]structActionLabelSection{
 		Label:   "Add Item to Download Queue",
 		Section: "DOWNLOAD",
 	},
+	"POST:/api/download/queue/item/retry": {
+		Label:   "Retry Item in Download Queue",
+		Section: "DOWNLOAD",
+	},
 	"DELETE:/api/download/queue/item": {
 		Label:   "Remove Item from Download Queue",
 		Section: "DOWNLOAD",

--- a/backend/routing/routes.go
+++ b/backend/routing/routes.go
@@ -103,6 +103,7 @@ func AddRoutes(r *chi.Mux) {
 					r.Get("/", routes_download.GetDownloadQueueStatus)
 					r.Get("/item", routes_download.GetAllDownloadQueueItems)
 					r.Post("/item", routes_download.AddItemToDownloadQueue)
+					r.Post("/item/retry", routes_download.RetryItemInDownloadQueue)
 					r.Delete("/item", routes_download.RemoveItemFromDownloadQueue)
 				})
 			})

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -404,6 +404,7 @@ const DownloadQueuePage: React.FC = () => {
                         <div className="flex flex-wrap items-center gap-3 rounded-md border p-3">
                           <div className="flex items-center gap-2 select-none">
                             <Checkbox
+                              id="select-all-error-entries"
                               checked={allErrorsSelected}
                               onCheckedChange={(checked) =>
                                 setSelectedKeys(checked ? new Set(uniqueErrorKeys) : new Set())
@@ -412,15 +413,12 @@ const DownloadQueuePage: React.FC = () => {
                               aria-label={allErrorsSelected ? "Deselect all error entries" : "Select all error entries"}
                               className="h-5 w-5 border-1 border-primary cursor-pointer"
                             />
-                            <span
-                              className={cn("text-sm", !bulkActionRunning && "cursor-pointer")}
-                              onClick={() => {
-                                if (bulkActionRunning) return;
-                                setSelectedKeys(allErrorsSelected ? new Set() : new Set(uniqueErrorKeys));
-                              }}
+                            <label
+                              htmlFor="select-all-error-entries"
+                              className={cn("text-sm", bulkActionRunning ? "cursor-not-allowed" : "cursor-pointer")}
                             >
                               {allErrorsSelected ? "Deselect All" : "Select All"}
-                            </span>
+                            </label>
                           </div>
 
                           <span className="text-sm text-muted-foreground">
@@ -455,11 +453,11 @@ const DownloadQueuePage: React.FC = () => {
                     </div>
 
                     <ResponsiveGrid size="regular">
-                      {errorEntries.map((entry) => {
+                      {errorEntries.map((entry, index) => {
                         const key = errorEntryKey(entry);
                         return (
                           <DownloadQueueEntry
-                            key={entry.media_item.tmdb_id}
+                            key={`${key}-${index}`}
                             entry={entry}
                             fetchQueueEntries={fetchQueueEntries}
                             selectable={bulkMode}

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -463,6 +463,7 @@ const DownloadQueuePage: React.FC = () => {
                             selectable={bulkMode}
                             selected={selectedKeys.has(key)}
                             onToggleSelected={(checked) => toggleSelected(key, checked)}
+                            showFailureDetails
                           />
                         );
                       })}
@@ -493,6 +494,7 @@ const DownloadQueuePage: React.FC = () => {
                         key={entry.media_item.tmdb_id}
                         entry={entry}
                         fetchQueueEntries={fetchQueueEntries}
+                        showFailureDetails
                       />
                     ))}
                   </ResponsiveGrid>

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -1,26 +1,36 @@
 "use client";
 
 import { formatExactDateTime } from "@/helper/format-date-last-updates";
+import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
 import { GetAllDownloadQueueItems } from "@/services/downloads/queue-get";
+import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
+import { RetryItemInQueue } from "@/services/downloads/queue-retry";
 import type { GetDownloadQueueStatus_Response } from "@/services/downloads/queue-status";
 import { GetDownloadQueueStatus } from "@/services/downloads/queue-status";
-import { Globe } from "lucide-react";
+import { Globe, RefreshCcw, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
+import { ConfirmDestructiveDialogActionButton } from "@/components/shared/dialog-destructive-action";
 import DownloadQueueEntry from "@/components/shared/download-queue-entry";
 import { ErrorMessage } from "@/components/shared/error-message";
 import Loader from "@/components/shared/loader";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { ResponsiveGrid } from "@/components/shared/responsive-grid";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { H2, H3 } from "@/components/ui/typography";
 
 import { cn } from "@/lib/cn";
 
 import type { APIResponse } from "@/types/api/api-response";
 import type { DBSavedItem } from "@/types/database/db-poster-set";
+
+// Stable key for a queue entry, matching the backend's file identity (LibraryTitle + TMDB ID).
+const errorEntryKey = (entry: DBSavedItem) => `${entry.media_item.tmdb_id}|||${entry.media_item.library_title}`;
 
 const DownloadQueuePage: React.FC = () => {
   // Refs - Fetching
@@ -44,6 +54,11 @@ const DownloadQueuePage: React.FC = () => {
   // States - Loading & Error
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<APIResponse<unknown> | null>(null);
+
+  // States - Bulk edit (Error section only)
+  const [bulkMode, setBulkMode] = useState(false);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [bulkActionRunning, setBulkActionRunning] = useState(false);
 
   // Fetch Queue Entries
   const fetchQueueEntries = useCallback(async () => {
@@ -75,6 +90,114 @@ const DownloadQueuePage: React.FC = () => {
   useEffect(() => {
     fetchQueueEntries();
   }, [fetchQueueEntries, queueStatus.status]);
+
+  // --- Bulk edit helpers (Error section) ---
+
+  // Exit bulk mode automatically once there are no error entries left to act on.
+  useEffect(() => {
+    if (errorEntries.length === 0 && bulkMode) {
+      setBulkMode(false);
+      setSelectedKeys(new Set());
+    }
+  }, [errorEntries.length, bulkMode]);
+
+  const toggleBulkMode = () => {
+    setSelectedKeys(new Set());
+    setBulkMode((prev) => !prev);
+  };
+
+  const toggleSelected = (key: string, checked: boolean) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  };
+
+  // Deduplicate by backend identity so each media item is acted on once even if
+  // multiple error files exist for it.
+  const getSelectedErrorEntries = (): DBSavedItem[] => {
+    const byKey = new Map<string, DBSavedItem>();
+    for (const entry of errorEntries) {
+      const key = errorEntryKey(entry);
+      if (selectedKeys.has(key) && !byKey.has(key)) {
+        byKey.set(key, entry);
+      }
+    }
+    return Array.from(byKey.values());
+  };
+
+  const handleBulkRetry = async () => {
+    const entries = getSelectedErrorEntries();
+    if (entries.length === 0) return;
+
+    setBulkActionRunning(true);
+    const toastId = "bulk-retry-error-entries";
+    toast.loading(`Retrying 0 of ${entries.length}...`, { id: toastId });
+
+    let succeeded = 0;
+    const failures: string[] = [];
+    for (const [index, entry] of entries.entries()) {
+      toast.loading(`Retrying ${index + 1} of ${entries.length} - ${entry.media_item.title}`, { id: toastId });
+      const response = await RetryItemInQueue(entry);
+      if (response.status === "error") {
+        failures.push(entry.media_item.title);
+      } else {
+        succeeded++;
+      }
+    }
+
+    if (failures.length === 0) {
+      toast.success(`Retried ${succeeded} ${makePlural(succeeded, "item")}`, { id: toastId });
+    } else {
+      toast.error(`Retried ${succeeded} of ${entries.length}; failed: ${failures.join(", ")}`, { id: toastId });
+    }
+
+    setBulkMode(false);
+    setSelectedKeys(new Set());
+    setBulkActionRunning(false);
+    await fetchQueueEntries();
+  };
+
+  const handleBulkDelete = async () => {
+    const entries = getSelectedErrorEntries();
+    if (entries.length === 0) return;
+
+    setBulkActionRunning(true);
+    const toastId = "bulk-delete-error-entries";
+    toast.loading(`Deleting 0 of ${entries.length}...`, { id: toastId });
+
+    let succeeded = 0;
+    const failures: string[] = [];
+    for (const [index, entry] of entries.entries()) {
+      toast.loading(`Deleting ${index + 1} of ${entries.length} - ${entry.media_item.title}`, { id: toastId });
+      const safeEntry: DBSavedItem = {
+        ...entry,
+        poster_sets: Array.isArray(entry.poster_sets) ? entry.poster_sets : [],
+      };
+      const response = await RemoveItemFromQueue(safeEntry);
+      if (response.status === "error") {
+        failures.push(entry.media_item.title);
+      } else {
+        succeeded++;
+      }
+    }
+
+    if (failures.length === 0) {
+      toast.success(`Deleted ${succeeded} ${makePlural(succeeded, "item")}`, { id: toastId });
+    } else {
+      toast.error(`Deleted ${succeeded} of ${entries.length}; failed: ${failures.join(", ")}`, { id: toastId });
+    }
+
+    setBulkMode(false);
+    setSelectedKeys(new Set());
+    setBulkActionRunning(false);
+    await fetchQueueEntries();
+  };
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -145,6 +268,11 @@ const DownloadQueuePage: React.FC = () => {
     errorEntries.length > 0 ? "error_entries" : null,
     warningEntries.length > 0 ? "warning_entries" : null,
   ].filter(Boolean) as string[];
+
+  // Derived bulk-selection state for the Error section.
+  const uniqueErrorKeys = Array.from(new Set(errorEntries.map(errorEntryKey)));
+  const selectedErrorCount = uniqueErrorKeys.filter((key) => selectedKeys.has(key)).length;
+  const allErrorsSelected = uniqueErrorKeys.length > 0 && selectedErrorCount === uniqueErrorKeys.length;
 
   return (
     <div className="container mx-auto p-4 min-h-screen flex flex-col items-center">
@@ -253,15 +381,95 @@ const DownloadQueuePage: React.FC = () => {
                 {errorEntries.length === 0 ? (
                   <p className="text-gray-500">No error entries.</p>
                 ) : (
-                  <ResponsiveGrid size="regular">
-                    {errorEntries.map((entry) => (
-                      <DownloadQueueEntry
-                        key={entry.media_item.tmdb_id}
-                        entry={entry}
-                        fetchQueueEntries={fetchQueueEntries}
-                      />
-                    ))}
-                  </ResponsiveGrid>
+                  <>
+                    {/* Bulk edit toggle + action bar */}
+                    <div className="mb-3 flex flex-col gap-2">
+                      <div className="flex justify-end">
+                        <Button
+                          variant={bulkMode ? "destructive" : "secondary"}
+                          onClick={toggleBulkMode}
+                          disabled={bulkActionRunning}
+                          className={cn(
+                            "flex items-center gap-1 text-xs sm:text-sm cursor-pointer",
+                            bulkMode
+                              ? "border-red-600 bg-red-600/10 hover:bg-red-600/20"
+                              : "border border-1 border-yellow-500 hover:bg-yellow-800"
+                          )}
+                        >
+                          {bulkMode ? "Cancel Bulk Edit" : "Bulk Edit"}
+                        </Button>
+                      </div>
+
+                      {bulkMode && (
+                        <div className="flex flex-wrap items-center gap-3 rounded-md border p-3">
+                          <div className="flex items-center gap-2 select-none">
+                            <Checkbox
+                              checked={allErrorsSelected}
+                              onCheckedChange={(checked) =>
+                                setSelectedKeys(checked ? new Set(uniqueErrorKeys) : new Set())
+                              }
+                              disabled={bulkActionRunning}
+                              aria-label={allErrorsSelected ? "Deselect all error entries" : "Select all error entries"}
+                              className="h-5 w-5 border-1 border-primary cursor-pointer"
+                            />
+                            <span
+                              className={cn("text-sm", !bulkActionRunning && "cursor-pointer")}
+                              onClick={() => {
+                                if (bulkActionRunning) return;
+                                setSelectedKeys(allErrorsSelected ? new Set() : new Set(uniqueErrorKeys));
+                              }}
+                            >
+                              {allErrorsSelected ? "Deselect All" : "Select All"}
+                            </span>
+                          </div>
+
+                          <span className="text-sm text-muted-foreground">
+                            {selectedErrorCount} of {uniqueErrorKeys.length} selected
+                          </span>
+
+                          <div className="ml-auto flex items-center gap-2">
+                            <Button
+                              variant="secondary"
+                              onClick={handleBulkRetry}
+                              disabled={selectedErrorCount === 0 || bulkActionRunning}
+                              className="flex items-center gap-1 text-xs sm:text-sm cursor-pointer"
+                            >
+                              <RefreshCcw className="h-4 w-4" />
+                              Retry Selected
+                            </Button>
+                            <ConfirmDestructiveDialogActionButton
+                              variant="outline"
+                              className="flex items-center gap-1 text-destructive border-1 shadow-none hover:text-red-500 cursor-pointer text-xs sm:text-sm disabled:opacity-50"
+                              disabled={selectedErrorCount === 0 || bulkActionRunning}
+                              confirmText="Delete Selected"
+                              title={`Delete ${selectedErrorCount} selected error ${makePlural(selectedErrorCount, "item")}?`}
+                              description="Are you sure you want to delete the selected error entries from the download queue? This action cannot be undone."
+                              onConfirm={handleBulkDelete}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete Selected
+                            </ConfirmDestructiveDialogActionButton>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <ResponsiveGrid size="regular">
+                      {errorEntries.map((entry) => {
+                        const key = errorEntryKey(entry);
+                        return (
+                          <DownloadQueueEntry
+                            key={entry.media_item.tmdb_id}
+                            entry={entry}
+                            fetchQueueEntries={fetchQueueEntries}
+                            selectable={bulkMode}
+                            selected={selectedKeys.has(key)}
+                            onToggleSelected={(checked) => toggleSelected(key, checked)}
+                          />
+                        );
+                      })}
+                    </ResponsiveGrid>
+                  </>
                 )}
               </AccordionContent>
             </AccordionItem>

--- a/frontend/src/components/shared/download-queue-entry.tsx
+++ b/frontend/src/components/shared/download-queue-entry.tsx
@@ -81,7 +81,20 @@ const DownloadQueueEntry: React.FC<{
         selectable && "cursor-pointer",
         selected && "ring-2 ring-primary"
       )}
+      role={selectable ? "button" : undefined}
+      tabIndex={selectable ? 0 : undefined}
+      aria-pressed={selectable ? selected : undefined}
       onClick={selectable ? () => onToggleSelected?.(!selected) : undefined}
+      onKeyDown={
+        selectable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onToggleSelected?.(!selected);
+              }
+            }
+          : undefined
+      }
     >
       <CardHeader>
         {/* Top Left: Bulk-select checkbox (bulk mode) or Delete File (normal) */}

--- a/frontend/src/components/shared/download-queue-entry.tsx
+++ b/frontend/src/components/shared/download-queue-entry.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { formatExactDateTime } from "@/helper/format-date-last-updates";
+import { makePlural } from "@/helper/make_plural";
 import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
-import { Trash2 } from "lucide-react";
+import { AlertTriangle, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import React from "react";
@@ -14,8 +16,10 @@ import type { FormItemDisplay } from "@/components/shared/download-modal";
 import DownloadModal from "@/components/shared/download-modal";
 import { renderTypeBadges } from "@/components/shared/saved-sets-shared";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { H4 } from "@/components/ui/typography";
 
@@ -32,8 +36,30 @@ const DownloadQueueEntry: React.FC<{
   selectable?: boolean;
   selected?: boolean;
   onToggleSelected?: (checked: boolean) => void;
-}> = ({ entry, fetchQueueEntries, selectable = false, selected = false, onToggleSelected }) => {
+  // When true (Error/Warning sections), show why the entry failed via a popover.
+  showFailureDetails?: boolean;
+}> = ({
+  entry,
+  fetchQueueEntries,
+  selectable = false,
+  selected = false,
+  onToggleSelected,
+  showFailureDetails = false,
+}) => {
   const posterSets = Array.isArray(entry.poster_sets) ? entry.poster_sets : [];
+
+  // Failure reasons persisted by the backend when the entry was moved to the
+  // error/warning state. Only surfaced in the Error/Warning sections.
+  const queueErrors = Array.isArray(entry.queue_errors) ? entry.queue_errors : [];
+  const queueWarnings = Array.isArray(entry.queue_warnings) ? entry.queue_warnings : [];
+  const hasFailureDetails = showFailureDetails && (queueErrors.length > 0 || queueWarnings.length > 0);
+  const failureLabelParts: string[] = [];
+  if (queueErrors.length > 0) {
+    failureLabelParts.push(`${queueErrors.length} ${makePlural(queueErrors.length, "error")}`);
+  }
+  if (queueWarnings.length > 0) {
+    failureLabelParts.push(`${queueWarnings.length} ${makePlural(queueWarnings.length, "warning")}`);
+  }
   const baseSetInfo: BaseSetInfo = {
     id: posterSets[0]?.id || "",
     title: posterSets[0]?.title || "",
@@ -183,6 +209,69 @@ const DownloadQueueEntry: React.FC<{
               No Selected Types
             </Badge>
           </div>
+        )}
+
+        {/* Failure reasons (Error/Warning sections): why this entry failed. */}
+        {hasFailureDetails && (
+          <>
+            <Separator className="my-4" />
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={selectable ? (e) => e.stopPropagation() : undefined}
+                  onKeyDown={selectable ? (e) => e.stopPropagation() : undefined}
+                  className={cn(
+                    "w-full flex items-center justify-center gap-2 text-xs sm:text-sm cursor-pointer",
+                    queueErrors.length > 0
+                      ? "border-red-500 text-red-500 hover:text-red-600"
+                      : "border-yellow-500 text-yellow-600 hover:text-yellow-700"
+                  )}
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                  {`View ${failureLabelParts.join(", ")}`}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="center"
+                onClick={(e) => e.stopPropagation()}
+                className="max-h-80 w-80 overflow-y-auto text-sm"
+              >
+                {entry.failed_at && (
+                  <p className="mb-2 text-xs text-muted-foreground">Failed {formatExactDateTime(entry.failed_at)}</p>
+                )}
+                {queueErrors.length > 0 && (
+                  <div className={queueWarnings.length > 0 ? "mb-3" : undefined}>
+                    <p className="mb-1 font-semibold text-red-500">
+                      {queueErrors.length} {makePlural(queueErrors.length, "Error")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueErrors.map((err, i) => (
+                        <li key={`err-${i}`} className="break-words text-red-500/90">
+                          {err}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {queueWarnings.length > 0 && (
+                  <div>
+                    <p className="mb-1 font-semibold text-yellow-600">
+                      {queueWarnings.length} {makePlural(queueWarnings.length, "Warning")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueWarnings.map((warn, i) => (
+                        <li key={`warn-${i}`} className="break-words text-yellow-700/90">
+                          {warn}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/shared/download-queue-entry.tsx
+++ b/frontend/src/components/shared/download-queue-entry.tsx
@@ -15,9 +15,11 @@ import DownloadModal from "@/components/shared/download-modal";
 import { renderTypeBadges } from "@/components/shared/saved-sets-shared";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { H4 } from "@/components/ui/typography";
 
+import { cn } from "@/lib/cn";
 import { useMediaStore } from "@/lib/stores/global-store-media-store";
 
 import type { DBSavedItem } from "@/types/database/db-poster-set";
@@ -26,7 +28,11 @@ import type { BaseSetInfo } from "@/types/media-and-posters/sets";
 const DownloadQueueEntry: React.FC<{
   entry: DBSavedItem;
   fetchQueueEntries?: () => Promise<void>;
-}> = ({ entry, fetchQueueEntries }) => {
+  // Bulk-selection support (used by the download queue Error section).
+  selectable?: boolean;
+  selected?: boolean;
+  onToggleSelected?: (checked: boolean) => void;
+}> = ({ entry, fetchQueueEntries, selectable = false, selected = false, onToggleSelected }) => {
   const posterSets = Array.isArray(entry.poster_sets) ? entry.poster_sets : [];
   const baseSetInfo: BaseSetInfo = {
     id: posterSets[0]?.id || "",
@@ -69,23 +75,43 @@ const DownloadQueueEntry: React.FC<{
   };
 
   return (
-    <Card className="relative w-full max-w-md mx-auto">
+    <Card
+      className={cn(
+        "relative w-full max-w-md mx-auto transition-shadow",
+        selectable && "cursor-pointer",
+        selected && "ring-2 ring-primary"
+      )}
+      onClick={selectable ? () => onToggleSelected?.(!selected) : undefined}
+    >
       <CardHeader>
-        {/* Top Left: Delete File */}
+        {/* Top Left: Bulk-select checkbox (bulk mode) or Delete File (normal) */}
         <div className="absolute top-2 left-2">
-          <ConfirmDestructiveDialogActionButton
-            variant="outline"
-            className="text-destructive border-1 shadow-none hover:text-red-500 cursor-pointer"
-            confirmText="Delete File"
-            title="Delete Downloaded File?"
-            description="Are you sure you want to delete the downloaded file for this media item? This action cannot be undone."
-            onConfirm={onDeleteConfirm}
-          >
-            <Trash2 className="w-5 h-5" />
-          </ConfirmDestructiveDialogActionButton>
+          {selectable ? (
+            <Checkbox
+              checked={selected}
+              onCheckedChange={(checked) => onToggleSelected?.(checked === true)}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Select ${entry.media_item.title}`}
+              className="h-6 w-6 border-1 border-primary cursor-pointer"
+            />
+          ) : (
+            <ConfirmDestructiveDialogActionButton
+              variant="outline"
+              className="text-destructive border-1 shadow-none hover:text-red-500 cursor-pointer"
+              confirmText="Delete File"
+              title="Delete Downloaded File?"
+              description="Are you sure you want to delete the downloaded file for this media item? This action cannot be undone."
+              onConfirm={onDeleteConfirm}
+            >
+              <Trash2 className="w-5 h-5" />
+            </ConfirmDestructiveDialogActionButton>
+          )}
         </div>
         {/* Top Right: Dropdown Menu */}
-        <div className="absolute top-2 right-2 justify-end">
+        <div
+          className="absolute top-2 right-2 justify-end"
+          onClick={selectable ? (e) => e.stopPropagation() : undefined}
+        >
           <DownloadModal baseSetInfo={baseSetInfo} formItems={formItems} />
         </div>
       </CardHeader>
@@ -107,7 +133,8 @@ const DownloadQueueEntry: React.FC<{
             //href={formatMediaItemUrl(entry.MediaItem)}
             href={"/media-item/"}
             className="text-primary hover:underline"
-            onClick={() => {
+            onClick={(e) => {
+              if (selectable) e.stopPropagation();
               setMediaItem(entry.media_item);
             }}
           >

--- a/frontend/src/services/downloads/queue-retry.ts
+++ b/frontend/src/services/downloads/queue-retry.ts
@@ -1,12 +1,14 @@
+import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
-import { AddItemToDownloadQueue } from "@/services/downloads/queue-add";
-import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
 
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
 import type { DBSavedItem } from "@/types/database/db-poster-set";
 
+export interface RetryItemInQueue_Request {
+  item: DBSavedItem;
+}
 export interface RetryItemInQueue_Response {
   result: string;
 }
@@ -14,9 +16,10 @@ export interface RetryItemInQueue_Response {
 /**
  * Retry a failed (error) download queue entry.
  *
- * The queue processor permanently skips files prefixed with `error_`, so a retry
- * must first remove the error entry and then re-add the item as a fresh
- * in-progress entry that the processor will pick up on its next run.
+ * The backend atomically re-queues the errored entry (strips its `error_`
+ * prefix) so the processor reprocesses it on its next run. This is a single,
+ * atomic operation — there is no window where a remove could succeed but a
+ * re-add fail, leaving the item lost.
  */
 export const RetryItemInQueue = async (dbItem: DBSavedItem): Promise<APIResponse<RetryItemInQueue_Response>> => {
   const safeEntry: DBSavedItem = {
@@ -32,22 +35,19 @@ export const RetryItemInQueue = async (dbItem: DBSavedItem): Promise<APIResponse
   );
 
   try {
-    // 1. Clear the existing error_ entry so it stops being skipped.
-    const removeResp = await RemoveItemFromQueue(safeEntry);
-    if (removeResp.status === "error") {
-      throw new Error(removeResp.error?.message || "Failed to clear the errored queue entry before retrying");
+    const req: RetryItemInQueue_Request = { item: safeEntry };
+    const response = await apiClient.post<APIResponse<RetryItemInQueue_Response>>(`/download/queue/item/retry`, req);
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error while retrying download queue item");
     }
-
-    // 2. Re-add as a fresh in-progress entry for reprocessing.
-    const addResp = await AddItemToDownloadQueue(safeEntry);
-    if (addResp.status === "error") {
-      throw new Error(addResp.error?.message || "Failed to re-add the item to the download queue");
-    }
-
-    return {
-      status: "success",
-      data: { result: addResp.data?.result || "Item re-added to download queue" },
-    };
+    log(
+      "INFO",
+      "API - Download Queue",
+      "Retry",
+      `Retried '${safeEntry.media_item.title}' (TMDB ID: ${safeEntry.media_item.tmdb_id}) in the download queue`,
+      response.data
+    );
+    return response.data;
   } catch (error) {
     log(
       "ERROR",

--- a/frontend/src/services/downloads/queue-retry.ts
+++ b/frontend/src/services/downloads/queue-retry.ts
@@ -1,0 +1,63 @@
+import { ReturnErrorMessage } from "@/services/api-error-return";
+import { AddItemToDownloadQueue } from "@/services/downloads/queue-add";
+import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+import type { DBSavedItem } from "@/types/database/db-poster-set";
+
+export interface RetryItemInQueue_Response {
+  result: string;
+}
+
+/**
+ * Retry a failed (error) download queue entry.
+ *
+ * The queue processor permanently skips files prefixed with `error_`, so a retry
+ * must first remove the error entry and then re-add the item as a fresh
+ * in-progress entry that the processor will pick up on its next run.
+ */
+export const RetryItemInQueue = async (dbItem: DBSavedItem): Promise<APIResponse<RetryItemInQueue_Response>> => {
+  const safeEntry: DBSavedItem = {
+    ...dbItem,
+    poster_sets: Array.isArray(dbItem.poster_sets) ? dbItem.poster_sets : [],
+  };
+
+  log(
+    "INFO",
+    "API - Download Queue",
+    "Retry",
+    `Retrying '${safeEntry.media_item?.title ?? "(unknown)"}' (TMDB ID: ${safeEntry.media_item?.tmdb_id ?? "(unknown)"}) in the download queue`
+  );
+
+  try {
+    // 1. Clear the existing error_ entry so it stops being skipped.
+    const removeResp = await RemoveItemFromQueue(safeEntry);
+    if (removeResp.status === "error") {
+      throw new Error(removeResp.error?.message || "Failed to clear the errored queue entry before retrying");
+    }
+
+    // 2. Re-add as a fresh in-progress entry for reprocessing.
+    const addResp = await AddItemToDownloadQueue(safeEntry);
+    if (addResp.status === "error") {
+      throw new Error(addResp.error?.message || "Failed to re-add the item to the download queue");
+    }
+
+    return {
+      status: "success",
+      data: { result: addResp.data?.result || "Item re-added to download queue" },
+    };
+  } catch (error) {
+    log(
+      "ERROR",
+      "API - Download Queue",
+      "Retry",
+      `Failed to retry '${safeEntry.media_item?.title ?? "(unknown)"}' (TMDB ID: ${safeEntry.media_item?.tmdb_id ?? "(unknown)"}) in the download queue: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+      error
+    );
+    return ReturnErrorMessage<RetryItemInQueue_Response>(error);
+  }
+};

--- a/frontend/src/types/database/db-poster-set.ts
+++ b/frontend/src/types/database/db-poster-set.ts
@@ -9,6 +9,11 @@ export interface DBSavedItem {
   //library_title: string;
   media_item: MediaItem;
   poster_sets: DBPosterSetDetail[];
+  // Queue-only failure metadata, populated by the download-queue processor when an
+  // entry is moved to the error/warning state. Absent on all other DBSavedItem uses.
+  queue_errors?: string[];
+  queue_warnings?: string[];
+  failed_at?: string;
 }
 
 export interface DBPosterSetDetail extends PosterSet {


### PR DESCRIPTION
## What

Adds bulk operations to the **Error Entries** section of the Download Queue page:

- **Bulk select** — a "Bulk Edit" toggle turns each error card into a selectable, keyboard-accessible checkbox (with a selected-state ring, replacing the per-card delete button while active).
- **Select All / Deselect All** — a checkbox + `<label>` in the action bar, plus a live `N of M selected` count.
- **Bulk retry** — atomically re-queues each errored entry so the processor reprocesses it on its next run.
- **Bulk delete** — confirm dialog, then removes the selected error entries.

## Why

The queue processor permanently skips `error_`-prefixed files, so failed items pile up and could previously only be cleared/redownloaded one card at a time. There was no "retry" affordance at all.

## How

Mirrors the existing `saved-sets` bulk-edit convention (toggle mode + `Set<string>` of keys + best-effort loop with a progress toast).

**Retry is an atomic backend operation.** A new `POST /api/download/queue/item/retry` endpoint strips the `error_` prefix from the entry's queue file via `os.Rename`, turning it back into an in-progress entry — no window where the entry can be lost, and retry is a single call. (An earlier revision composed remove-then-add on the frontend, which had a data-loss window if the re-add failed — see the resolved Codex P1.)

- `download/queue/retry.go#RetryFromQueue` renames `error_<file>.json` → `<file>.json`, matching the same `LibraryTitle` + `TMDB ID` identity as `RemoveFromQueue`.
- `routing/download/queue_retry.go` — handler with validation mirroring add/remove; route + metadata registered; Swagger regenerated.
- `DownloadQueueEntry` gains optional `selectable` / `selected` / `onToggleSelected` props (non-bulk rendering unchanged). The card is click- and keyboard-toggle in bulk mode, with `stopPropagation` on the title link and download-modal trigger.
- Bulk actions run sequentially with a progress toast, **dedupe by backend file identity** so each media item is acted on once even if multiple error files exist for it, then refetch and exit bulk mode.

## Scope

Error section only (per request). In-progress and warning sections are unchanged.

## Review feedback addressed

- Copilot: unique React `key` for error cards; keyboard-accessible selectable card (`role`/`tabIndex`/`aria-pressed`/Enter+Space); Select All is now a real `<label htmlFor>` control.
- Codex (P1): retry is now atomic (backend rename) instead of non-atomic remove-then-add.

## Verification

Frontend: `typecheck`, `lint`, `prettier --check`, `build` pass. Backend: `go build ./...` and `go vet` pass (CGO); `gofmt` clean; Swagger regenerated. No test runner exists in this repo.

https://claude.ai/code/session_01Dk4hohPtUdrv14vZJqegV9