### PR TITLE
feat(download-queue): show why error/warning entries failed

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -4349,6 +4349,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "failed_at": {
+                    "description": "FailedAt is when the entry was moved to the error/warning state.",
                     "type": "string"
                 },
                 "media_item": {
@@ -4361,13 +4362,14 @@ const docTemplate = `{
                     }
                 },
                 "queue_errors": {
-                    "description": "Queue-only, transient failure metadata. The download-queue processor\npopulates these when it moves an entry to the error_/warning_ state so the\nUI can show why it failed. They are never persisted to the database\n(UpsertSavedItem reads explicit columns, not the marshalled struct) and are\nomitted from every other response via omitempty.",
+                    "description": "QueueErrors lists the fatal reasons the entry failed to download.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -4348,6 +4348,9 @@ const docTemplate = `{
         "models.DBSavedItem": {
             "type": "object",
             "properties": {
+                "failed_at": {
+                    "type": "string"
+                },
                 "media_item": {
                     "$ref": "#/definitions/models.MediaItem"
                 },
@@ -4355,6 +4358,19 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.DBPosterSetDetail"
+                    }
+                },
+                "queue_errors": {
+                    "description": "Queue-only, transient failure metadata. The download-queue processor\npopulates these when it moves an entry to the error_/warning_ state so the\nUI can show why it failed. They are never persisted to the database\n(UpsertSavedItem reads explicit columns, not the marshalled struct) and are\nomitted from every other response via omitempty.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -4340,6 +4340,9 @@
         "models.DBSavedItem": {
             "type": "object",
             "properties": {
+                "failed_at": {
+                    "type": "string"
+                },
                 "media_item": {
                     "$ref": "#/definitions/models.MediaItem"
                 },
@@ -4347,6 +4350,19 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.DBPosterSetDetail"
+                    }
+                },
+                "queue_errors": {
+                    "description": "Queue-only, transient failure metadata. The download-queue processor\npopulates these when it moves an entry to the error_/warning_ state so the\nUI can show why it failed. They are never persisted to the database\n(UpsertSavedItem reads explicit columns, not the marshalled struct) and are\nomitted from every other response via omitempty.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -4341,6 +4341,7 @@
             "type": "object",
             "properties": {
                 "failed_at": {
+                    "description": "FailedAt is when the entry was moved to the error/warning state.",
                     "type": "string"
                 },
                 "media_item": {
@@ -4353,13 +4354,14 @@
                     }
                 },
                 "queue_errors": {
-                    "description": "Queue-only, transient failure metadata. The download-queue processor\npopulates these when it moves an entry to the error_/warning_ state so the\nUI can show why it failed. They are never persisted to the database\n(UpsertSavedItem reads explicit columns, not the marshalled struct) and are\nomitted from every other response via omitempty.",
+                    "description": "QueueErrors lists the fatal reasons the entry failed to download.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -783,11 +783,27 @@ definitions:
     type: object
   models.DBSavedItem:
     properties:
+      failed_at:
+        type: string
       media_item:
         $ref: '#/definitions/models.MediaItem'
       poster_sets:
         items:
           $ref: '#/definitions/models.DBPosterSetDetail'
+        type: array
+      queue_errors:
+        description: |-
+          Queue-only, transient failure metadata. The download-queue processor
+          populates these when it moves an entry to the error_/warning_ state so the
+          UI can show why it failed. They are never persisted to the database
+          (UpsertSavedItem reads explicit columns, not the marshalled struct) and are
+          omitted from every other response via omitempty.
+        items:
+          type: string
+        type: array
+      queue_warnings:
+        items:
+          type: string
         type: array
     type: object
   models.DBSavedSet:

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -784,6 +784,7 @@ definitions:
   models.DBSavedItem:
     properties:
       failed_at:
+        description: FailedAt is when the entry was moved to the error/warning state.
         type: string
       media_item:
         $ref: '#/definitions/models.MediaItem'
@@ -792,16 +793,13 @@ definitions:
           $ref: '#/definitions/models.DBPosterSetDetail'
         type: array
       queue_errors:
-        description: |-
-          Queue-only, transient failure metadata. The download-queue processor
-          populates these when it moves an entry to the error_/warning_ state so the
-          UI can show why it failed. They are never persisted to the database
-          (UpsertSavedItem reads explicit columns, not the marshalled struct) and are
-          omitted from every other response via omitempty.
+        description: QueueErrors lists the fatal reasons the entry failed to download.
         items:
           type: string
         type: array
       queue_warnings:
+        description: QueueWarnings lists non-fatal issues recorded while processing
+          the entry.
         items:
           type: string
         type: array

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -13,16 +13,54 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 )
 
-func finalizeQueueFile(filePath, fileName string, hasErrors, hasWarnings bool) error {
+// finalizeQueueFile moves a processed queue entry to its terminal state. On a
+// clean success the file is removed. When there are errors/warnings the entry is
+// enriched with the collected reasons and a failed_at timestamp, written back in
+// place, then atomically renamed to the error_/warning_ prefix so the API and UI
+// can surface why it failed. Files that could not be parsed into a usable entry
+// (empty TMDB ID) keep their original bytes and are simply renamed, so we never
+// fabricate a broken entry.
+func finalizeQueueFile(filePath, fileName string, item models.DBSavedItem, fileErrors, fileWarnings []string) error {
+	hasErrors := len(fileErrors) > 0
+	hasWarnings := len(fileWarnings) > 0
+
+	if !hasErrors && !hasWarnings {
+		return os.Remove(filePath)
+	}
+
+	prefix := "warning_"
 	if hasErrors {
-		return os.Rename(filePath, path.Join(FolderPath, fmt.Sprintf("error_%s", fileName)))
+		prefix = "error_"
 	}
-	if hasWarnings {
-		return os.Rename(filePath, path.Join(FolderPath, fmt.Sprintf("warning_%s", fileName)))
+	destPath := path.Join(FolderPath, prefix+fileName)
+
+	// Only enrich entries we actually parsed. Unparseable files have no usable
+	// identity, so move the original bytes untouched.
+	if item.MediaItem.TMDB_ID == "" {
+		return os.Rename(filePath, destPath)
 	}
-	return os.Remove(filePath)
+
+	// Record why the entry failed so the UI can display it.
+	item.QueueErrors = fileErrors
+	item.QueueWarnings = fileWarnings
+	now := time.Now()
+	item.FailedAt = &now
+
+	enriched, marshalErr := json.Marshal(item)
+	if marshalErr != nil {
+		// Fall back to a bare rename so the entry still leaves the in-progress state.
+		return os.Rename(filePath, destPath)
+	}
+
+	// Overwrite in place, then atomically rename to the prefixed path so a reader
+	// never observes a half-written file under the final name.
+	if writeErr := os.WriteFile(filePath, enriched, 0644); writeErr != nil {
+		return os.Rename(filePath, destPath)
+	}
+	return os.Rename(filePath, destPath)
 }
 
 func ProcessQueueItems() {
@@ -75,6 +113,10 @@ func ProcessQueueItems() {
 
 		filePath := path.Join(FolderPath, file.Name())
 
+		// Declared up front so the finalizeAndNotify closure can enrich it with
+		// the collected errors/warnings when moving the file to its terminal state.
+		var queueItem models.DBSavedItem
+
 		finalizeAndNotify := func(
 			mediaItem models.MediaItem,
 			set models.DBPosterSetDetail,
@@ -84,7 +126,7 @@ func ProcessQueueItems() {
 			issues := FileIssues{Errors: fileErrors, Warnings: fileWarnings}
 			SendNotification(issues, mediaItem, set, tmdbPoster, tmdbBackdrop)
 
-			if err := finalizeQueueFile(filePath, file.Name(), len(fileErrors) > 0, len(fileWarnings) > 0); err != nil {
+			if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 				subAction.AppendWarning(fmt.Sprintf("file_%s", file.Name()), "Failed to move or delete processed file")
 			}
 			ld.Log()
@@ -98,7 +140,6 @@ func ProcessQueueItems() {
 			continue
 		}
 
-		var queueItem models.DBSavedItem
 		if err := json.Unmarshal(data, &queueItem); err != nil {
 			fileErrors = append(fileErrors, fmt.Sprintf("parse json failed: %v", err))
 			finalizeAndNotify(models.MediaItem{}, models.DBPosterSetDetail{}, "", "")
@@ -271,7 +312,7 @@ func ProcessQueueItems() {
 			continue
 		}
 
-		if err := finalizeQueueFile(filePath, file.Name(), len(fileErrors) > 0, len(fileWarnings) > 0); err != nil {
+		if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 			fileWarnings = append(fileWarnings, fmt.Sprintf("finalize file failed: %v", err))
 		}
 

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -55,12 +55,24 @@ func finalizeQueueFile(filePath, fileName string, item models.DBSavedItem, fileE
 		return os.Rename(filePath, destPath)
 	}
 
-	// Overwrite in place, then atomically rename to the prefixed path so a reader
-	// never observes a half-written file under the final name.
-	if writeErr := os.WriteFile(filePath, enriched, 0644); writeErr != nil {
+	// Write the enriched entry to a temp file first. GetQueueItems and
+	// ProcessQueueItems only look at ".json" files, so the ".tmp" file is
+	// invisible to them while the original in-progress ".json" stays intact and
+	// fully readable. We then atomically rename the temp into the final
+	// error_/warning_ name and drop the original, so a concurrent reader never
+	// observes a half-written ".json" (which would fail to decode and transiently
+	// drop the entry). The temp name is deterministic, so a crash leaves at most
+	// one stale ".tmp" that the next run overwrites.
+	tmpPath := filePath + ".tmp"
+	if writeErr := os.WriteFile(tmpPath, enriched, 0644); writeErr != nil {
 		return os.Rename(filePath, destPath)
 	}
-	return os.Rename(filePath, destPath)
+	if renameErr := os.Rename(tmpPath, destPath); renameErr != nil {
+		_ = os.Remove(tmpPath)
+		return os.Rename(filePath, destPath)
+	}
+	// The enriched entry now exists under its final name; drop the original.
+	return os.Remove(filePath)
 }
 
 func ProcessQueueItems() {

--- a/backend/models/db_item.go
+++ b/backend/models/db_item.go
@@ -13,9 +13,13 @@ type DBSavedItem struct {
 	// UI can show why it failed. They are never persisted to the database
 	// (UpsertSavedItem reads explicit columns, not the marshalled struct) and are
 	// omitted from every other response via omitempty.
-	QueueErrors   []string   `json:"queue_errors,omitempty"`
-	QueueWarnings []string   `json:"queue_warnings,omitempty"`
-	FailedAt      *time.Time `json:"failed_at,omitempty"`
+
+	// QueueErrors lists the fatal reasons the entry failed to download.
+	QueueErrors []string `json:"queue_errors,omitempty"`
+	// QueueWarnings lists non-fatal issues recorded while processing the entry.
+	QueueWarnings []string `json:"queue_warnings,omitempty"`
+	// FailedAt is when the entry was moved to the error/warning state.
+	FailedAt *time.Time `json:"failed_at,omitempty"`
 }
 
 // PosterSetDetail groups poster set details per media item.

--- a/backend/models/db_item.go
+++ b/backend/models/db_item.go
@@ -7,6 +7,15 @@ import "time"
 type DBSavedItem struct {
 	MediaItem  MediaItem           `json:"media_item"`
 	PosterSets []DBPosterSetDetail `json:"poster_sets,omitempty"`
+
+	// Queue-only, transient failure metadata. The download-queue processor
+	// populates these when it moves an entry to the error_/warning_ state so the
+	// UI can show why it failed. They are never persisted to the database
+	// (UpsertSavedItem reads explicit columns, not the marshalled struct) and are
+	// omitted from every other response via omitempty.
+	QueueErrors   []string   `json:"queue_errors,omitempty"`
+	QueueWarnings []string   `json:"queue_warnings,omitempty"`
+	FailedAt      *time.Time `json:"failed_at,omitempty"`
 }
 
 // PosterSetDetail groups poster set details per media item.

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -463,6 +463,7 @@ const DownloadQueuePage: React.FC = () => {
                             selectable={bulkMode}
                             selected={selectedKeys.has(key)}
                             onToggleSelected={(checked) => toggleSelected(key, checked)}
+                            showFailureDetails
                           />
                         );
                       })}
@@ -493,6 +494,7 @@ const DownloadQueuePage: React.FC = () => {
                         key={entry.media_item.tmdb_id}
                         entry={entry}
                         fetchQueueEntries={fetchQueueEntries}
+                        showFailureDetails
                       />
                     ))}
                   </ResponsiveGrid>

--- a/frontend/src/components/shared/download-queue-entry.tsx
+++ b/frontend/src/components/shared/download-queue-entry.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { formatExactDateTime } from "@/helper/format-date-last-updates";
+import { makePlural } from "@/helper/make_plural";
 import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
-import { Trash2 } from "lucide-react";
+import { AlertTriangle, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import React from "react";
@@ -14,8 +16,10 @@ import type { FormItemDisplay } from "@/components/shared/download-modal";
 import DownloadModal from "@/components/shared/download-modal";
 import { renderTypeBadges } from "@/components/shared/saved-sets-shared";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { H4 } from "@/components/ui/typography";
 
@@ -32,8 +36,30 @@ const DownloadQueueEntry: React.FC<{
   selectable?: boolean;
   selected?: boolean;
   onToggleSelected?: (checked: boolean) => void;
-}> = ({ entry, fetchQueueEntries, selectable = false, selected = false, onToggleSelected }) => {
+  // When true (Error/Warning sections), show why the entry failed via a popover.
+  showFailureDetails?: boolean;
+}> = ({
+  entry,
+  fetchQueueEntries,
+  selectable = false,
+  selected = false,
+  onToggleSelected,
+  showFailureDetails = false,
+}) => {
   const posterSets = Array.isArray(entry.poster_sets) ? entry.poster_sets : [];
+
+  // Failure reasons persisted by the backend when the entry was moved to the
+  // error/warning state. Only surfaced in the Error/Warning sections.
+  const queueErrors = Array.isArray(entry.queue_errors) ? entry.queue_errors : [];
+  const queueWarnings = Array.isArray(entry.queue_warnings) ? entry.queue_warnings : [];
+  const hasFailureDetails = showFailureDetails && (queueErrors.length > 0 || queueWarnings.length > 0);
+  const failureLabelParts: string[] = [];
+  if (queueErrors.length > 0) {
+    failureLabelParts.push(`${queueErrors.length} ${makePlural(queueErrors.length, "error")}`);
+  }
+  if (queueWarnings.length > 0) {
+    failureLabelParts.push(`${queueWarnings.length} ${makePlural(queueWarnings.length, "warning")}`);
+  }
   const baseSetInfo: BaseSetInfo = {
     id: posterSets[0]?.id || "",
     title: posterSets[0]?.title || "",
@@ -183,6 +209,69 @@ const DownloadQueueEntry: React.FC<{
               No Selected Types
             </Badge>
           </div>
+        )}
+
+        {/* Failure reasons (Error/Warning sections): why this entry failed. */}
+        {hasFailureDetails && (
+          <>
+            <Separator className="my-4" />
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={selectable ? (e) => e.stopPropagation() : undefined}
+                  onKeyDown={selectable ? (e) => e.stopPropagation() : undefined}
+                  className={cn(
+                    "w-full flex items-center justify-center gap-2 text-xs sm:text-sm cursor-pointer",
+                    queueErrors.length > 0
+                      ? "border-red-500 text-red-500 hover:text-red-600"
+                      : "border-yellow-500 text-yellow-600 hover:text-yellow-700"
+                  )}
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                  {`View ${failureLabelParts.join(", ")}`}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="center"
+                onClick={(e) => e.stopPropagation()}
+                className="max-h-80 w-80 overflow-y-auto text-sm"
+              >
+                {entry.failed_at && (
+                  <p className="mb-2 text-xs text-muted-foreground">Failed {formatExactDateTime(entry.failed_at)}</p>
+                )}
+                {queueErrors.length > 0 && (
+                  <div className={queueWarnings.length > 0 ? "mb-3" : undefined}>
+                    <p className="mb-1 font-semibold text-red-500">
+                      {queueErrors.length} {makePlural(queueErrors.length, "Error")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueErrors.map((err, i) => (
+                        <li key={`err-${i}`} className="break-words text-red-500/90">
+                          {err}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {queueWarnings.length > 0 && (
+                  <div>
+                    <p className="mb-1 font-semibold text-yellow-600">
+                      {queueWarnings.length} {makePlural(queueWarnings.length, "Warning")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueWarnings.map((warn, i) => (
+                        <li key={`warn-${i}`} className="break-words text-yellow-700/90">
+                          {warn}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/types/database/db-poster-set.ts
+++ b/frontend/src/types/database/db-poster-set.ts
@@ -9,6 +9,11 @@ export interface DBSavedItem {
   //library_title: string;
   media_item: MediaItem;
   poster_sets: DBPosterSetDetail[];
+  // Queue-only failure metadata, populated by the download-queue processor when an
+  // entry is moved to the error/warning state. Absent on all other DBSavedItem uses.
+  queue_errors?: string[];
+  queue_warnings?: string[];
+  failed_at?: string;
 }
 
 export interface DBPosterSetDetail extends PosterSet {


### PR DESCRIPTION
## What & why

Follow-up to #32. Error (and warning) queue entries carried **no record of why they failed** — the reasons only existed transiently in `LatestInfo`, notifications, and logs, and were discarded once the file was renamed to `error_`/`warning_`. This persists them so the UI can explain each failure.

> Stacked on #32 (`feat/download-queue-bulk-error-actions`). Base will retarget to `main` once #32 merges. Review #32 first.

## Backend

- **`models/db_item.go`** — add `QueueErrors []string`, `QueueWarnings []string`, `FailedAt *time.Time` to `DBSavedItem`, all `omitempty`. These are **queue-only/transient**: `UpsertSavedItem` decomposes the item into explicit SQL columns (it never marshals the struct), so they're never persisted to the DB, and `omitempty` keeps them out of every other `DBSavedItem` response (saved-sets, search, db).
- **`download/queue/process.go`** — `finalizeQueueFile` now enriches the parsed entry with the collected errors/warnings + a `failed_at` timestamp, writes it back **in place**, then **atomically renames** it to the `error_`/`warning_` prefix (a reader never sees a half-written file under the final name). Unparseable files (empty TMDB ID) keep their original bytes and are moved untouched, so no broken entry is fabricated. Clean successes are still removed.
- Swagger regenerated (additive only).

`retry.go` (the atomic rename from #32) is unchanged.

## Frontend

- **`types/database/db-poster-set.ts`** — add optional `queue_errors?`, `queue_warnings?`, `failed_at?`.
- **`download-queue-entry.tsx`** — new `showFailureDetails` prop renders a **popover** ("View N errors / warnings") listing each reason (errors red, warnings yellow) plus the failure time. `stopPropagation` so it doesn't toggle bulk selection.
- **`download-queue/page.tsx`** — pass `showFailureDetails` on the **error and warning** maps only. In-progress entries never show it, so a just-retried entry (which briefly reappears in-progress still carrying its prior reasons) doesn't display stale detail.

## Caveat

Pre-existing `error_`/`warning_` files written before this change carry no detail until they're reprocessed. No DB migration needed.

## Verification

- Backend: `go build ./...`, `go vet`, `gofmt` — all clean (CGO).
- Frontend: `typecheck`, `lint`, `format:check` (changed files), `build` — all pass.

https://claude.ai/code/session_01Dk4hohPtUdrv14vZJqegV9