### PR TITLE
feat(download): default popups to queue + add collection queue support

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -922,6 +922,243 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/download/queue/collection": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve the current items in the collection download queue, categorized by their status (in-progress, warning, error).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Get Collection Items",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.GetAllCollectionDownloadQueueItems_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Add a Collection and its selected images to the collection download queue. The entry is processed by the download worker and removed from the queue once completed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Add Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Add Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.AddCollectionToDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.AddCollectionToDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a specific Collection entry from the download queue. This can be used to cancel pending collection downloads or clean up errored entries.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Remove Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Remove Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/download/queue/collection/retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a failed (errored) Collection entry in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Retry Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Retry Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RetryCollectionInDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RetryCollectionInDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/download/queue/item": {
             "get": {
                 "security": [
@@ -4257,6 +4494,38 @@ const docTemplate = `{
                 }
             }
         },
+        "models.CollectionQueueItem": {
+            "type": "object",
+            "properties": {
+                "collection_item": {
+                    "$ref": "#/definitions/models.CollectionItem"
+                },
+                "failed_at": {
+                    "description": "FailedAt is when the entry was moved to its terminal error/warning state.",
+                    "type": "string"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ImageFile"
+                    }
+                },
+                "queue_errors": {
+                    "description": "QueueErrors lists the fatal reasons the entry failed to apply.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "models.CreatorSetsResponse": {
             "type": "object",
             "properties": {
@@ -5093,6 +5362,22 @@ const docTemplate = `{
                 }
             }
         },
+        "routes_download.AddCollectionToDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.AddCollectionToDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
         "routes_download.AddItemToDownloadQueue_Request": {
             "type": "object",
             "properties": {
@@ -5147,6 +5432,29 @@ const docTemplate = `{
                 }
             }
         },
+        "routes_download.GetAllCollectionDownloadQueueItems_Response": {
+            "type": "object",
+            "properties": {
+                "error_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                },
+                "in_progress_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                },
+                "warning_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                }
+            }
+        },
         "routes_download.GetAllDownloadQueueItems_Response": {
             "type": "object",
             "properties": {
@@ -5196,6 +5504,22 @@ const docTemplate = `{
                 }
             }
         },
+        "routes_download.RemoveCollectionFromDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.RemoveCollectionFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
         "routes_download.RemoveItemFromDownloadQueue_Request": {
             "type": "object",
             "properties": {
@@ -5205,6 +5529,22 @@ const docTemplate = `{
             }
         },
         "routes_download.RemoveItemFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes_download.RetryCollectionInDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.RetryCollectionInDownloadQueue_Response": {
             "type": "object",
             "properties": {
                 "result": {

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -914,6 +914,243 @@
                 }
             }
         },
+        "/api/download/queue/collection": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve the current items in the collection download queue, categorized by their status (in-progress, warning, error).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Get Collection Items",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.GetAllCollectionDownloadQueueItems_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Add a Collection and its selected images to the collection download queue. The entry is processed by the download worker and removed from the queue once completed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Add Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Add Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.AddCollectionToDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.AddCollectionToDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a specific Collection entry from the download queue. This can be used to cancel pending collection downloads or clean up errored entries.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Remove Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Remove Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/download/queue/collection/retry": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retry a failed (errored) Collection entry in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Download"
+                ],
+                "summary": "Download Queue - Retry Collection Item",
+                "parameters": [
+                    {
+                        "description": "Queue Retry Collection Item Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes_download.RetryCollectionInDownloadQueue_Request"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httpx.JSONResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/routes_download.RetryCollectionInDownloadQueue_Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized (only when Auth.Enabled=true)",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.UnauthorizedResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.JSONResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/download/queue/item": {
             "get": {
                 "security": [
@@ -4249,6 +4486,38 @@
                 }
             }
         },
+        "models.CollectionQueueItem": {
+            "type": "object",
+            "properties": {
+                "collection_item": {
+                    "$ref": "#/definitions/models.CollectionItem"
+                },
+                "failed_at": {
+                    "description": "FailedAt is when the entry was moved to its terminal error/warning state.",
+                    "type": "string"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ImageFile"
+                    }
+                },
+                "queue_errors": {
+                    "description": "QueueErrors lists the fatal reasons the entry failed to apply.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "queue_warnings": {
+                    "description": "QueueWarnings lists non-fatal issues recorded while processing the entry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "models.CreatorSetsResponse": {
             "type": "object",
             "properties": {
@@ -5085,6 +5354,22 @@
                 }
             }
         },
+        "routes_download.AddCollectionToDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.AddCollectionToDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
         "routes_download.AddItemToDownloadQueue_Request": {
             "type": "object",
             "properties": {
@@ -5139,6 +5424,29 @@
                 }
             }
         },
+        "routes_download.GetAllCollectionDownloadQueueItems_Response": {
+            "type": "object",
+            "properties": {
+                "error_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                },
+                "in_progress_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                },
+                "warning_entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CollectionQueueItem"
+                    }
+                }
+            }
+        },
         "routes_download.GetAllDownloadQueueItems_Response": {
             "type": "object",
             "properties": {
@@ -5188,6 +5496,22 @@
                 }
             }
         },
+        "routes_download.RemoveCollectionFromDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.RemoveCollectionFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
         "routes_download.RemoveItemFromDownloadQueue_Request": {
             "type": "object",
             "properties": {
@@ -5197,6 +5521,22 @@
             }
         },
         "routes_download.RemoveItemFromDownloadQueue_Response": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "routes_download.RetryCollectionInDownloadQueue_Request": {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/models.CollectionQueueItem"
+                }
+            }
+        },
+        "routes_download.RetryCollectionInDownloadQueue_Response": {
             "type": "object",
             "properties": {
                 "result": {

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -725,6 +725,30 @@ definitions:
       tmdb_id:
         type: string
     type: object
+  models.CollectionQueueItem:
+    properties:
+      collection_item:
+        $ref: '#/definitions/models.CollectionItem'
+      failed_at:
+        description: FailedAt is when the entry was moved to its terminal error/warning
+          state.
+        type: string
+      images:
+        items:
+          $ref: '#/definitions/models.ImageFile'
+        type: array
+      queue_errors:
+        description: QueueErrors lists the fatal reasons the entry failed to apply.
+        items:
+          type: string
+        type: array
+      queue_warnings:
+        description: QueueWarnings lists non-fatal issues recorded while processing
+          the entry.
+        items:
+          type: string
+        type: array
+    type: object
   models.CreatorSetsResponse:
     properties:
       boxsets:
@@ -1295,6 +1319,16 @@ definitions:
       result:
         type: string
     type: object
+  routes_download.AddCollectionToDownloadQueue_Request:
+    properties:
+      item:
+        $ref: '#/definitions/models.CollectionQueueItem'
+    type: object
+  routes_download.AddCollectionToDownloadQueue_Response:
+    properties:
+      result:
+        type: string
+    type: object
   routes_download.AddItemToDownloadQueue_Request:
     properties:
       item:
@@ -1329,6 +1363,21 @@ definitions:
       result:
         type: string
     type: object
+  routes_download.GetAllCollectionDownloadQueueItems_Response:
+    properties:
+      error_entries:
+        items:
+          $ref: '#/definitions/models.CollectionQueueItem'
+        type: array
+      in_progress_entries:
+        items:
+          $ref: '#/definitions/models.CollectionQueueItem'
+        type: array
+      warning_entries:
+        items:
+          $ref: '#/definitions/models.CollectionQueueItem'
+        type: array
+    type: object
   routes_download.GetAllDownloadQueueItems_Response:
     properties:
       error_entries:
@@ -1361,12 +1410,32 @@ definitions:
           type: string
         type: array
     type: object
+  routes_download.RemoveCollectionFromDownloadQueue_Request:
+    properties:
+      item:
+        $ref: '#/definitions/models.CollectionQueueItem'
+    type: object
+  routes_download.RemoveCollectionFromDownloadQueue_Response:
+    properties:
+      result:
+        type: string
+    type: object
   routes_download.RemoveItemFromDownloadQueue_Request:
     properties:
       item:
         $ref: '#/definitions/models.DBSavedItem'
     type: object
   routes_download.RemoveItemFromDownloadQueue_Response:
+    properties:
+      result:
+        type: string
+    type: object
+  routes_download.RetryCollectionInDownloadQueue_Request:
+    properties:
+      item:
+        $ref: '#/definitions/models.CollectionQueueItem'
+    type: object
+  routes_download.RetryCollectionInDownloadQueue_Response:
     properties:
       result:
         type: string
@@ -2204,6 +2273,151 @@ paths:
       security:
       - BearerAuth: []
       summary: Download Queue - Get Status
+      tags:
+      - Download
+  /api/download/queue/collection:
+    delete:
+      consumes:
+      - application/json
+      description: Remove a specific Collection entry from the download queue. This
+        can be used to cancel pending collection downloads or clean up errored entries.
+      parameters:
+      - description: Queue Remove Collection Item Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Request'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_download.RemoveCollectionFromDownloadQueue_Response'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Download Queue - Remove Collection Item
+      tags:
+      - Download
+    get:
+      consumes:
+      - application/json
+      description: Retrieve the current items in the collection download queue, categorized
+        by their status (in-progress, warning, error).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_download.GetAllCollectionDownloadQueueItems_Response'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Download Queue - Get Collection Items
+      tags:
+      - Download
+    post:
+      consumes:
+      - application/json
+      description: Add a Collection and its selected images to the collection download
+        queue. The entry is processed by the download worker and removed from the
+        queue once completed.
+      parameters:
+      - description: Queue Add Collection Item Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/routes_download.AddCollectionToDownloadQueue_Request'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_download.AddCollectionToDownloadQueue_Response'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Download Queue - Add Collection Item
+      tags:
+      - Download
+  /api/download/queue/collection/retry:
+    post:
+      consumes:
+      - application/json
+      description: Retry a failed (errored) Collection entry in the download queue.
+        The errored entry is atomically re-queued as an in-progress entry so the download
+        worker reprocesses it on its next run.
+      parameters:
+      - description: Queue Retry Collection Item Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/routes_download.RetryCollectionInDownloadQueue_Request'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httpx.JSONResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/routes_download.RetryCollectionInDownloadQueue_Response'
+              type: object
+        "401":
+          description: Unauthorized (only when Auth.Enabled=true)
+          schema:
+            $ref: '#/definitions/httpx.UnauthorizedResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httpx.JSONResponse'
+      security:
+      - BearerAuth: []
+      summary: Download Queue - Retry Collection Item
       tags:
       - Download
   /api/download/queue/item:

--- a/backend/download/queue/collection_add.go
+++ b/backend/download/queue/collection_add.go
@@ -1,0 +1,60 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/models"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+// AddCollectionToQueue writes a CollectionQueueItem to the collection download
+// queue as a JSON file named "LibraryTitle_RatingKey_timestamp.json".
+//
+// Collection entries are keyed by RatingKey (not TMDB ID like the media-item
+// queue) because a native media-server Collection is not guaranteed to have a
+// TMDB ID, whereas RatingKey is always present and unique per media server.
+func AddCollectionToQueue(ctx context.Context, item models.CollectionQueueItem) (Err logging.LogErrorInfo) {
+	_, logAction := logging.AddSubActionToContext(ctx,
+		fmt.Sprintf("Add Collection Queue Entry for '%s' [%s]",
+			item.CollectionItem.Title, item.CollectionItem.RatingKey),
+		logging.LevelDebug)
+	defer logAction.Complete()
+
+	Err = logging.LogErrorInfo{}
+
+	timestamp := time.Now().Unix()
+	fileName := path.Join(CollectionFolderPath, fmt.Sprintf("%s_%s_%d.json",
+		strings.ReplaceAll(item.CollectionItem.LibraryTitle, " ", `_`),
+		item.CollectionItem.RatingKey,
+		timestamp,
+	))
+
+	jsonData, marshalErr := json.Marshal(item)
+	if marshalErr != nil {
+		logAction.SetError("Failed to marshal Collection Queue Item to JSON",
+			"Ensure that the Collection Queue Item can be converted to JSON",
+			map[string]any{
+				"error": marshalErr.Error(),
+				"item":  item,
+			})
+		return *logAction.Error
+	}
+
+	if writeErr := os.WriteFile(fileName, jsonData, 0644); writeErr != nil {
+		logAction.SetError("Failed to write Collection Queue Item to download queue file",
+			"Ensure that the application has permission to write to the download queue folder",
+			map[string]any{
+				"error": writeErr.Error(),
+				"file":  fileName,
+			})
+		return *logAction.Error
+	}
+
+	logAction.AppendResult("file", fileName)
+	return Err
+}

--- a/backend/download/queue/collection_add.go
+++ b/backend/download/queue/collection_add.go
@@ -7,8 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
-	"strings"
+	"path/filepath"
 	"time"
 )
 
@@ -27,12 +26,26 @@ func AddCollectionToQueue(ctx context.Context, item models.CollectionQueueItem) 
 
 	Err = logging.LogErrorInfo{}
 
+	// Sanitize the attacker-controlled Collection fields into safe single path
+	// segments, then verify the resulting name is a local (non-traversing) path
+	// element before writing. Defense in depth: sanitizeQueueSegment already
+	// strips path separators, and filepath.IsLocal rejects anything that could
+	// still escape CollectionFolderPath (CodeQL go/path-injection).
 	timestamp := time.Now().Unix()
-	fileName := path.Join(CollectionFolderPath, fmt.Sprintf("%s_%s_%d.json",
-		strings.ReplaceAll(item.CollectionItem.LibraryTitle, " ", `_`),
-		item.CollectionItem.RatingKey,
+	baseName := fmt.Sprintf("%s_%s_%d.json",
+		sanitizeQueueSegment(item.CollectionItem.LibraryTitle),
+		sanitizeQueueSegment(item.CollectionItem.RatingKey),
 		timestamp,
-	))
+	)
+	if !filepath.IsLocal(baseName) {
+		logAction.SetError("Refusing to write collection queue entry with a non-local file name",
+			"The collection's library title or rating key produced an unsafe file name",
+			map[string]any{
+				"file": baseName,
+			})
+		return *logAction.Error
+	}
+	fileName := filepath.Join(CollectionFolderPath, baseName)
 
 	jsonData, marshalErr := json.Marshal(item)
 	if marshalErr != nil {

--- a/backend/download/queue/collection_get.go
+++ b/backend/download/queue/collection_get.go
@@ -1,0 +1,91 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/models"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+// GetCollectionQueueItems reads the collection download queue subfolder and
+// returns its entries categorized by status, using the same "error_"/"warning_"
+// filename-prefix scheme as the media-item queue.
+func GetCollectionQueueItems(ctx context.Context) (inProgressItems []models.CollectionQueueItem, warningItems []models.CollectionQueueItem, errorItems []models.CollectionQueueItem, Err logging.LogErrorInfo) {
+	ctx, logAction := logging.AddSubActionToContext(ctx, "Get Collection Download Queue Items", logging.LevelInfo)
+	defer logAction.Complete()
+
+	Err = logging.LogErrorInfo{}
+	inProgressItems = []models.CollectionQueueItem{}
+	warningItems = []models.CollectionQueueItem{}
+	errorItems = []models.CollectionQueueItem{}
+
+	files, readErr := os.ReadDir(CollectionFolderPath)
+	if readErr != nil {
+		logAction.SetError("Failed to read collection download queue folder",
+			"Ensure that the application has permission to read the download queue folder",
+			map[string]any{
+				"error": readErr.Error(),
+				"path":  CollectionFolderPath,
+			})
+		return inProgressItems, warningItems, errorItems, Err
+	}
+
+	if len(files) == 0 {
+		logAction.AppendResult("message", "No items found in the collection download queue")
+		return inProgressItems, warningItems, errorItems, Err
+	}
+
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
+			continue
+		}
+
+		_, subAction := logging.AddSubActionToContext(ctx, fmt.Sprintf("Processing file: %s", file.Name()), logging.LevelDebug)
+
+		filePath := path.Join(CollectionFolderPath, file.Name())
+		subAction.AppendResult("file_path", filePath)
+
+		content, readFileErr := os.ReadFile(filePath)
+		if readFileErr != nil {
+			subAction.SetError("Failed to read file",
+				"Ensure that the application has permission to read files from the download queue folder",
+				map[string]any{
+					"error": readFileErr.Error(),
+					"file":  filePath,
+				})
+			subAction.Complete()
+			continue
+		}
+
+		var item models.CollectionQueueItem
+		if decodeErr := json.Unmarshal(content, &item); decodeErr != nil {
+			subAction.SetError("Failed to decode JSON content",
+				"Ensure that the files in the collection download queue folder contain valid JSON with the correct structure",
+				map[string]any{
+					"error": decodeErr.Error(),
+					"file":  filePath,
+				})
+			subAction.Complete()
+			continue
+		}
+
+		if strings.HasPrefix(file.Name(), "error_") {
+			errorItems = append(errorItems, item)
+		} else if strings.HasPrefix(file.Name(), "warning_") {
+			warningItems = append(warningItems, item)
+		} else {
+			inProgressItems = append(inProgressItems, item)
+		}
+
+		subAction.Complete()
+	}
+
+	logAction.AppendResult("in_progress_count", len(inProgressItems))
+	logAction.AppendResult("warning_count", len(warningItems))
+	logAction.AppendResult("error_count", len(errorItems))
+	return inProgressItems, warningItems, errorItems, Err
+}

--- a/backend/download/queue/collection_process.go
+++ b/backend/download/queue/collection_process.go
@@ -116,25 +116,14 @@ func ProcessCollectionQueueItems() {
 		var queueItem models.CollectionQueueItem
 
 		finalizeAndNotify := func() {
-			// Update the shared queue status independently of notification delivery.
-			// SendNotification returns early (without touching LatestInfo) when
-			// notifications are disabled — the default — so without this the status
-			// banner would stay stuck on "Processing..." after a successful run.
-			status := LAST_STATUS_SUCCESS
-			if len(fileErrors) > 0 {
-				status = LAST_STATUS_ERROR
-			} else if len(fileWarnings) > 0 {
-				status = LAST_STATUS_WARNING
-			}
+			// Record the terminal status before notifying (see setLatestInfoTerminal):
+			// SendNotification skips the LatestInfo update when notifications are
+			// disabled, which would otherwise leave the banner stuck on "Processing...".
 			label := queueItem.CollectionItem.Title
 			if label == "" {
 				label = file.Name()
 			}
-			LatestInfo.Time = time.Now()
-			LatestInfo.Status = status
-			LatestInfo.Message = fmt.Sprintf("Collection: %s", label)
-			LatestInfo.Errors = fileErrors
-			LatestInfo.Warnings = fileWarnings
+			setLatestInfoTerminal(fmt.Sprintf("Collection: %s", label), fileErrors, fileWarnings)
 
 			sendCollectionNotification(FileIssues{Errors: fileErrors, Warnings: fileWarnings}, queueItem)
 			if err := finalizeCollectionQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {

--- a/backend/download/queue/collection_process.go
+++ b/backend/download/queue/collection_process.go
@@ -116,6 +116,26 @@ func ProcessCollectionQueueItems() {
 		var queueItem models.CollectionQueueItem
 
 		finalizeAndNotify := func() {
+			// Update the shared queue status independently of notification delivery.
+			// SendNotification returns early (without touching LatestInfo) when
+			// notifications are disabled — the default — so without this the status
+			// banner would stay stuck on "Processing..." after a successful run.
+			status := LAST_STATUS_SUCCESS
+			if len(fileErrors) > 0 {
+				status = LAST_STATUS_ERROR
+			} else if len(fileWarnings) > 0 {
+				status = LAST_STATUS_WARNING
+			}
+			label := queueItem.CollectionItem.Title
+			if label == "" {
+				label = file.Name()
+			}
+			LatestInfo.Time = time.Now()
+			LatestInfo.Status = status
+			LatestInfo.Message = fmt.Sprintf("Collection: %s", label)
+			LatestInfo.Errors = fileErrors
+			LatestInfo.Warnings = fileWarnings
+
 			sendCollectionNotification(FileIssues{Errors: fileErrors, Warnings: fileWarnings}, queueItem)
 			if err := finalizeCollectionQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 				subAction.AppendWarning(fmt.Sprintf("file_%s", file.Name()), "Failed to move or delete processed file")

--- a/backend/download/queue/collection_process.go
+++ b/backend/download/queue/collection_process.go
@@ -1,0 +1,213 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/mediaserver"
+	"aura/models"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+// finalizeCollectionQueueFile mirrors finalizeQueueFile for the collection
+// queue: on a clean success the file is removed, otherwise the entry is enriched
+// with the collected errors/warnings + a failed_at timestamp and atomically
+// renamed to the error_/warning_ prefix. Entries we could not parse (empty
+// RatingKey) keep their original bytes and are simply renamed.
+func finalizeCollectionQueueFile(filePath, fileName string, item models.CollectionQueueItem, fileErrors, fileWarnings []string) error {
+	hasErrors := len(fileErrors) > 0
+	hasWarnings := len(fileWarnings) > 0
+
+	if !hasErrors && !hasWarnings {
+		return os.Remove(filePath)
+	}
+
+	prefix := "warning_"
+	if hasErrors {
+		prefix = "error_"
+	}
+	destPath := path.Join(CollectionFolderPath, prefix+fileName)
+
+	// Only enrich entries we actually parsed. Unparseable files have no usable
+	// identity, so move the original bytes untouched.
+	if item.CollectionItem.RatingKey == "" {
+		return os.Rename(filePath, destPath)
+	}
+
+	item.QueueErrors = fileErrors
+	item.QueueWarnings = fileWarnings
+	now := time.Now()
+	item.FailedAt = &now
+
+	enriched, marshalErr := json.Marshal(item)
+	if marshalErr != nil {
+		return os.Rename(filePath, destPath)
+	}
+
+	// Write to a temp file first, then atomically rename it into the final
+	// error_/warning_ name so a concurrent reader never observes a half-written
+	// ".json" (see finalizeQueueFile for the full rationale).
+	tmpPath := filePath + ".tmp"
+	if writeErr := os.WriteFile(tmpPath, enriched, 0644); writeErr != nil {
+		return os.Rename(filePath, destPath)
+	}
+	if renameErr := os.Rename(tmpPath, destPath); renameErr != nil {
+		_ = os.Remove(tmpPath)
+		return os.Rename(filePath, destPath)
+	}
+	return os.Remove(filePath)
+}
+
+// ProcessCollectionQueueItems processes queued collection-image downloads. It is
+// the collection counterpart to ProcessQueueItems and is invoked on the same
+// cron tick. Unlike the media-item processor it does no media-server item
+// lookup, DB upsert, or label/tag handling: a Collection is applied directly by
+// its RatingKey via mediaserver.ApplyCollectionImage (which also writes the
+// Kometa asset when Kometa mode is enabled).
+func ProcessCollectionQueueItems() {
+	_, ld := logging.CreateLoggingContext(context.Background(), "Collection Download Queue Processing")
+	logAction := ld.AddAction("Processing Collection Download Queue", logging.LevelInfo)
+	defer logAction.Complete()
+
+	files, err := os.ReadDir(CollectionFolderPath)
+	if err != nil {
+		logging.LOGGER.Warn().Timestamp().Err(err).Msg("Failed to read collection download queue directory")
+		logAction.SetError("Failed to read collection download queue directory", "Ensure the directory exists and is accessible",
+			map[string]any{
+				"error":      err.Error(),
+				"folderPath": CollectionFolderPath,
+			})
+		return
+	}
+
+	if len(files) == 0 {
+		logAction.AppendResult("result", "collection queue is empty")
+		return
+	}
+
+	for _, file := range files {
+		if file.IsDir() || path.Ext(file.Name()) != ".json" {
+			continue
+		}
+
+		// Skip already-terminal entries.
+		if strings.HasPrefix(file.Name(), "error_") || strings.HasPrefix(file.Name(), "warning_") {
+			continue
+		}
+
+		ctx, ld := logging.CreateLoggingContext(context.Background(), "Collection Download Queue - Processing")
+		subAction := ld.AddAction(fmt.Sprintf("Processing file: %s", file.Name()), logging.LevelInfo)
+		ctx = logging.WithCurrentAction(ctx, subAction)
+
+		LatestInfo.Status = LAST_STATUS_PROCESSING
+		LatestInfo.Message = fmt.Sprintf("Processing collection file: %s", file.Name())
+		LatestInfo.Errors = []string{}
+		LatestInfo.Warnings = []string{}
+
+		fileErrors := []string{}
+		fileWarnings := []string{}
+
+		filePath := path.Join(CollectionFolderPath, file.Name())
+
+		var queueItem models.CollectionQueueItem
+
+		finalizeAndNotify := func() {
+			sendCollectionNotification(FileIssues{Errors: fileErrors, Warnings: fileWarnings}, queueItem)
+			if err := finalizeCollectionQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
+				subAction.AppendWarning(fmt.Sprintf("file_%s", file.Name()), "Failed to move or delete processed file")
+			}
+			ld.Log()
+		}
+
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			fileErrors = append(fileErrors, fmt.Sprintf("read file failed: %v", readErr))
+			finalizeAndNotify()
+			continue
+		}
+
+		if err := json.Unmarshal(data, &queueItem); err != nil {
+			fileErrors = append(fileErrors, fmt.Sprintf("parse json failed: %v", err))
+			finalizeAndNotify()
+			continue
+		}
+
+		if queueItem.CollectionItem.RatingKey == "" || queueItem.CollectionItem.Title == "" || queueItem.CollectionItem.LibraryTitle == "" {
+			fileErrors = append(fileErrors, "collection item missing required fields: ratingKey/title/libraryTitle")
+			finalizeAndNotify()
+			continue
+		}
+
+		if len(queueItem.Images) == 0 {
+			fileWarnings = append(fileWarnings, "no images to download")
+			finalizeAndNotify()
+			continue
+		}
+
+		LatestInfo.Message = fmt.Sprintf("Collection: %s", queueItem.CollectionItem.Title)
+
+		collectionItem := queueItem.CollectionItem
+		for _, image := range queueItem.Images {
+			if image.ID == "" || image.Type == "" {
+				fileWarnings = append(fileWarnings, "skipped image with missing id/type")
+				continue
+			}
+			if image.Type != "collection_poster" && image.Type != "collection_backdrop" {
+				fileWarnings = append(fileWarnings, fmt.Sprintf("image '%s' has unsupported type '%s'", image.ID, image.Type))
+				continue
+			}
+
+			Err := mediaserver.ApplyCollectionImage(ctx, &collectionItem, image)
+			if Err.Message != "" {
+				fileErrors = append(fileErrors, fmt.Sprintf("%s: %s", image.Type, Err.Message))
+			}
+		}
+
+		finalizeAndNotify()
+	}
+}
+
+// sendCollectionNotification reuses the shared download-queue notification (and
+// its LatestInfo status bookkeeping) by adapting a CollectionQueueItem into the
+// MediaItem/DBPosterSetDetail shape SendNotification expects. This deliberately
+// avoids adding a new notification template type (a 7-file change) — a queued
+// collection reuses the existing "Download Queue" template.
+func sendCollectionNotification(issues FileIssues, item models.CollectionQueueItem) {
+	mediaItem := models.MediaItem{
+		Title:        item.CollectionItem.Title,
+		LibraryTitle: item.CollectionItem.LibraryTitle,
+		Type:         "collection",
+		TMDB_ID:      item.CollectionItem.TMDB_ID,
+		RatingKey:    item.CollectionItem.RatingKey,
+	}
+
+	posterSet := models.DBPosterSetDetail{
+		PosterSet: models.PosterSet{
+			BaseSetInfo: models.BaseSetInfo{
+				ID:    item.CollectionItem.RatingKey,
+				Title: item.CollectionItem.Title,
+				Type:  "collection",
+			},
+			Images: item.Images,
+		},
+		SelectedTypes: models.SelectedTypes{
+			Poster:   collectionImagesInclude(item.Images, "collection_poster"),
+			Backdrop: collectionImagesInclude(item.Images, "collection_backdrop"),
+		},
+	}
+
+	SendNotification(issues, mediaItem, posterSet, "", "")
+}
+
+func collectionImagesInclude(images []models.ImageFile, imageType string) bool {
+	for _, image := range images {
+		if image.Type == imageType {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/download/queue/collection_remove.go
+++ b/backend/download/queue/collection_remove.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"strings"
 )
 
 // RemoveCollectionFromQueue deletes every queue file (in-progress, warning, or
@@ -35,11 +34,12 @@ func RemoveCollectionFromQueue(ctx context.Context, deleteItem models.Collection
 		return deleted, Err
 	}
 
-	// QuoteMeta escapes regex metacharacters in the library title / rating key so
-	// the pattern matches the literal filename AddCollectionToQueue wrote.
+	// Match on the same sanitized segments AddCollectionToQueue wrote, so a
+	// caller passing the raw Collection still targets the right files. QuoteMeta
+	// then escapes any regex metacharacters ("." / "-") left in those segments.
 	pattern := fmt.Sprintf(`^(error_|warning_)?%s_%s_\d+\.json$`,
-		regexp.QuoteMeta(strings.ReplaceAll(deleteItem.CollectionItem.LibraryTitle, " ", `_`)),
-		regexp.QuoteMeta(deleteItem.CollectionItem.RatingKey),
+		regexp.QuoteMeta(sanitizeQueueSegment(deleteItem.CollectionItem.LibraryTitle)),
+		regexp.QuoteMeta(sanitizeQueueSegment(deleteItem.CollectionItem.RatingKey)),
 	)
 	re := regexp.MustCompile(pattern)
 

--- a/backend/download/queue/collection_remove.go
+++ b/backend/download/queue/collection_remove.go
@@ -1,0 +1,68 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/models"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// RemoveCollectionFromQueue deletes every queue file (in-progress, warning, or
+// error) belonging to a collection entry. Entries are matched by LibraryTitle +
+// RatingKey, mirroring the filename AddCollectionToQueue wrote.
+func RemoveCollectionFromQueue(ctx context.Context, deleteItem models.CollectionQueueItem) (deleted int, Err logging.LogErrorInfo) {
+	_, logAction := logging.AddSubActionToContext(ctx,
+		fmt.Sprintf("Remove Collection Queue Entry for '%s' [%s]",
+			deleteItem.CollectionItem.Title, deleteItem.CollectionItem.RatingKey),
+		logging.LevelDebug)
+	defer logAction.Complete()
+
+	Err = logging.LogErrorInfo{}
+	deleted = 0
+
+	files, readErr := os.ReadDir(CollectionFolderPath)
+	if readErr != nil {
+		logAction.SetError("Failed to read collection download queue folder",
+			"Ensure that the application has permission to read the download queue folder",
+			map[string]any{
+				"error": readErr.Error(),
+				"path":  CollectionFolderPath,
+			})
+		return deleted, Err
+	}
+
+	// QuoteMeta escapes regex metacharacters in the library title / rating key so
+	// the pattern matches the literal filename AddCollectionToQueue wrote.
+	pattern := fmt.Sprintf(`^(error_|warning_)?%s_%s_\d+\.json$`,
+		regexp.QuoteMeta(strings.ReplaceAll(deleteItem.CollectionItem.LibraryTitle, " ", `_`)),
+		regexp.QuoteMeta(deleteItem.CollectionItem.RatingKey),
+	)
+	re := regexp.MustCompile(pattern)
+
+	for _, file := range files {
+		if file.IsDir() || !re.MatchString(file.Name()) {
+			continue
+		}
+
+		filePath := path.Join(CollectionFolderPath, file.Name())
+		if delErr := os.Remove(filePath); delErr != nil {
+			logAction.SetError("Failed to delete item from collection download queue",
+				"Ensure that the application has permission to delete files from the download queue folder",
+				map[string]any{
+					"error": delErr.Error(),
+					"file":  filePath,
+				})
+			return deleted, Err
+		}
+
+		logAction.AppendResult("deleted_file", filePath)
+		deleted++
+	}
+
+	logAction.AppendResult("total_deleted", deleted)
+	return deleted, Err
+}

--- a/backend/download/queue/collection_retry.go
+++ b/backend/download/queue/collection_retry.go
@@ -37,10 +37,11 @@ func RetryCollectionFromQueue(ctx context.Context, retryItem models.CollectionQu
 	}
 
 	// Match only errored files for this collection (LibraryTitle + RatingKey),
-	// using the same name construction as RemoveCollectionFromQueue.
+	// using the same sanitized name construction as AddCollectionToQueue /
+	// RemoveCollectionFromQueue.
 	pattern := fmt.Sprintf(`^error_%s_%s_\d+\.json$`,
-		regexp.QuoteMeta(strings.ReplaceAll(retryItem.CollectionItem.LibraryTitle, " ", `_`)),
-		regexp.QuoteMeta(retryItem.CollectionItem.RatingKey),
+		regexp.QuoteMeta(sanitizeQueueSegment(retryItem.CollectionItem.LibraryTitle)),
+		regexp.QuoteMeta(sanitizeQueueSegment(retryItem.CollectionItem.RatingKey)),
 	)
 	re := regexp.MustCompile(pattern)
 

--- a/backend/download/queue/collection_retry.go
+++ b/backend/download/queue/collection_retry.go
@@ -1,0 +1,72 @@
+package downloadqueue
+
+import (
+	"aura/logging"
+	"aura/models"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// RetryCollectionFromQueue re-queues an errored collection entry by stripping
+// the "error_" prefix from its file, turning it back into an in-progress entry
+// the processor picks up on its next run. The rename is atomic, so there is no
+// window where the entry is lost.
+func RetryCollectionFromQueue(ctx context.Context, retryItem models.CollectionQueueItem) (retried int, Err logging.LogErrorInfo) {
+	_, logAction := logging.AddSubActionToContext(ctx,
+		fmt.Sprintf("Retry Collection Queue Entry for '%s' [%s]",
+			retryItem.CollectionItem.Title, retryItem.CollectionItem.RatingKey),
+		logging.LevelDebug)
+	defer logAction.Complete()
+
+	Err = logging.LogErrorInfo{}
+	retried = 0
+
+	files, readErr := os.ReadDir(CollectionFolderPath)
+	if readErr != nil {
+		logAction.SetError("Failed to read collection download queue folder",
+			"Ensure that the application has permission to read the download queue folder",
+			map[string]any{
+				"error": readErr.Error(),
+				"path":  CollectionFolderPath,
+			})
+		return retried, Err
+	}
+
+	// Match only errored files for this collection (LibraryTitle + RatingKey),
+	// using the same name construction as RemoveCollectionFromQueue.
+	pattern := fmt.Sprintf(`^error_%s_%s_\d+\.json$`,
+		regexp.QuoteMeta(strings.ReplaceAll(retryItem.CollectionItem.LibraryTitle, " ", `_`)),
+		regexp.QuoteMeta(retryItem.CollectionItem.RatingKey),
+	)
+	re := regexp.MustCompile(pattern)
+
+	for _, file := range files {
+		if file.IsDir() || !re.MatchString(file.Name()) {
+			continue
+		}
+
+		oldPath := path.Join(CollectionFolderPath, file.Name())
+		newPath := path.Join(CollectionFolderPath, strings.TrimPrefix(file.Name(), "error_"))
+
+		if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
+			logAction.SetError("Failed to re-queue errored collection item",
+				"Ensure that the application has permission to modify files in the download queue folder",
+				map[string]any{
+					"error": renameErr.Error(),
+					"from":  oldPath,
+					"to":    newPath,
+				})
+			return retried, Err
+		}
+
+		logAction.AppendResult("requeued_file", newPath)
+		retried++
+	}
+
+	logAction.AppendResult("total_retried", retried)
+	return retried, Err
+}

--- a/backend/download/queue/collection_util.go
+++ b/backend/download/queue/collection_util.go
@@ -1,0 +1,31 @@
+package downloadqueue
+
+import (
+	"regexp"
+	"strings"
+)
+
+// unsafeQueueSegmentChars matches any run of characters that must not appear in a
+// queue filename segment. Anything outside this allow-list — most importantly the
+// path separators "/" and "\" — is collapsed to a single underscore.
+var unsafeQueueSegmentChars = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// sanitizeQueueSegment reduces a user-provided value (a Collection's library
+// title or rating key) to a single safe path segment for use in a collection
+// download-queue filename. The Collection is supplied verbatim in the request
+// body, so its fields are attacker-controlled; collapsing path separators and
+// trimming leading/trailing dots guarantees the value cannot traverse out of the
+// queue folder (CodeQL go/path-injection).
+//
+// AddCollectionToQueue, RemoveCollectionFromQueue, and RetryCollectionFromQueue
+// all run request values through this helper so the filename that is written and
+// the patterns that later match it stay in sync.
+func sanitizeQueueSegment(s string) string {
+	s = strings.ReplaceAll(s, " ", "_")
+	s = unsafeQueueSegmentChars.ReplaceAllString(s, "_")
+	s = strings.Trim(s, ".")
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/backend/download/queue/init.go
+++ b/backend/download/queue/init.go
@@ -30,6 +30,13 @@ var (
 	}{}
 
 	FolderPath string = ""
+
+	// CollectionFolderPath is a subfolder of FolderPath that holds queued
+	// collection-image entries (models.CollectionQueueItem). It is a child
+	// directory of FolderPath, so the media-item queue code — which does a
+	// non-recursive os.ReadDir and skips directories — never picks these files
+	// up, and vice versa.
+	CollectionFolderPath string = ""
 )
 
 type FileIssues struct {
@@ -45,9 +52,16 @@ func init() {
 	defer logAction.Complete()
 
 	FolderPath = path.Join(config.ConfigPath, "download-queue")
+	CollectionFolderPath = path.Join(FolderPath, "collections")
 
 	// Create the download queue folder if it doesn't exist
 	Err := utils.CreateFolderIfNotExists(ctx, FolderPath)
+	if Err.Message != "" {
+		os.Exit(1)
+	}
+
+	// Create the collection sub-folder if it doesn't exist
+	Err = utils.CreateFolderIfNotExists(ctx, CollectionFolderPath)
 	if Err.Message != "" {
 		os.Exit(1)
 	}

--- a/backend/download/queue/init.go
+++ b/backend/download/queue/init.go
@@ -44,6 +44,29 @@ type FileIssues struct {
 	Warnings []string
 }
 
+// setLatestInfoTerminal records the terminal status of a processed queue entry on
+// the shared LatestInfo, independent of notification delivery. SendNotification
+// only updates LatestInfo when notifications are enabled — which is off by
+// default — so without this the download queue status banner would stay stuck on
+// "Processing..." after a successful run. Notification-enabled paths may still
+// overwrite LatestInfo afterwards with their richer per-set message.
+func setLatestInfoTerminal(message string, fileErrors, fileWarnings []string) {
+	status := LAST_STATUS_SUCCESS
+	if len(fileErrors) > 0 {
+		status = LAST_STATUS_ERROR
+	} else if len(fileWarnings) > 0 {
+		status = LAST_STATUS_WARNING
+	}
+	if message == "" {
+		message = "Unknown"
+	}
+	LatestInfo.Time = time.Now()
+	LatestInfo.Status = status
+	LatestInfo.Message = message
+	LatestInfo.Errors = fileErrors
+	LatestInfo.Warnings = fileWarnings
+}
+
 func init() {
 	ctx, ld := logging.CreateLoggingContext(context.Background(), "Download Queue Init")
 	defer ld.Log()

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -137,6 +137,10 @@ func ProcessQueueItems() {
 			tmdbBackdrop string,
 		) {
 			issues := FileIssues{Errors: fileErrors, Warnings: fileWarnings}
+			// Record the terminal status before notifying: SendNotification skips
+			// the LatestInfo update when notifications are disabled (the default),
+			// which would otherwise leave the banner stuck on "Processing...".
+			setLatestInfoTerminal(mediaItem.Title, fileErrors, fileWarnings)
 			SendNotification(issues, mediaItem, set, tmdbPoster, tmdbBackdrop)
 
 			if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
@@ -349,6 +353,10 @@ func ProcessQueueItems() {
 			)
 			continue
 		}
+
+		// Success path: per-set SendNotification calls only touched LatestInfo when
+		// notifications are enabled, so record the terminal status here too.
+		setLatestInfoTerminal(queueItem.MediaItem.Title, fileErrors, fileWarnings)
 
 		if err := finalizeQueueFile(filePath, file.Name(), queueItem, fileErrors, fileWarnings); err != nil {
 			fileWarnings = append(fileWarnings, fmt.Sprintf("finalize file failed: %v", err))

--- a/backend/jobs/download_queue.go
+++ b/backend/jobs/download_queue.go
@@ -29,6 +29,7 @@ func StartDownloadQueueJob() error {
 			}
 		}()
 		downloadqueue.ProcessQueueItems()
+		downloadqueue.ProcessCollectionQueueItems()
 	})
 	if err != nil {
 		return err

--- a/backend/models/collection_queue.go
+++ b/backend/models/collection_queue.go
@@ -1,0 +1,30 @@
+package models
+
+import "time"
+
+// CollectionQueueItem is a queued request to download and apply one or more
+// MediUX images to a native media-server Collection (e.g. "James Bond
+// Collection"). Unlike DBSavedItem it is not tied to a movie/show MediaItem or a
+// MediUX poster set: a Collection only supports poster and backdrop artwork,
+// which is applied directly to the Collection's rating key via
+// mediaserver.ApplyCollectionImage.
+//
+// Collection queue entries live in their own download-queue/collections
+// subfolder so the media-item queue code (which unmarshals every file into a
+// DBSavedItem) never sees them.
+type CollectionQueueItem struct {
+	CollectionItem CollectionItem `json:"collection_item"`
+	Images         []ImageFile    `json:"images"`
+
+	// Queue-only, transient failure metadata. The collection queue processor
+	// populates these when it moves an entry to the error_/warning_ state so the
+	// UI can show why it failed. They are omitted from every other response via
+	// omitempty and are never persisted anywhere else.
+
+	// QueueErrors lists the fatal reasons the entry failed to apply.
+	QueueErrors []string `json:"queue_errors,omitempty"`
+	// QueueWarnings lists non-fatal issues recorded while processing the entry.
+	QueueWarnings []string `json:"queue_warnings,omitempty"`
+	// FailedAt is when the entry was moved to its terminal error/warning state.
+	FailedAt *time.Time `json:"failed_at,omitempty"`
+}

--- a/backend/routing/download/queue_collection_add.go
+++ b/backend/routing/download/queue_collection_add.go
@@ -1,0 +1,90 @@
+package routes_download
+
+import (
+	downloadqueue "aura/download/queue"
+	"aura/logging"
+	"aura/models"
+	"aura/utils/httpx"
+	"net/http"
+)
+
+type AddCollectionToDownloadQueue_Request struct {
+	Item models.CollectionQueueItem `json:"item"`
+}
+
+type AddCollectionToDownloadQueue_Response struct {
+	Result string `json:"result"`
+}
+
+// AddCollectionToDownloadQueue godoc
+// @Summary      Download Queue - Add Collection Item
+// @Description  Add a Collection and its selected images to the collection download queue. The entry is processed by the download worker and removed from the queue once completed.
+// @Tags         Download
+// @Accept       json
+// @Produce      json
+// @Param        req  body      AddCollectionToDownloadQueue_Request  true  "Queue Add Collection Item Request"
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200           {object}  httpx.JSONResponse{data=AddCollectionToDownloadQueue_Response}
+// @Failure      500           {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/download/queue/collection [post]
+func AddCollectionToDownloadQueue(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Download Queue - Add Collection Item", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+
+	var req AddCollectionToDownloadQueue_Request
+	var response AddCollectionToDownloadQueue_Response
+
+	Err := httpx.DecodeRequestBodyToJSON(ctx, r.Body, &req, "Queue Add Collection Item - Decode Request Body")
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	validateAction := logAction.AddSubAction("Validate Collection Queue Item", logging.LevelDebug)
+	if req.Item.CollectionItem.RatingKey == "" || req.Item.CollectionItem.Title == "" || req.Item.CollectionItem.LibraryTitle == "" {
+		validateAction.SetError("Invalid Collection Queue Item structure",
+			"Ensure that the request body contains a Collection Item with RatingKey, Title, and LibraryTitle",
+			map[string]any{
+				"item": req.Item,
+			})
+		validateAction.Complete()
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	if len(req.Item.Images) == 0 {
+		validateAction.SetError("Invalid Collection Queue Item structure - No Images",
+			"Ensure that the Collection Item contains at least one image to download",
+			map[string]any{
+				"item": req.Item,
+			})
+		validateAction.Complete()
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	for _, image := range req.Item.Images {
+		if image.ID == "" || image.Type == "" {
+			validateAction.SetError("Invalid Collection Queue Item structure - Image missing ID/Type",
+				"Ensure that each image in the Collection Item contains a valid ID and Type",
+				map[string]any{
+					"image": image,
+				})
+			validateAction.Complete()
+			httpx.SendResponse(w, ld, response)
+			return
+		}
+	}
+	validateAction.Complete()
+
+	addErr := downloadqueue.AddCollectionToQueue(ctx, req.Item)
+	if addErr.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	response.Result = "Collection item added to download queue"
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/download/queue_collection_get.go
+++ b/backend/routing/download/queue_collection_get.go
@@ -1,0 +1,44 @@
+package routes_download
+
+import (
+	downloadqueue "aura/download/queue"
+	"aura/logging"
+	"aura/models"
+	"aura/utils/httpx"
+	"net/http"
+)
+
+type GetAllCollectionDownloadQueueItems_Response struct {
+	InProgressEntries []models.CollectionQueueItem `json:"in_progress_entries"`
+	WarningEntries    []models.CollectionQueueItem `json:"warning_entries"`
+	ErrorEntries      []models.CollectionQueueItem `json:"error_entries"`
+}
+
+// GetAllCollectionDownloadQueueItems godoc
+// @Summary      Download Queue - Get Collection Items
+// @Description  Retrieve the current items in the collection download queue, categorized by their status (in-progress, warning, error).
+// @Tags         Download
+// @Accept       json
+// @Produce      json
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200  {object}  httpx.JSONResponse{data=GetAllCollectionDownloadQueueItems_Response}
+// @Failure      500           {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/download/queue/collection [get]
+func GetAllCollectionDownloadQueueItems(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Download Queue - Get Collection Items", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	var response GetAllCollectionDownloadQueueItems_Response
+
+	inProgressItems, warningItems, errorItems, Err := downloadqueue.GetCollectionQueueItems(ctx)
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	response.InProgressEntries = inProgressItems
+	response.WarningEntries = warningItems
+	response.ErrorEntries = errorItems
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/download/queue_collection_remove.go
+++ b/backend/routing/download/queue_collection_remove.go
@@ -1,0 +1,73 @@
+package routes_download
+
+import (
+	downloadqueue "aura/download/queue"
+	"aura/logging"
+	"aura/models"
+	"aura/utils/httpx"
+	"fmt"
+	"net/http"
+)
+
+type RemoveCollectionFromDownloadQueue_Request struct {
+	Item models.CollectionQueueItem `json:"item"`
+}
+
+type RemoveCollectionFromDownloadQueue_Response struct {
+	Result string `json:"result"`
+}
+
+// RemoveCollectionFromDownloadQueue godoc
+// @Summary      Download Queue - Remove Collection Item
+// @Description  Remove a specific Collection entry from the download queue. This can be used to cancel pending collection downloads or clean up errored entries.
+// @Tags         Download
+// @Accept       json
+// @Produce      json
+// @Param        req  body      RemoveCollectionFromDownloadQueue_Request  true  "Queue Remove Collection Item Request"
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200           {object}  httpx.JSONResponse{data=RemoveCollectionFromDownloadQueue_Response}
+// @Failure      500           {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/download/queue/collection [delete]
+func RemoveCollectionFromDownloadQueue(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Download Queue - Remove Collection Item", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	var req RemoveCollectionFromDownloadQueue_Request
+	var response RemoveCollectionFromDownloadQueue_Response
+
+	Err := httpx.DecodeRequestBodyToJSON(ctx, r.Body, &req, "Queue Remove Collection Item - Decode Request Body")
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	validateAction := logAction.AddSubAction("Validate Delete Collection Item", logging.LevelDebug)
+	if req.Item.CollectionItem.RatingKey == "" || req.Item.CollectionItem.LibraryTitle == "" {
+		validateAction.SetError("Invalid Delete Collection Item structure",
+			"Ensure that the request body contains a Collection Item with RatingKey and LibraryTitle",
+			map[string]any{
+				"item": req.Item,
+			})
+		validateAction.Complete()
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+	validateAction.Complete()
+
+	deleted, Err := downloadqueue.RemoveCollectionFromQueue(ctx, req.Item)
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	if deleted > 0 {
+		logAction.AppendResult("total_deleted", deleted)
+	} else {
+		logAction.AppendResult("total_deleted", 0)
+		logAction.AppendResult("message", "No matching items found in the collection download queue")
+	}
+
+	response.Result = fmt.Sprintf("Removed %d item(s) from the collection download queue", deleted)
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/download/queue_collection_retry.go
+++ b/backend/routing/download/queue_collection_retry.go
@@ -1,0 +1,73 @@
+package routes_download
+
+import (
+	downloadqueue "aura/download/queue"
+	"aura/logging"
+	"aura/models"
+	"aura/utils/httpx"
+	"fmt"
+	"net/http"
+)
+
+type RetryCollectionInDownloadQueue_Request struct {
+	Item models.CollectionQueueItem `json:"item"`
+}
+
+type RetryCollectionInDownloadQueue_Response struct {
+	Result string `json:"result"`
+}
+
+// RetryCollectionInDownloadQueue godoc
+// @Summary      Download Queue - Retry Collection Item
+// @Description  Retry a failed (errored) Collection entry in the download queue. The errored entry is atomically re-queued as an in-progress entry so the download worker reprocesses it on its next run.
+// @Tags         Download
+// @Accept       json
+// @Produce      json
+// @Param        req  body      RetryCollectionInDownloadQueue_Request  true  "Queue Retry Collection Item Request"
+// @Security 	 BearerAuth
+// @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
+// @Success      200           {object}  httpx.JSONResponse{data=RetryCollectionInDownloadQueue_Response}
+// @Failure      500           {object}  httpx.JSONResponse "Internal Server Error"
+// @Router       /api/download/queue/collection/retry [post]
+func RetryCollectionInDownloadQueue(w http.ResponseWriter, r *http.Request) {
+	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
+	logAction := ld.AddAction("Download Queue - Retry Collection Item", logging.LevelInfo)
+	ctx = logging.WithCurrentAction(ctx, logAction)
+	var req RetryCollectionInDownloadQueue_Request
+	var response RetryCollectionInDownloadQueue_Response
+
+	Err := httpx.DecodeRequestBodyToJSON(ctx, r.Body, &req, "Queue Retry Collection Item - Decode Request Body")
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	validateAction := logAction.AddSubAction("Validate Retry Collection Item", logging.LevelDebug)
+	if req.Item.CollectionItem.RatingKey == "" || req.Item.CollectionItem.LibraryTitle == "" {
+		validateAction.SetError("Invalid Retry Collection Item structure",
+			"Ensure that the request body contains a Collection Item with RatingKey and LibraryTitle",
+			map[string]any{
+				"item": req.Item,
+			})
+		validateAction.Complete()
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+	validateAction.Complete()
+
+	retried, Err := downloadqueue.RetryCollectionFromQueue(ctx, req.Item)
+	if Err.Message != "" {
+		httpx.SendResponse(w, ld, response)
+		return
+	}
+
+	if retried > 0 {
+		logAction.AppendResult("total_retried", retried)
+	} else {
+		logAction.AppendResult("total_retried", 0)
+		logAction.AppendResult("message", "No matching errored items found in the collection download queue")
+	}
+
+	response.Result = fmt.Sprintf("Re-queued %d errored collection item(s) for download", retried)
+	httpx.SendResponse(w, ld, response)
+}

--- a/backend/routing/routes.go
+++ b/backend/routing/routes.go
@@ -105,6 +105,12 @@ func AddRoutes(r *chi.Mux) {
 					r.Post("/item", routes_download.AddItemToDownloadQueue)
 					r.Post("/item/retry", routes_download.RetryItemInDownloadQueue)
 					r.Delete("/item", routes_download.RemoveItemFromDownloadQueue)
+
+					// Collection Download Queue Routes
+					r.Get("/collection", routes_download.GetAllCollectionDownloadQueueItems)
+					r.Post("/collection", routes_download.AddCollectionToDownloadQueue)
+					r.Post("/collection/retry", routes_download.RetryCollectionInDownloadQueue)
+					r.Delete("/collection", routes_download.RemoveCollectionFromDownloadQueue)
 				})
 			})
 

--- a/frontend/src/app/collection-item/collection-download-modal.tsx
+++ b/frontend/src/app/collection-item/collection-download-modal.tsx
@@ -2,9 +2,11 @@
 
 import type { CollectionItem } from "@/app/collections/page";
 import { formatDownloadSize } from "@/helper/format-download-size";
+import { AddCollectionToQueue } from "@/services/downloads/collection-queue-add";
 import { DownloadImageFileForCollectionItem } from "@/services/downloads/download-collection-image";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Check, Download, LoaderIcon, User, X } from "lucide-react";
+import { Check, Download, ListEnd, LoaderIcon, User, X } from "lucide-react";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -36,6 +38,7 @@ import { cn } from "@/lib/cn";
 import { log } from "@/lib/logger";
 import { useUserPreferencesStore } from "@/lib/stores/global-user-preferences";
 
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
 import type { CollectionItemImageFile, CollectionItemSetRef } from "@/types/media-and-posters/sets";
 import {
   DOWNLOAD_COLLECTION_IMAGE_TYPE_OPTIONS,
@@ -70,6 +73,11 @@ const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ ite
     poster_error?: string;
     backdrop_error?: string;
   }>({});
+
+  // State - Add to Queue. Defaults to true to match the media-item download
+  // modal: queueing runs the download in the background instead of blocking the
+  // dialog until every image is applied.
+  const [addToQueueOnly, setAddToQueueOnly] = useState(true);
 
   // User Preferences
   const { downloadDefaults } = useUserPreferencesStore();
@@ -223,6 +231,27 @@ const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ ite
     setIsMounted(true);
 
     try {
+      // Add to Queue: enqueue the selected images and let the background download
+      // worker apply them, instead of downloading synchronously in this dialog.
+      if (addToQueueOnly) {
+        const images: CollectionItemImageFile[] = [];
+        if (data.poster && posterImage) images.push(posterImage);
+        if (data.backdrop && backdropImage) images.push(backdropImage);
+
+        const queueItem: CollectionQueueItem = {
+          collection_item: item,
+          images,
+        };
+
+        const response = await AddCollectionToQueue(queueItem);
+        if (response.status === "error") {
+          toast.error(`Error adding to queue: ${response.error?.message || "Unknown error occurred."}`);
+        } else {
+          toast.success(response.data?.result || "Added to download queue.");
+        }
+        return;
+      }
+
       // Reset errors and progress
       setErrors({});
       setProgress({});
@@ -352,6 +381,17 @@ const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ ite
                 <>
                   <div className="text-sm text-muted-foreground">Number of Images: {numberOfImagesSelected}</div>
                   <div className="text-sm text-muted-foreground">Total Download Size: ~{sizeOfImagesSelected}</div>
+
+                  <FormItem className="flex items-center space-x-2 mt-2">
+                    <FormControl>
+                      <Checkbox
+                        checked={addToQueueOnly}
+                        onCheckedChange={(checked) => setAddToQueueOnly(checked === true)}
+                        className="h-5 w-5 sm:h-4 sm:w-4 cursor-pointer"
+                      />
+                    </FormControl>
+                    <FormLabel className="text-md font-normal cursor-pointer">Add to Queue</FormLabel>
+                  </FormItem>
                 </>
               ) : (
                 <div className="text-sm text-destructive">
@@ -413,7 +453,14 @@ const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ ite
                   </Button>
                 </DialogClose>
                 <Button type="submit" disabled={!form.watch("poster") && !form.watch("backdrop")}>
-                  {downloadButtonText}
+                  {addToQueueOnly && numberOfImagesSelected > 0 ? (
+                    <>
+                      <ListEnd className="mr-1 h-4 w-4" />
+                      Add to Queue
+                    </>
+                  ) : (
+                    downloadButtonText
+                  )}
                 </Button>
               </DialogFooter>
             </form>

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -3,6 +3,7 @@
 import { formatExactDateTime } from "@/helper/format-date-last-updates";
 import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import { GetAllCollectionQueueItems } from "@/services/downloads/collection-queue-get";
 import { GetAllDownloadQueueItems } from "@/services/downloads/queue-get";
 import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
 import { RetryItemInQueue } from "@/services/downloads/queue-retry";
@@ -13,6 +14,7 @@ import { toast } from "sonner";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
+import CollectionQueueEntry from "@/components/shared/collection-queue-entry";
 import { ConfirmDestructiveDialogActionButton } from "@/components/shared/dialog-destructive-action";
 import DownloadQueueEntry from "@/components/shared/download-queue-entry";
 import { ErrorMessage } from "@/components/shared/error-message";
@@ -27,6 +29,7 @@ import { H2, H3 } from "@/components/ui/typography";
 import { cn } from "@/lib/cn";
 
 import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
 import type { DBSavedItem } from "@/types/database/db-poster-set";
 
 // Stable key for a queue entry, matching the backend's file identity (LibraryTitle + TMDB ID).
@@ -40,6 +43,11 @@ const DownloadQueuePage: React.FC = () => {
   const [inProgressEntries, setInProgressEntries] = useState<DBSavedItem[]>([]);
   const [errorEntries, setErrorEntries] = useState<DBSavedItem[]>([]);
   const [warningEntries, setWarningEntries] = useState<DBSavedItem[]>([]);
+
+  // States - Collection Queue Entries
+  const [collectionInProgress, setCollectionInProgress] = useState<CollectionQueueItem[]>([]);
+  const [collectionErrors, setCollectionErrors] = useState<CollectionQueueItem[]>([]);
+  const [collectionWarnings, setCollectionWarnings] = useState<CollectionQueueItem[]>([]);
 
   // States - Queue Status
   const [queueStatus, setQueueStatus] = useState<GetDownloadQueueStatus_Response>({
@@ -68,7 +76,10 @@ const DownloadQueuePage: React.FC = () => {
     try {
       setLoading(true);
 
-      const response = await GetAllDownloadQueueItems();
+      const [response, collectionResponse] = await Promise.all([
+        GetAllDownloadQueueItems(),
+        GetAllCollectionQueueItems(),
+      ]);
 
       if (response.status === "error") {
         setError(response);
@@ -78,6 +89,14 @@ const DownloadQueuePage: React.FC = () => {
       setInProgressEntries(response.data?.in_progress_entries || []);
       setErrorEntries(response.data?.error_entries || []);
       setWarningEntries(response.data?.warning_entries || []);
+
+      // The collection queue is a secondary concern: if it fails to load, still
+      // show the media-item queue rather than erroring the whole page.
+      if (collectionResponse.status !== "error") {
+        setCollectionInProgress(collectionResponse.data?.in_progress_entries || []);
+        setCollectionErrors(collectionResponse.data?.error_entries || []);
+        setCollectionWarnings(collectionResponse.data?.warning_entries || []);
+      }
       setError(null);
     } catch (error) {
       setError(ReturnErrorMessage<unknown>(error));
@@ -263,10 +282,16 @@ const DownloadQueuePage: React.FC = () => {
     );
   }
 
+  const hasCollectionEntries =
+    collectionInProgress.length > 0 || collectionErrors.length > 0 || collectionWarnings.length > 0;
+
   const defaultAccordionValues = [
     inProgressEntries.length > 0 ? "in_progress" : null,
     errorEntries.length > 0 ? "error_entries" : null,
     warningEntries.length > 0 ? "warning_entries" : null,
+    collectionInProgress.length > 0 ? "collection_in_progress" : null,
+    collectionErrors.length > 0 ? "collection_error_entries" : null,
+    collectionWarnings.length > 0 ? "collection_warning_entries" : null,
   ].filter(Boolean) as string[];
 
   // Derived bulk-selection state for the Error section.
@@ -333,9 +358,10 @@ const DownloadQueuePage: React.FC = () => {
         )}
       </pre>
 
-      {inProgressEntries.length === 0 && errorEntries.length === 0 && warningEntries.length === 0 && (
-        <p className="text-gray-500">No download queue entries found</p>
-      )}
+      {inProgressEntries.length === 0 &&
+        errorEntries.length === 0 &&
+        warningEntries.length === 0 &&
+        !hasCollectionEntries && <p className="text-gray-500">No download queue entries found</p>}
 
       <div className="w-full">
         <Accordion type="multiple" className="mb-4" defaultValue={defaultAccordionValues}>
@@ -499,6 +525,81 @@ const DownloadQueuePage: React.FC = () => {
                     ))}
                   </ResponsiveGrid>
                 )}
+              </AccordionContent>
+            </AccordionItem>
+          )}
+
+          {collectionInProgress.length > 0 && (
+            <AccordionItem value="collection_in_progress">
+              <AccordionTrigger
+                className={cn(
+                  "cursor-pointer",
+                  "hover:underline-none focus:underline-none underline-none hover:no-underline focus:no-underline justify-center"
+                )}
+              >
+                <H3>Collection Entries - In Progress</H3>
+              </AccordionTrigger>
+              <AccordionContent>
+                <ResponsiveGrid size="regular">
+                  {collectionInProgress.map((entry, index) => (
+                    <CollectionQueueEntry
+                      key={`${entry.collection_item.rating_key}-${index}`}
+                      entry={entry}
+                      fetchEntries={fetchQueueEntries}
+                    />
+                  ))}
+                </ResponsiveGrid>
+              </AccordionContent>
+            </AccordionItem>
+          )}
+
+          {collectionErrors.length > 0 && (
+            <AccordionItem value="collection_error_entries">
+              <AccordionTrigger
+                className={cn(
+                  "cursor-pointer",
+                  "hover:underline-none focus:underline-none underline-none hover:no-underline focus:no-underline justify-center"
+                )}
+              >
+                <H3>Collection Entries - Errors</H3>
+              </AccordionTrigger>
+              <AccordionContent>
+                <ResponsiveGrid size="regular">
+                  {collectionErrors.map((entry, index) => (
+                    <CollectionQueueEntry
+                      key={`${entry.collection_item.rating_key}-${index}`}
+                      entry={entry}
+                      fetchEntries={fetchQueueEntries}
+                      showFailureDetails
+                      showRetry
+                    />
+                  ))}
+                </ResponsiveGrid>
+              </AccordionContent>
+            </AccordionItem>
+          )}
+
+          {collectionWarnings.length > 0 && (
+            <AccordionItem value="collection_warning_entries">
+              <AccordionTrigger
+                className={cn(
+                  "cursor-pointer",
+                  "hover:underline-none focus:underline-none underline-none hover:no-underline focus:no-underline justify-center"
+                )}
+              >
+                <H3>Collection Entries - Warnings</H3>
+              </AccordionTrigger>
+              <AccordionContent>
+                <ResponsiveGrid size="larger">
+                  {collectionWarnings.map((entry, index) => (
+                    <CollectionQueueEntry
+                      key={`${entry.collection_item.rating_key}-${index}`}
+                      entry={entry}
+                      fetchEntries={fetchQueueEntries}
+                      showFailureDetails
+                    />
+                  ))}
+                </ResponsiveGrid>
               </AccordionContent>
             </AccordionItem>
           )}

--- a/frontend/src/components/shared/collection-queue-entry.tsx
+++ b/frontend/src/components/shared/collection-queue-entry.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { formatExactDateTime } from "@/helper/format-date-last-updates";
+import { makePlural } from "@/helper/make_plural";
+import { RemoveCollectionFromQueue } from "@/services/downloads/collection-queue-remove";
+import { RetryCollectionInQueue } from "@/services/downloads/collection-queue-retry";
+import { AlertTriangle, RefreshCcw, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import React from "react";
+
+import { AssetImage } from "@/components/shared/asset-image";
+import { ConfirmDestructiveDialogActionButton } from "@/components/shared/dialog-destructive-action";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { H4 } from "@/components/ui/typography";
+
+import { cn } from "@/lib/cn";
+
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
+
+const CollectionQueueEntry: React.FC<{
+  entry: CollectionQueueItem;
+  fetchEntries?: () => Promise<void>;
+  // When true (Error/Warning sections), show why the entry failed via a popover.
+  showFailureDetails?: boolean;
+  // When true (Error section), show a Retry button to re-queue the entry.
+  showRetry?: boolean;
+}> = ({ entry, fetchEntries, showFailureDetails = false, showRetry = false }) => {
+  const images = Array.isArray(entry.images) ? entry.images : [];
+  const hasPoster = images.some((img) => img.type === "collection_poster");
+  const hasBackdrop = images.some((img) => img.type === "collection_backdrop");
+
+  // Prefer the poster for the preview thumbnail, falling back to the backdrop.
+  const previewImage = images.find((img) => img.type === "collection_poster") ?? images[0];
+
+  const queueErrors = Array.isArray(entry.queue_errors) ? entry.queue_errors : [];
+  const queueWarnings = Array.isArray(entry.queue_warnings) ? entry.queue_warnings : [];
+  const hasFailureDetails = showFailureDetails && (queueErrors.length > 0 || queueWarnings.length > 0);
+  const failureLabelParts: string[] = [];
+  if (queueErrors.length > 0) {
+    failureLabelParts.push(`${queueErrors.length} ${makePlural(queueErrors.length, "error")}`);
+  }
+  if (queueWarnings.length > 0) {
+    failureLabelParts.push(`${queueWarnings.length} ${makePlural(queueWarnings.length, "warning")}`);
+  }
+
+  const refresh = async () => {
+    if (fetchEntries) await fetchEntries();
+  };
+
+  const onDeleteConfirm = async () => {
+    try {
+      const response = await RemoveCollectionFromQueue(entry);
+      if (response.status === "error") {
+        toast.error(`Error deleting from queue: ${response.error?.message || "Unknown error occurred."}`);
+      } else {
+        toast.success(response.data?.result || "Successfully deleted from queue.");
+      }
+    } catch (error) {
+      toast.error(`Error deleting from queue: ${error instanceof Error ? error.message : "Unknown error occurred."}`);
+    }
+    await refresh();
+  };
+
+  const onRetry = async () => {
+    try {
+      const response = await RetryCollectionInQueue(entry);
+      if (response.status === "error") {
+        toast.error(`Error retrying: ${response.error?.message || "Unknown error occurred."}`);
+      } else {
+        toast.success(response.data?.result || "Re-queued for download.");
+      }
+    } catch (error) {
+      toast.error(`Error retrying: ${error instanceof Error ? error.message : "Unknown error occurred."}`);
+    }
+    await refresh();
+  };
+
+  return (
+    <Card className="relative w-full max-w-md mx-auto transition-shadow">
+      <CardHeader>
+        {/* Top Left: Delete */}
+        <div className="absolute top-2 left-2">
+          <ConfirmDestructiveDialogActionButton
+            variant="outline"
+            className="text-destructive border-1 shadow-none hover:text-red-500 cursor-pointer"
+            confirmText="Delete Entry"
+            title="Delete Queue Entry?"
+            description="Are you sure you want to delete this collection entry from the download queue? This action cannot be undone."
+            onConfirm={onDeleteConfirm}
+          >
+            <Trash2 className="w-5 h-5" />
+          </ConfirmDestructiveDialogActionButton>
+        </div>
+        {/* Top Right: Retry (error section) */}
+        {showRetry && (
+          <div className="absolute top-2 right-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onRetry}
+              aria-label="Retry collection download"
+              className="border-1 shadow-none cursor-pointer hover:text-primary"
+            >
+              <RefreshCcw className="w-5 h-5" />
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+
+      {/* Middle: Image */}
+      {previewImage && (
+        <div className="flex justify-center">
+          <AssetImage
+            image={previewImage}
+            imageType="mediux"
+            aspect={previewImage.type === "collection_backdrop" ? "backdrop" : "poster"}
+            className="w-[80%] h-auto transition-transform hover:scale-105"
+          />
+        </div>
+      )}
+
+      {/* Content */}
+      <CardContent className="p-0 ml-2 mr-2">
+        <H4 className="text-primary">{entry.collection_item.title}</H4>
+
+        <span className="text-xs sm:text-sm text-muted-foreground inline-block">
+          {entry.collection_item.library_title}
+        </span>
+
+        <Separator className="my-4" />
+
+        {hasPoster || hasBackdrop ? (
+          <div className="flex flex-wrap gap-2">
+            {hasPoster && (
+              <Badge variant="outline" className="text-sm">
+                Poster
+              </Badge>
+            )}
+            {hasBackdrop && (
+              <Badge variant="outline" className="text-sm">
+                Backdrop
+              </Badge>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="text-sm bg-red-500">
+              No Selected Types
+            </Badge>
+          </div>
+        )}
+
+        {/* Failure reasons (Error/Warning sections). */}
+        {hasFailureDetails && (
+          <>
+            <Separator className="my-4" />
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={cn(
+                    "w-full flex items-center justify-center gap-2 text-xs sm:text-sm cursor-pointer",
+                    queueErrors.length > 0
+                      ? "border-red-500 text-red-500 hover:text-red-600"
+                      : "border-yellow-500 text-yellow-600 hover:text-yellow-700"
+                  )}
+                >
+                  <AlertTriangle className="h-4 w-4" />
+                  {`View ${failureLabelParts.join(", ")}`}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="center" className="max-h-80 w-80 overflow-y-auto text-sm">
+                {entry.failed_at && (
+                  <p className="mb-2 text-xs text-muted-foreground">Failed {formatExactDateTime(entry.failed_at)}</p>
+                )}
+                {queueErrors.length > 0 && (
+                  <div className={queueWarnings.length > 0 ? "mb-3" : undefined}>
+                    <p className="mb-1 font-semibold text-red-500">
+                      {queueErrors.length} {makePlural(queueErrors.length, "Error")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueErrors.map((err, i) => (
+                        <li key={`err-${i}`} className="break-words text-red-500/90">
+                          {err}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {queueWarnings.length > 0 && (
+                  <div>
+                    <p className="mb-1 font-semibold text-yellow-600">
+                      {queueWarnings.length} {makePlural(queueWarnings.length, "Warning")}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {queueWarnings.map((warn, i) => (
+                        <li key={`warn-${i}`} className="break-words text-yellow-700/90">
+                          {warn}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CollectionQueueEntry;

--- a/frontend/src/components/shared/download-modal.tsx
+++ b/frontend/src/components/shared/download-modal.tsx
@@ -286,8 +286,9 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
   // State - Duplicate Media Items
   const [duplicates, setDuplicates] = useState<DuplicateMap>({});
 
-  // State - Add to Queue Only
-  const [addToQueueOnly, setAddToQueueOnly] = useState(false);
+  // State - Add to Queue Only. Defaults to true so the download popups queue by
+  // default instead of downloading synchronously.
+  const [addToQueueOnly, setAddToQueueOnly] = useState(true);
 
   // State - Add New Collection Items
   const [autoAddNewCollectionItems, setAutoAddNewCollectionItems] = useState(false);

--- a/frontend/src/services/downloads/collection-queue-add.ts
+++ b/frontend/src/services/downloads/collection-queue-add.ts
@@ -20,7 +20,9 @@ export const AddCollectionToQueue = async (
     "INFO",
     "API - Download Queue",
     "Add Collection to Queue",
-    `Adding collection '${item.collection_item.title}' [${item.collection_item.rating_key}] to the download queue`
+    `Adding collection '${item.collection_item?.title ?? "(unknown)"}' [${
+      item.collection_item?.rating_key ?? "(unknown)"
+    }] to the download queue`
   );
   try {
     const req: AddCollectionToQueue_Request = { item };
@@ -44,7 +46,7 @@ export const AddCollectionToQueue = async (
       "ERROR",
       "API - Download Queue",
       "Add Collection to Queue",
-      `Failed to add collection '${item.collection_item.title}' to the download queue: ${
+      `Failed to add collection '${item.collection_item?.title ?? "(unknown)"}' to the download queue: ${
         error instanceof Error ? error.message : "Unknown error"
       }`,
       error

--- a/frontend/src/services/downloads/collection-queue-add.ts
+++ b/frontend/src/services/downloads/collection-queue-add.ts
@@ -1,0 +1,54 @@
+import apiClient from "@/services/api-client";
+import { ReturnErrorMessage } from "@/services/api-error-return";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
+
+export interface AddCollectionToQueue_Request {
+  item: CollectionQueueItem;
+}
+export interface AddCollectionToQueue_Response {
+  result: string;
+}
+
+export const AddCollectionToQueue = async (
+  item: CollectionQueueItem
+): Promise<APIResponse<AddCollectionToQueue_Response>> => {
+  log(
+    "INFO",
+    "API - Download Queue",
+    "Add Collection to Queue",
+    `Adding collection '${item.collection_item.title}' [${item.collection_item.rating_key}] to the download queue`
+  );
+  try {
+    const req: AddCollectionToQueue_Request = { item };
+    const response = await apiClient.post<APIResponse<AddCollectionToQueue_Response>>(
+      `/download/queue/collection`,
+      req
+    );
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error while adding collection to download queue");
+    }
+    log(
+      "INFO",
+      "API - Download Queue",
+      "Add Collection to Queue",
+      `Added collection '${item.collection_item.title}' to the download queue`,
+      response.data
+    );
+    return response.data;
+  } catch (error) {
+    log(
+      "ERROR",
+      "API - Download Queue",
+      "Add Collection to Queue",
+      `Failed to add collection '${item.collection_item.title}' to the download queue: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+      error
+    );
+    return ReturnErrorMessage<AddCollectionToQueue_Response>(error);
+  }
+};

--- a/frontend/src/services/downloads/collection-queue-get.ts
+++ b/frontend/src/services/downloads/collection-queue-get.ts
@@ -1,0 +1,28 @@
+import apiClient from "@/services/api-client";
+import { ReturnErrorMessage } from "@/services/api-error-return";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
+
+export interface GetAllCollectionQueueItems_Response {
+  in_progress_entries: CollectionQueueItem[];
+  warning_entries: CollectionQueueItem[];
+  error_entries: CollectionQueueItem[];
+}
+
+export const GetAllCollectionQueueItems = async (): Promise<APIResponse<GetAllCollectionQueueItems_Response>> => {
+  try {
+    log("INFO", "API - Download Queue", "Fetch", "Fetching collection download queue entries");
+    const response =
+      await apiClient.get<APIResponse<GetAllCollectionQueueItems_Response>>(`/download/queue/collection`);
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error fetching collection download queue entries");
+    }
+    return response.data;
+  } catch (error) {
+    log("ERROR", "API - Download Queue", "Fetch", "Error fetching collection download queue entries", { error });
+    return ReturnErrorMessage<GetAllCollectionQueueItems_Response>(error);
+  }
+};

--- a/frontend/src/services/downloads/collection-queue-remove.ts
+++ b/frontend/src/services/downloads/collection-queue-remove.ts
@@ -1,0 +1,47 @@
+import apiClient from "@/services/api-client";
+import { ReturnErrorMessage } from "@/services/api-error-return";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
+
+export interface RemoveCollectionFromQueue_Request {
+  item: CollectionQueueItem;
+}
+export interface RemoveCollectionFromQueue_Response {
+  result: string;
+}
+
+export const RemoveCollectionFromQueue = async (
+  item: CollectionQueueItem
+): Promise<APIResponse<RemoveCollectionFromQueue_Response>> => {
+  log(
+    "INFO",
+    "API - Download Queue",
+    "Delete Collection from Queue",
+    `Deleting collection '${item.collection_item?.title ?? "(unknown)"}' [${
+      item.collection_item?.rating_key ?? "(unknown)"
+    }] from the download queue`
+  );
+  try {
+    const req: RemoveCollectionFromQueue_Request = { item };
+    const response = await apiClient.delete<APIResponse<RemoveCollectionFromQueue_Response>>(
+      `/download/queue/collection`,
+      { data: req }
+    );
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error while deleting collection from download queue");
+    }
+    return response.data;
+  } catch (error) {
+    log(
+      "ERROR",
+      "API - Download Queue",
+      "Delete Collection from Queue",
+      `Failed to delete collection from the download queue: ${error instanceof Error ? error.message : "Unknown error"}`,
+      error
+    );
+    return ReturnErrorMessage<RemoveCollectionFromQueue_Response>(error);
+  }
+};

--- a/frontend/src/services/downloads/collection-queue-retry.ts
+++ b/frontend/src/services/downloads/collection-queue-retry.ts
@@ -1,0 +1,52 @@
+import apiClient from "@/services/api-client";
+import { ReturnErrorMessage } from "@/services/api-error-return";
+
+import { log } from "@/lib/logger";
+
+import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionQueueItem } from "@/types/database/db-collection-queue";
+
+export interface RetryCollectionInQueue_Request {
+  item: CollectionQueueItem;
+}
+export interface RetryCollectionInQueue_Response {
+  result: string;
+}
+
+/**
+ * Retry a failed (error) collection download queue entry. The backend atomically
+ * re-queues the errored entry (strips its `error_` prefix) so the processor
+ * reprocesses it on its next run.
+ */
+export const RetryCollectionInQueue = async (
+  item: CollectionQueueItem
+): Promise<APIResponse<RetryCollectionInQueue_Response>> => {
+  log(
+    "INFO",
+    "API - Download Queue",
+    "Retry Collection",
+    `Retrying collection '${item.collection_item?.title ?? "(unknown)"}' [${
+      item.collection_item?.rating_key ?? "(unknown)"
+    }] in the download queue`
+  );
+  try {
+    const req: RetryCollectionInQueue_Request = { item };
+    const response = await apiClient.post<APIResponse<RetryCollectionInQueue_Response>>(
+      `/download/queue/collection/retry`,
+      req
+    );
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error while retrying collection in download queue");
+    }
+    return response.data;
+  } catch (error) {
+    log(
+      "ERROR",
+      "API - Download Queue",
+      "Retry Collection",
+      `Failed to retry collection in the download queue: ${error instanceof Error ? error.message : "Unknown error"}`,
+      error
+    );
+    return ReturnErrorMessage<RetryCollectionInQueue_Response>(error);
+  }
+};

--- a/frontend/src/types/database/db-collection-queue.ts
+++ b/frontend/src/types/database/db-collection-queue.ts
@@ -1,0 +1,17 @@
+import type { CollectionItem } from "@/app/collections/page";
+
+import type { CollectionItemImageFile } from "@/types/media-and-posters/sets";
+
+// Mirror of the backend models.CollectionQueueItem. A queued request to download
+// and apply one or more MediUX images (poster/backdrop only) to a native
+// media-server Collection. Distinct from DBSavedItem, which represents a
+// movie/show media item + MediUX poster sets.
+export interface CollectionQueueItem {
+  collection_item: CollectionItem;
+  images: CollectionItemImageFile[];
+  // Queue-only failure metadata, populated by the backend when an entry is moved
+  // to the error/warning state. Absent on in-progress entries.
+  queue_errors?: string[];
+  queue_warnings?: string[];
+  failed_at?: string;
+}


### PR DESCRIPTION
## Summary

Two related changes to the download popups:

1. **Default to "Add to Queue".** The main download modal (`DownloadModal`, used across media-item / set / boxset / saved-sets / carousel pages) now defaults its **Add to Queue** checkbox to checked, so downloads are queued and processed in the background instead of running synchronously in the dialog.

2. **Collection images can now be queued too.** The collection-item download modal previously had *no* queue option and always downloaded immediately. It now has an **Add to Queue** checkbox (default checked) and a matching backend queue.

## Why the collection change needed a backend

The download queue — backend *and* frontend — was built entirely around `DBSavedItem` (a movie/show `MediaItem` + MediUX poster sets). A native media-server **Collection** doesn't fit that shape: it may have no TMDB ID, needs a different apply function (`ApplyCollectionImage`), and has no DB upsert or label/tag handling. So this adds an **isolated collection queue** rather than shoehorning collections into the existing one.

## Backend

- New `models.CollectionQueueItem` (`CollectionItem` + selected `ImageFile`s).
- Entries live in a **`download-queue/collections/` subfolder**. The existing media-item queue does a non-recursive `ReadDir` and skips directories, so the two queues never see each other's files.
- `add` / `get` / `process` / `remove` / `retry` mirror the media-item queue (same `error_`/`warning_` filename scheme, same atomic-rename finalize logic). The processor applies each image via `mediaserver.ApplyCollectionImage`, which also performs the **Kometa asset write** when Kometa mode is enabled.
- Reuses the existing **"Download Queue" notification template** (no new template plumbing) by adapting the collection into the `MediaItem`/`PosterSet` shape `SendNotification` expects.
- Routes: `GET`/`POST`/`DELETE /download/queue/collection` and `POST /download/queue/collection/retry`. Processing is wired into the existing 1-minute download-queue cron tick.
- Swagger docs regenerated.

## Frontend

- Collection download modal: **Add to Queue** checkbox (default checked); when checked it enqueues the selected poster/backdrop images instead of downloading immediately.
- Download Queue page: queued collection entries render in their own **In Progress / Errors / Warnings** sections, with per-entry **retry** + **remove** and failure-detail popovers, mirroring the media-item queue.

## Scope note

Per-entry retry/remove is provided for collection entries; the media-item queue's **bulk-edit** flow was intentionally not duplicated for collections to keep the diff focused. Easy to add later if wanted.

## Testing

- `go build ./...` + `go vet` clean; swagger regenerated.
- Frontend `tsc --noEmit`, `eslint --max-warnings=0`, and Prettier all clean.
- Not exercised against a live media server / MediUX — worth a manual smoke test of: queue a collection poster+backdrop, confirm the queue page shows it, the cron applies it (and writes the Kometa asset if enabled), and retry/remove work on a forced error.

https://claude.ai/code/session_01QP9oyWQpsw2aCaLmasuRQw