### PR TITLE
refactor(types): move CollectionItem to a shared types module

### DIFF
--- a/frontend/src/app/collection-item/collection-download-modal.tsx
+++ b/frontend/src/app/collection-item/collection-download-modal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { CollectionItem } from "@/app/collections/page";
 import { formatDownloadSize } from "@/helper/format-download-size";
 import { DownloadImageFileForCollectionItem } from "@/services/downloads/download-collection-image";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -36,6 +35,7 @@ import { cn } from "@/lib/cn";
 import { log } from "@/lib/logger";
 import { useUserPreferencesStore } from "@/lib/stores/global-user-preferences";
 
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { CollectionItemImageFile, CollectionItemSetRef } from "@/types/media-and-posters/sets";
 import {
   DOWNLOAD_COLLECTION_IMAGE_TYPE_OPTIONS,

--- a/frontend/src/app/collection-item/page.tsx
+++ b/frontend/src/app/collection-item/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import CollectionsDownloadModal from "@/app/collection-item/collection-download-modal";
-import type { CollectionItem } from "@/app/collections/page";
 import { formatLastUpdatedDate } from "@/helper/format-date-last-updates";
 import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
@@ -41,6 +40,7 @@ import { useCollectionItemPageStore } from "@/lib/stores/page-store-collection-i
 import { useCollectionsPageStore } from "@/lib/stores/page-store-collections";
 
 import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { CollectionItemSetRef } from "@/types/media-and-posters/sets";
 import type { MediuxUserInfo } from "@/types/mediux/mediux-user-follow-hide";
 

--- a/frontend/src/app/collections/page.tsx
+++ b/frontend/src/app/collections/page.tsx
@@ -22,17 +22,13 @@ import { useCollectionsPageStore } from "@/lib/stores/page-store-collections";
 import { searchItems } from "@/hooks/search-query";
 
 import type { APIResponse } from "@/types/api/api-response";
-import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 
-export interface CollectionItem {
-  rating_key: string;
-  index: string;
-  title: string;
-  summary?: string;
-  child_count: number;
-  media_items: MediaItem[];
-  library_title?: string;
-}
+// Backward-compatible re-export: CollectionItem now lives in
+// @/types/media-and-posters/collection-item. Prefer importing it from there.
+// This re-export keeps any remaining "@/app/collections/page" imports working
+// during migration and can be removed once every consumer has moved over.
+export type { CollectionItem };
 
 export default function CollectionsPage() {
   const isMounted = useRef(false);

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { CollectionItem } from "@/app/collections/page";
 import { formatExactDateTime } from "@/helper/format-date-last-updates";
 import { formatDownloadSize } from "@/helper/format-download-size";
 import { downloadImageFileForMediaItem } from "@/services/downloads/download-image";
@@ -20,6 +19,7 @@ import { isKometaImageId, kometaImageSrc } from "@/lib/kometa";
 import { log } from "@/lib/logger";
 import { useUserPreferencesStore } from "@/lib/stores/global-user-preferences";
 
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
 import type { CollectionItemImageFile, ImageFile, IncludedItem } from "@/types/media-and-posters/sets";
 

--- a/frontend/src/components/shared/collection-item-details.tsx
+++ b/frontend/src/components/shared/collection-item-details.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import type { CollectionItem } from "@/app/collections/page";
-
 import { AssetImage } from "@/components/shared/asset-image";
 import { CollectionMediaItemsCarousel } from "@/components/shared/collection-media-items-carousel";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { H1, Lead } from "@/components/ui/typography";
+
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 
 type CollectionItemDetailsProps = {
   collectionItem: CollectionItem;

--- a/frontend/src/components/shared/media-item-card.tsx
+++ b/frontend/src/components/shared/media-item-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { CollectionItem } from "@/app/collections/page";
 import { Database, EyeClosedIcon, EyeOffIcon } from "lucide-react";
 
 import React from "react";
@@ -15,6 +14,7 @@ import { cn } from "@/lib/cn";
 import { useCollectionStore } from "@/lib/stores/global-store-collection-store";
 import { useMediaStore } from "@/lib/stores/global-store-media-store";
 
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
 
 interface HomeMediaItemCardProps {

--- a/frontend/src/helper/item-info.tsx
+++ b/frontend/src/helper/item-info.tsx
@@ -1,5 +1,4 @@
-import type { CollectionItem } from "@/app/collections/page";
-
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
 
 const titleYearSuffixRe = /\s*\((\d{4})\)\s*$/;

--- a/frontend/src/lib/stores/global-store-collection-store.ts
+++ b/frontend/src/lib/stores/global-store-collection-store.ts
@@ -1,8 +1,9 @@
-import type { CollectionItem } from "@/app/collections/page";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 import { GlobalStore } from "@/lib/stores/stores";
+
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 
 interface CollectionStore {
   collectionItem: CollectionItem | null;

--- a/frontend/src/lib/stores/page-store-collections.ts
+++ b/frontend/src/lib/stores/page-store-collections.ts
@@ -1,9 +1,9 @@
-import type { CollectionItem } from "@/app/collections/page";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 import { PageStore } from "@/lib/stores/stores";
 
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { PaginationStore, SortStore } from "@/types/store-interfaces";
 import type { TYPE_SORT_ORDER_OPTIONS } from "@/types/ui-options";
 

--- a/frontend/src/services/downloads/download-collection-image.ts
+++ b/frontend/src/services/downloads/download-collection-image.ts
@@ -1,4 +1,3 @@
-import type { CollectionItem } from "@/app/collections/page";
 import { collectionItemInfo } from "@/helper/item-info";
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
@@ -6,6 +5,7 @@ import { ReturnErrorMessage } from "@/services/api-error-return";
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { CollectionItemImageFile } from "@/types/media-and-posters/sets";
 import { TYPE_DOWNLOAD_COLLECTION_IMAGE_TYPE_OPTIONS } from "@/types/ui-options";
 

--- a/frontend/src/services/mediaserver/get-movie-collection-children-items.ts
+++ b/frontend/src/services/mediaserver/get-movie-collection-children-items.ts
@@ -1,10 +1,10 @@
-import type { CollectionItem } from "@/app/collections/page";
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
 
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { CollectionItemSetRef } from "@/types/media-and-posters/sets";
 import type { MediuxUserInfo } from "@/types/mediux/mediux-user-follow-hide";
 

--- a/frontend/src/services/mediaserver/get-movie-collections.ts
+++ b/frontend/src/services/mediaserver/get-movie-collections.ts
@@ -1,10 +1,10 @@
-import type { CollectionItem } from "@/app/collections/page";
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
 
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 
 export interface GetCollectionItems_Response {
   collections: CollectionItem[];

--- a/frontend/src/types/media-and-posters/collection-item.ts
+++ b/frontend/src/types/media-and-posters/collection-item.ts
@@ -1,0 +1,18 @@
+import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
+
+// A native media-server Collection (e.g. "James Bond Collection") — a library
+// grouping of media items with its own artwork. Mirrors the backend
+// models.CollectionItem.
+//
+// This was previously defined in @/app/collections/page; it lives here so shared
+// code (services, stores, types, components) can import it without depending on a
+// client page module.
+export interface CollectionItem {
+  rating_key: string;
+  index: string;
+  title: string;
+  summary?: string;
+  child_count: number;
+  media_items: MediaItem[];
+  library_title?: string;
+}


### PR DESCRIPTION
## Summary

`CollectionItem` was defined in `@/app/collections/page` and imported by **11** modules across services, stores, components, and types. That coupled the shared types layer to a **client page module** and created a `collections/page` → `media-item-card` → `collections/page` import cycle.

This moves the interface to **`@/types/media-and-posters/collection-item`** — next to the `MediaItem` type it references, and mirroring the backend's `models.CollectionItem` location — and repoints all importers.

## Why a separate PR

Split out from #45 (collection download queue) at reviewer (Copilot) request, so the pure-refactor churn is reviewable on its own with no behavior change.

## Changes
- New `frontend/src/types/media-and-posters/collection-item.ts` holding `CollectionItem`.
- Repointed all 11 importers from `@/app/collections/page` → the new module.
- `collections/page.tsx` drops the local definition and keeps a **backward-compatible re-export** (`export type { CollectionItem }`) so any remaining `@/app/collections/page` consumers keep working during migration — notably #45's `db-collection-queue.ts`, so these two PRs can merge in either order without breaking. The re-export can be removed once every consumer imports from the new path.

## Testing
- `tsc --noEmit`, `eslint --max-warnings=0`, and `prettier --check` all clean on the changed files.
- No runtime/behavior change — type-only move.

## Follow-up
Once this and #45 are both merged, drop the re-export in `collections/page.tsx` and switch #45's `db-collection-queue.ts` to import from `@/types/media-and-posters/collection-item`.

https://claude.ai/code/session_01QP9oyWQpsw2aCaLmasuRQw