### PR TITLE
fix(download-queue): re-resolve stale rating keys by TMDB before processing

### DIFF
--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -177,19 +177,26 @@ func ProcessQueueItems() {
 			fileWarnings = append(fileWarnings, fmt.Sprintf("mediux lookup failed: %s", mErr.Message))
 		}
 
-		// The queue file snapshotted this item's rating key when it was enqueued. If the media
-		// server removed and re-added the item since then (e.g. a file move / re-import), that key
-		// is now stale and GetMediaItemDetails would 404 on it. The in-memory library cache is
-		// refreshed from the media server and keyed by the stable TMDB ID, so re-resolve the current
-		// rating key from it first — matching what the auto-download check already does
-		// (download/auto/check.go). If the item is not in the cache it is genuinely gone; keep the
-		// snapshot key and let the normal 404 / Sonarr-Radarr fallback path below handle it.
-		if cached, ok := cache.LibraryStore.GetMediaItemFromSectionByTMDBID(queueItem.MediaItem.LibraryTitle, queueItem.MediaItem.TMDB_ID); ok && cached.RatingKey != "" && cached.RatingKey != queueItem.MediaItem.RatingKey {
-			subAction.AppendResult(fmt.Sprintf("rating_key_refresh_%s", file.Name()), fmt.Sprintf("%s -> %s (stale key re-resolved by TMDB %s)", queueItem.MediaItem.RatingKey, cached.RatingKey, queueItem.MediaItem.TMDB_ID))
-			queueItem.MediaItem.RatingKey = cached.RatingKey
+		found, mediaErr := mediaserver.GetMediaItemDetails(ctx, &queueItem.MediaItem)
+
+		// The queue file snapshotted this item's rating key when it was enqueued. Media-server
+		// rating keys are not stable (Plex reassigns them when an item is removed and re-added,
+		// e.g. a file move / re-import), so a key that was valid at enqueue time can be dead by the
+		// time the queue drains — the fetch above then 404s. Before failing, re-resolve the current
+		// key from the in-memory library cache by the stable TMDB ID and retry the fetch once.
+		//
+		// This runs only after a genuine 404, never for an item whose queued key still resolves, so
+		// a valid entry is never redirected to a different item that merely shares the TMDB ID
+		// (duplicate editions in the same library). If the cache holds no newer key, the queued key
+		// is left as-is and the existing Sonarr/Radarr fallback + error path below handles it.
+		if mediaserver.IsItemNotFound(mediaErr) {
+			if cached, ok := cache.LibraryStore.GetMediaItemFromSectionByTMDBID(queueItem.MediaItem.LibraryTitle, queueItem.MediaItem.TMDB_ID); ok && cached.RatingKey != "" && cached.RatingKey != queueItem.MediaItem.RatingKey {
+				subAction.AppendResult(fmt.Sprintf("rating_key_refresh_%s", file.Name()), fmt.Sprintf("%s -> %s (stale key re-resolved by TMDB %s)", queueItem.MediaItem.RatingKey, cached.RatingKey, queueItem.MediaItem.TMDB_ID))
+				queueItem.MediaItem.RatingKey = cached.RatingKey
+				found, mediaErr = mediaserver.GetMediaItemDetails(ctx, &queueItem.MediaItem)
+			}
 		}
 
-		found, mediaErr := mediaserver.GetMediaItemDetails(ctx, &queueItem.MediaItem)
 		if mediaErr.Message != "" || !found {
 			// The media server can't resolve the item (e.g. Plex returns a 404 for a stale rating
 			// key). If the Sonarr/Radarr → Kometa fallback is enabled and the item exists in

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -1,6 +1,7 @@
 package downloadqueue
 
 import (
+	"aura/cache"
 	"aura/database"
 	"aura/kometa"
 	"aura/logging"
@@ -174,6 +175,18 @@ func ProcessQueueItems() {
 		mediuxItemInfo, mErr := mediux.GetBaseItemInfoByTMDB_ID(queueItem.MediaItem.TMDB_ID, queueItem.MediaItem.Type)
 		if mErr.Message != "" {
 			fileWarnings = append(fileWarnings, fmt.Sprintf("mediux lookup failed: %s", mErr.Message))
+		}
+
+		// The queue file snapshotted this item's rating key when it was enqueued. If the media
+		// server removed and re-added the item since then (e.g. a file move / re-import), that key
+		// is now stale and GetMediaItemDetails would 404 on it. The in-memory library cache is
+		// refreshed from the media server and keyed by the stable TMDB ID, so re-resolve the current
+		// rating key from it first — matching what the auto-download check already does
+		// (download/auto/check.go). If the item is not in the cache it is genuinely gone; keep the
+		// snapshot key and let the normal 404 / Sonarr-Radarr fallback path below handle it.
+		if cached, ok := cache.LibraryStore.GetMediaItemFromSectionByTMDBID(queueItem.MediaItem.LibraryTitle, queueItem.MediaItem.TMDB_ID); ok && cached.RatingKey != "" && cached.RatingKey != queueItem.MediaItem.RatingKey {
+			subAction.AppendResult(fmt.Sprintf("rating_key_refresh_%s", file.Name()), fmt.Sprintf("%s -> %s (stale key re-resolved by TMDB %s)", queueItem.MediaItem.RatingKey, cached.RatingKey, queueItem.MediaItem.TMDB_ID))
+			queueItem.MediaItem.RatingKey = cached.RatingKey
 		}
 
 		found, mediaErr := mediaserver.GetMediaItemDetails(ctx, &queueItem.MediaItem)


### PR DESCRIPTION
## Problem

Download-queue files snapshot the media-server **rating key** at enqueue time (`download/queue/add.go` marshals the full `MediaItem`, including its rating key, into `LibraryTitle_TMDBID_timestamp.json`). At process time, `ProcessQueueItems` passes that snapshotted key straight to `mediaserver.GetMediaItemDetails`, which fetches `/library/metadata/{RatingKey}` and does `*item = *extracted`.

Plex rating keys are **not stable** — they are auto-increment DB row IDs that get reassigned whenever an item is removed and re-added. When the queue drains slowly (or the app restarts mid-drain) and an item is removed/re-added on the server between enqueue and process (a file move, root-folder migration, or re-import), the snapshotted key is now dead and `GetMediaItemDetails` returns a 404 — failing the download with `media server lookup failed for '<title>' in '<library>': ... 404`, even though the item still exists under a new key.

Observed live: a bulk re-add of ~34 TV shows on a single morning invalidated the rating keys embedded in queue files written a day earlier; every one of those entries 404'd on drain.

## Fix

Before calling `GetMediaItemDetails`, re-resolve the current rating key from the in-memory `LibraryStore` cache by the **stable TMDB ID**. The cache is refreshed from the media server by cron and is authoritative; the DB/cache already self-heal rating keys this way via the 6h `CheckForMediaItemChanges` job. This just extends the same treatment to the queue-processing path, which was the one place still trusting the stale snapshot.

This mirrors what `download/auto/check.go` already does (resolve from cache by TMDB → `GetMediaItemDetails`).

Behavior when the item is **not** in the cache (genuinely removed) is unchanged: the snapshot key is kept and the existing 404 / Sonarr-Radarr → Kometa fallback path handles it.

## Scope / safety

- Only swaps the key when the cache has a **different, non-empty** key for that TMDB ID; otherwise no-op.
- Server-type agnostic — resolving by TMDB from the cache is correct for Plex/Emby/Jellyfin (the churn is a Plex issue in practice).
- `GetMediaItemDetails` re-fetches full item info (including fresh season/episode keys) from the resolved key, so downstream season-poster / titlecard application uses current keys too, not just the top-level one.
- `CGO_ENABLED=1 go build ./...` and `go vet ./download/queue/` pass.

https://claude.ai/code/session_01ABeACy7AfUTdESbAR5Z2ZN