### PR TITLE
chore(types): drop CollectionItem compatibility re-export

### DIFF
--- a/frontend/src/app/collections/page.tsx
+++ b/frontend/src/app/collections/page.tsx
@@ -24,12 +24,6 @@ import { searchItems } from "@/hooks/search-query";
 import type { APIResponse } from "@/types/api/api-response";
 import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 
-// Backward-compatible re-export: CollectionItem now lives in
-// @/types/media-and-posters/collection-item. Prefer importing it from there.
-// This re-export keeps any remaining "@/app/collections/page" imports working
-// during migration and can be removed once every consumer has moved over.
-export type { CollectionItem };
-
 export default function CollectionsPage() {
   const isMounted = useRef(false);
 

--- a/frontend/src/types/database/db-collection-queue.ts
+++ b/frontend/src/types/database/db-collection-queue.ts
@@ -1,5 +1,4 @@
-import type { CollectionItem } from "@/app/collections/page";
-
+import type { CollectionItem } from "@/types/media-and-posters/collection-item";
 import type { CollectionItemImageFile } from "@/types/media-and-posters/sets";
 
 // Mirror of the backend models.CollectionQueueItem. A queued request to download


### PR DESCRIPTION
## Summary

Follow-up cleanup now that #45 (collection download queue) and #46 (move `CollectionItem` to a shared type) are both merged.

- Migrate the last remaining consumer — `types/database/db-collection-queue.ts` (added by #45) — to import `CollectionItem` from `@/types/media-and-posters/collection-item` instead of `@/app/collections/page`.
- Remove the backward-compatible re-export that #46 left in `app/collections/page.tsx`.

Verified with `git grep` that no other file imports `CollectionItem` from the page module, so dropping the re-export is safe. The page still imports the type for its own local use.

## Testing
- `tsc --noEmit`, `eslint --max-warnings=0`, and `prettier --check` all clean (the passing typecheck confirms nothing else depended on the page's re-export).
- Type-only change, no behavior change.

https://claude.ai/code/session_01QP9oyWQpsw2aCaLmasuRQw