### PR TITLE
fix(download): skip specials poster when season 0 is missing from the media server

### DIFF
--- a/backend/mediaserver/ej/image_apply.go
+++ b/backend/mediaserver/ej/image_apply.go
@@ -21,7 +21,8 @@ func applyImageToMediaItem(ctx context.Context, item *models.MediaItem, imageFil
 	// Determine the Item Rating Key from Emby/Jellyfin
 	itemRatingKey := getItemRatingKeyFromImageFile(*item, imageFile)
 	if itemRatingKey == "" {
-		logAction.SetError("Failed to determine Rating Key for Media Item", "Ensure the Media Item and Image File data are correct", nil)
+		message, help := utils.RatingKeyNotFoundMessage(imageFile)
+		logAction.SetError(message, help, nil)
 		return *logAction.Error
 	}
 

--- a/backend/mediaserver/plex/image_download.go
+++ b/backend/mediaserver/plex/image_download.go
@@ -28,7 +28,8 @@ func (p *Plex) DownloadApplyImageToMediaItem(ctx context.Context, item *models.M
 	// Determine the Item Rating Key from Plex
 	itemRatingKey := getItemRatingKeyFromImageFile(*item, imageFile)
 	if itemRatingKey == "" {
-		logAction.SetError("Failed to determine Rating Key for Media Item", "Ensure the Media Item and Image File data are correct", nil)
+		message, help := utils.RatingKeyNotFoundMessage(imageFile)
+		logAction.SetError(message, help, nil)
 		return *logAction.Error
 	}
 	logAction.AppendResult("image_rating_key", itemRatingKey)

--- a/backend/utils/rating_key_not_found_message.go
+++ b/backend/utils/rating_key_not_found_message.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"aura/models"
+	"fmt"
+)
+
+// RatingKeyNotFoundMessage builds an actionable message and help string for when a
+// media item's rating key cannot be determined for an image. For season posters and
+// titlecards the most common cause is that the season/episode does not (yet) exist on
+// the media server, so the message names the missing season/episode.
+func RatingKeyNotFoundMessage(imageFile models.ImageFile) (message string, help string) {
+	switch imageFile.Type {
+	case "season_poster", "special_season_poster":
+		if imageFile.SeasonNumber != nil {
+			return fmt.Sprintf("Season %d not found on the media server for this show", *imageFile.SeasonNumber),
+				"The season does not exist on the media server yet. It will be applied automatically once the season is added, if the set is saved with Auto Download enabled."
+		}
+	case "titlecard":
+		if imageFile.SeasonNumber != nil && imageFile.EpisodeNumber != nil {
+			return fmt.Sprintf("Season %d Episode %d not found on the media server for this show", *imageFile.SeasonNumber, *imageFile.EpisodeNumber),
+				"The episode does not exist on the media server yet. It will be applied automatically once the episode is added, if the set is saved with Auto Download enabled."
+		}
+	}
+	return "Failed to determine Rating Key for Media Item", "Ensure the Media Item and Image File data are correct"
+}

--- a/frontend/src/components/shared/download-modal.tsx
+++ b/frontend/src/components/shared/download-modal.tsx
@@ -1522,6 +1522,7 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
               );
 
               for (const sp of specialSeasonPosters) {
+                const exists = latestMediaItem.series?.seasons.some((season) => season.season_number === 0);
                 const taskId = newId();
                 const payload: DownloadTaskPayload = {
                   kind: "download",
@@ -1539,6 +1540,12 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
                   attempts: 0,
                   payload,
                 });
+
+                if (!exists) {
+                  updateTask(taskId, (t) => ({ ...t, status: "skipped" }));
+                  continue;
+                }
+
                 downloadJobs.push({ taskId, payload });
               }
               break;

--- a/frontend/src/components/shared/download-modal.tsx
+++ b/frontend/src/components/shared/download-modal.tsx
@@ -1521,8 +1521,9 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
                 (sp) => sp.type === "season_poster" && sp.season_number === 0
               );
 
+              const exists = latestMediaItem.series?.seasons.some((season) => season.season_number === 0) ?? false;
+
               for (const sp of specialSeasonPosters) {
-                const exists = latestMediaItem.series?.seasons.some((season) => season.season_number === 0);
                 const taskId = newId();
                 const payload: DownloadTaskPayload = {
                   kind: "download",


### PR DESCRIPTION
## Problem

Downloading a MediUX set for a show whose **Specials (season 0)** does not exist on the media server (Plex/Emby/Jellyfin) failed with:

> "Modern Family" - Specials Season Poster - **Failed to determine Rating Key for Media Item**

even though every other image in the set applied and the set was saved. Desired behavior: as long as the **show** exists, images for seasons/episodes not yet present should be staged (saved to the DB, skipped now) and applied later when the season/episode is added.

## Root cause

In `frontend/src/components/shared/download-modal.tsx`, the `season_poster` and `titlecard` job builders already skip images whose season/episode is absent from the media item (marking the task `skipped`). The `special_season_poster` branch did **not** — it always queued the direct-apply request, which hit the backend season-0 rating-key lookup, returned an empty key, and raised a fatal error.

## Changes

- **Frontend:** `special_season_poster` now checks whether the show has season 0 and marks the task `skipped` when it doesn't, mirroring the existing `season_poster`/`titlecard` behavior. The set is still persisted (via the existing `totalForItem === 0` / add-to-DB paths), so the specials poster is applied later by the auto-download recheck when Plex/Sonarr gains the Specials season.
- **Backend:** the "Failed to determine Rating Key" error (reachable via explicit single-image applies) now names the missing season/episode instead of a generic message. Shared helper `utils.RatingKeyNotFoundMessage`, used by both the Plex and Emby/Jellyfin apply paths.

## Verification

- `cd frontend && npm run lint && npm run typecheck` — pass; Prettier clean.
- `cd backend && CGO_ENABLED=1 go build ./...` — pass; `gofmt` clean.
- Manual: show with no season 0, MediUX set with a specials poster, download all types without "Add to Queue" → Specials task shows **skipped**, other images apply, set saved with the `special_season_poster` badge.

https://claude.ai/code/session_011SdoFfXK58B6sGJJkoHjux