### PR TITLE
fix(security): bind masked-token restoration to destination URL

### DIFF
--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -1081,12 +1081,19 @@ func checkConfigDifferences_SonarrRadarr(ctx context.Context, oldSR config.Confi
 	// Restore ApiTokens
 	for i, app := range newSR.Applications {
 		if strings.HasPrefix(app.ApiToken, "***") {
-			// Find matching old app by Library and Type
+			// Find matching old app by Library, Type and URL. The URL must match too: otherwise
+			// the restored real token would be sent to a caller-supplied URL by TestConnection below.
+			matched := false
 			for _, oldApp := range oldSR.Applications {
-				if app.Library == oldApp.Library && app.Type == oldApp.Type {
+				if app.Library == oldApp.Library && app.Type == oldApp.Type && app.URL == oldApp.URL {
 					newSR.Applications[i].ApiToken = oldApp.ApiToken
+					matched = true
 					break
 				}
+			}
+			if !matched {
+				logAction.SetError("SonarrRadarr.Application.ApiToken is masked but no matching Library/Type/URL was found", "A new API token must be provided when adding an application or changing its URL", nil)
+				return changed, false
 			}
 		}
 	}

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -248,6 +248,11 @@ func checkConfigDifferences_MediaServer(ctx context.Context, oldMediaServer conf
 					Str("new_api_token", fmt.Sprintf("%s", newMediaServer.ApiToken)).
 					Msg("MediaServer.ApiToken changed")
 				changed = true
+			} else if newMediaServer.URL != oldMediaServer.URL {
+				// A masked token can only be restored for the URL it was issued for. Otherwise the
+				// real, live token would be sent to a caller-supplied URL by the TestConnection call below.
+				logAction.SetError("MediaServer.ApiToken is masked but MediaServer.URL changed", "A new API token must be provided when changing the media server URL", nil)
+				return changed, false, serverName
 			} else {
 				newMediaServer.ApiToken = oldMediaServer.ApiToken
 			}

--- a/backend/routing/mediaserver/get_library_section_options.go
+++ b/backend/routing/mediaserver/get_library_section_options.go
@@ -47,6 +47,13 @@ func GetLibrarySectionOptions(w http.ResponseWriter, r *http.Request) {
 	msConfig := req.MediaServer
 
 	if strings.HasPrefix(msConfig.ApiToken, "***") {
+		// A masked token can only be restored for the URL it was issued for. Otherwise the
+		// real, live token would be sent to a caller-supplied URL by GetLibrarySections below.
+		if msConfig.URL != config.Current.MediaServer.URL {
+			logAction.SetError("Unable to unmask media server credentials", "A new API token must be provided when changing the media server URL", nil)
+			httpx.SendResponse(w, ld, response)
+			return
+		}
 		msConfig.ApiToken = config.Current.MediaServer.ApiToken
 	}
 

--- a/backend/routing/validation/mediaserver.go
+++ b/backend/routing/validation/mediaserver.go
@@ -48,6 +48,13 @@ func ValidateMediaServerInfo(w http.ResponseWriter, r *http.Request) {
 
 	// If the Media Server Token is masked, retrieve the actual token from the config
 	if config.IsMaskedField(mediaServerInfo.ApiToken) {
+		// A masked token can only be restored for the URL it was issued for. Otherwise the
+		// real, live token would be sent to a caller-supplied URL by TestConnection below.
+		if mediaServerInfo.URL != config.Current.MediaServer.URL {
+			logAction.SetError("Unable to unmask media server credentials", "A new API token must be provided when changing the media server URL", nil)
+			httpx.SendResponse(w, ld, response)
+			return
+		}
 		mediaServerInfo.ApiToken = config.Current.MediaServer.ApiToken
 	}
 

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -255,6 +255,13 @@ func SendTestNotification(w http.ResponseWriter, r *http.Request) {
 			url = getUnmaskedGotifyField("URL", url)
 		}
 		if config.IsMaskedField(apiToken) {
+			// A masked token can only be restored for the URL it was issued for. Otherwise the
+			// real, live token would be sent to a caller-supplied URL by SendGotifyMessage below.
+			if url != storedGotifyURL() {
+				logAction.SetError("Unable to unmask Gotify credentials", "A new API token must be provided when changing the Gotify URL", nil)
+				httpx.SendResponse(w, ld, response)
+				return
+			}
 			apiToken = getUnmaskedGotifyField("Token", apiToken)
 		}
 		if url == "" || apiToken == "" {
@@ -323,6 +330,15 @@ func getUnmaskedDiscordWebhook(currentValue string) string {
 					}
 				}
 			}
+		}
+	}
+	return ""
+}
+
+func storedGotifyURL() string {
+	for _, existingProvider := range config.Current.Notifications.Providers {
+		if existingProvider.Provider == "Gotify" && existingProvider.Gotify != nil {
+			return existingProvider.Gotify.URL
 		}
 	}
 	return ""

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -251,18 +251,25 @@ func SendTestNotification(w http.ResponseWriter, r *http.Request) {
 	case "Gotify":
 		url := nProvider.Gotify.URL
 		apiToken := nProvider.Gotify.ApiToken
-		if config.IsMaskedField(url) {
-			url = getUnmaskedGotifyField("URL", url)
-		}
-		if config.IsMaskedField(apiToken) {
-			// A masked token can only be restored for the URL it was issued for. Otherwise the
-			// real, live token would be sent to a caller-supplied URL by SendGotifyMessage below.
-			if url != storedGotifyURL() {
-				logAction.SetError("Unable to unmask Gotify credentials", "A new API token must be provided when changing the Gotify URL", nil)
+		urlMasked := config.IsMaskedField(url)
+		tokenMasked := config.IsMaskedField(apiToken)
+		if urlMasked || tokenMasked {
+			// Masked URL/token must be restored together from the same stored provider.
+			// Matching each field independently against any stored Gotify provider would let a
+			// real token from one provider be paired with another provider's URL and sent there
+			// by SendGotifyMessage below.
+			matched := matchGotifyProvider(url, urlMasked, apiToken, tokenMasked)
+			if matched == nil {
+				logAction.SetError("Unable to unmask Gotify credentials", "Please provide the full Gotify URL and ApiToken", nil)
 				httpx.SendResponse(w, ld, response)
 				return
 			}
-			apiToken = getUnmaskedGotifyField("Token", apiToken)
+			if urlMasked {
+				url = matched.URL
+			}
+			if tokenMasked {
+				apiToken = matched.ApiToken
+			}
 		}
 		if url == "" || apiToken == "" {
 			logAction.SetError("Unable to unmask Gotify credentials", "Please provide the full Gotify URL and ApiToken", nil)
@@ -335,39 +342,35 @@ func getUnmaskedDiscordWebhook(currentValue string) string {
 	return ""
 }
 
-func storedGotifyURL() string {
-	for _, existingProvider := range config.Current.Notifications.Providers {
-		if existingProvider.Provider == "Gotify" && existingProvider.Gotify != nil {
-			return existingProvider.Gotify.URL
-		}
+// maskedFieldMatches reports whether maskedValue is a masked representation of realValue, i.e.
+// their last few characters agree, mirroring the masking scheme in config.IsMaskedField.
+func maskedFieldMatches(maskedValue, realValue string) bool {
+	if len(maskedValue) <= 3 || len(realValue) < 3 {
+		return false
 	}
-	return ""
+	return maskedValue[len(maskedValue)-3:] == realValue[len(realValue)-3:]
 }
 
-func getUnmaskedGotifyField(field, currentValue string) string {
+// matchGotifyProvider finds the single stored Gotify provider whose URL and ApiToken both match
+// the given (possibly masked) values, so a masked field can only be restored alongside the other
+// field it was originally paired with, never mixed with a different stored provider.
+func matchGotifyProvider(url string, urlMasked bool, apiToken string, apiTokenMasked bool) *config.Config_Notification_Gotify {
 	for _, existingProvider := range config.Current.Notifications.Providers {
-		if existingProvider.Provider == "Gotify" && existingProvider.Gotify != nil {
-			switch field {
-			case "URL":
-				if existingProvider.Gotify.URL != "" {
-					// Make sure that the last few characters match the masked value
-					if len(currentValue) > 3 && len(existingProvider.Gotify.URL) >= 3 {
-						if currentValue[len(currentValue)-3:] == existingProvider.Gotify.URL[len(existingProvider.Gotify.URL)-3:] {
-							return existingProvider.Gotify.URL
-						}
-					}
-				}
-			case "Token":
-				if existingProvider.Gotify.ApiToken != "" {
-					// Make sure that the last few characters match the masked value
-					if len(currentValue) > 3 && len(existingProvider.Gotify.ApiToken) >= 3 {
-						if currentValue[len(currentValue)-3:] == existingProvider.Gotify.ApiToken[len(existingProvider.Gotify.ApiToken)-3:] {
-							return existingProvider.Gotify.ApiToken
-						}
-					}
-				}
-			}
+		if existingProvider.Provider != "Gotify" || existingProvider.Gotify == nil {
+			continue
 		}
+		stored := existingProvider.Gotify
+		if urlMasked {
+			if !maskedFieldMatches(url, stored.URL) {
+				continue
+			}
+		} else if url != stored.URL {
+			continue
+		}
+		if apiTokenMasked && !maskedFieldMatches(apiToken, stored.ApiToken) {
+			continue
+		}
+		return stored
 	}
-	return ""
+	return nil
 }


### PR DESCRIPTION
## Summary
Fixes the 2 CRITICAL findings from the 2026-07-15 adversarial security audit (`~/security-audit-skill/AURA/run-1/`, findings #0 and #1), plus a related bug found while implementing the fix.

- `checkConfigDifferences_MediaServer` (`backend/routing/config/update.go`) restored the real, live media-server API token whenever the submitted `api_token` merely started with `"***"`, with no check that the submitted `url` matched the currently stored one. The handler then called `mediaserver.TestConnection` with the attacker-supplied URL and the restored real token, sending the live secret to that URL.
- The Gotify branch of `SendTestNotification` (`backend/routing/validation/notification.go`) had the identical pattern for the Gotify API token.
- `checkConfigDifferences_SonarrRadarr` (same file) had the same class of bug: it restored an app's real token whenever the value looked masked and matched an existing app by Library+Type, without checking the URL — so an attacker could keep Library+Type the same, change the URL, and have the real Sonarr/Radarr token sent to it via `TestConnection`. This wasn't a confirmed finding in the original audit (it was cited as the *safe* contrast case), but is the same vulnerability once you check the URL binding.

Because `Auth.Enabled` defaults to `false`, all three endpoints were reachable with zero credentials in the default deployment.

All three call sites now require the real token to be resubmitted (not just its masked form) whenever the destination URL changes.

## Out of scope
This PR only fixes the CRITICAL-class masked-token/URL-binding bug and its sibling instances. The audit also flagged 5 HIGH and several MEDIUM/LOW findings (arbitrary file write in the download queue, unsynchronized map write causing a crash, wildcard CORS + no CSRF, etc.) — not addressed here. Full detail in `FINDINGS-DETAIL.md` from the audit run.

## Test plan
- [x] `CGO_ENABLED=1 go build ./...` passes
- [x] `go vet ./routing/config/... ./routing/validation/...` clean
- [ ] Manual verification: submit `POST /api/config` with a real stored token's masked prefix + a different `media_server.url` → expect rejection instead of an outbound call to the new URL
- [ ] Manual verification: same for `POST /api/validate/notifications` with a Gotify provider
- [ ] Manual verification: same for a SonarrRadarr app entry with a changed URL

https://claude.ai/code/session_01SxVijwN9JZh2ukzPVWrZhL