### PR TITLE
ci(release): correct the weekly dependency roll-up rules

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -102,7 +102,12 @@ jobs:
           # created by the app that the branch rulesets allow to bypass.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # The weekly scheduled run promotes dependency bumps to a patch release.
-          RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
+          # workflow_dispatch counts too: schedule only ever fires on the default
+          # branch, so a manual run is the only way to sweep beta's suppressed
+          # fix(deps) commits, and dispatching this workflow by hand is itself the
+          # deliberate "release what's ready now" signal. Matches the expression in
+          # jabrown93/.github's npm-release.yml / docker-release.yml.
+          RELEASE_DEPS: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: npx semantic-release
 
       # A squash merge of main -> beta does NOT make main's commits (or their tags)

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -4,12 +4,18 @@
 //   * push to `main` -> stable release (feat -> minor, fix/perf -> patch, ! -> major)
 //   * push to `beta` -> prerelease (vX.Y.Z-beta.N)
 //
-// Dependency bumps intentionally do NOT cut a release on ordinary pushes. Renovate
-// labels them fix(deps) (runtime deps), chore(deps) (dev deps / lock maintenance),
-// or build(deps) — fix would otherwise trigger a patch via the default rules, so it
-// is explicitly suppressed here. The weekly scheduled workflow run sets
-// RELEASE_DEPS=true, which promotes all accumulated dependency commits to a single
-// patch release.
+// Routine runtime dependency bumps intentionally do NOT cut a release on ordinary
+// pushes. Renovate labels them fix(deps), which would otherwise trigger a patch via
+// the default rules, so it is explicitly suppressed here. The weekly scheduled run
+// (and a manual workflow_dispatch) sets RELEASE_DEPS=true, which promotes the
+// accumulated bumps to a single patch release.
+//
+// Only fix(deps) is promoted. chore(deps)/build(deps) are dev-only, test-only or
+// CI-only changes under the shared Renovate preset, so promoting them would cut a
+// release with no runtime change in it. They don't release by default, and are
+// deliberately left that way. Vulnerability fixes are typed fix(security), not
+// fix(deps), so they are unaffected by the suppression and release immediately.
+// See jabrown93/.github's README, "Weekly dependency releases".
 //
 // This file is CommonJS: the root package.json (CI-only tooling that pins
 // semantic-release + its plugins) deliberately does NOT set `"type": "module"`,
@@ -19,17 +25,18 @@
 
 const releaseDeps = process.env.RELEASE_DEPS === "true";
 
-// Custom rules are evaluated before commit-analyzer's defaults, and the first
-// match wins — so `release: false` on fix(deps) suppresses the default fix->patch.
-// chore/build already don't release by default; they only need promotion when
-// RELEASE_DEPS is set.
-const depReleaseRules = releaseDeps
-  ? [
-      { type: "fix", scope: "deps", release: "patch" },
-      { type: "chore", scope: "deps", release: "patch" },
-      { type: "build", scope: "deps", release: "patch" },
-    ]
-  : [{ type: "fix", scope: "deps", release: false }];
+// Custom rules are evaluated before commit-analyzer's defaults, so `release: false`
+// on fix(deps) suppresses the default fix->patch.
+const depReleaseRules = [
+  // Required: commit-analyzer evaluates every matching custom rule and keeps the
+  // highest release type, so without this a breaking fix(deps)! (or one with a
+  // BREAKING CHANGE: footer) would match ONLY the suppression rule below and never
+  // release at all. Listed first so the analyzer short-circuits on major.
+  { type: "fix", scope: "deps", breaking: true, release: "major" },
+  releaseDeps
+    ? { type: "fix", scope: "deps", release: "patch" }
+    : { type: "fix", scope: "deps", release: false },
+];
 
 // GitHub rejects a Release body over 125,000 characters (HTTP 422). Normal
 // automated releases are far below that, but a first release with no prior tag


### PR DESCRIPTION
This repo **originated** the `RELEASE_DEPS` pattern that [jabrown93/.github#27](https://github.com/jabrown93/.github/pull/27) generalized for the rest of the fleet. That PR corrected two bugs while porting it, and documented AURA as still carrying them. This aligns AURA with the corrected version.

## 1. The weekly run promoted `chore(deps)` and `build(deps)`

```js
// before — RELEASE_DEPS=true
[{ type: "fix",   scope: "deps", release: "patch" },
 { type: "chore", scope: "deps", release: "patch" },   // dev-only
 { type: "build", scope: "deps", release: "patch" }]   // CI-only
```

Under the shared Renovate preset, `chore(deps)`/`build(deps)` are dev-only, test-only or CI-only changes. Promoting them means a week containing **only** dev-dependency bumps cuts a release with no runtime change in it. Only `fix(deps)` is promoted now.

## 2. A breaking `fix(deps)!` never released at all

It matched only the suppression rule. commit-analyzer evaluates *every* matching custom rule and keeps the highest release type — with the suppression rule alone, a `fix(deps)!` carrying a `BREAKING CHANGE:` footer returns **`null`**. Verified directly against `commit-analyzer@13`. An explicit `breaking → major` rule is required.

## 3. `workflow_dispatch` couldn't promote anything

`version-release.yml` already exposes `workflow_dispatch`, but set:

```yaml
RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
```

So a manual run still evaluated the suppressing rule. This matters because **`schedule` only ever fires on the default branch** — dispatch is the only way to sweep `beta`'s suppressed `fix(deps)` commits, and today that escape hatch is a no-op. A human dispatching a release workflow is itself the deliberate "release what's ready now" signal, so it now sets `RELEASE_DEPS` the same as `schedule`, matching the reusable workflows.

## Resulting behavior

| commit | on push | on weekly / dispatch |
|---|---|---|
| `fix(deps): bump x` | no release | **patch** |
| `fix(deps)!: …BREAKING` | **major** (was: *never released*) | **major** |
| `fix(security): …` | **patch** | patch |
| `chore(deps)` / `build(deps)` | no release | no release (was: **patch**) |
| `feat:` / `fix:` | minor / patch | unchanged |

Also drops the comment claiming custom rules are "evaluated first-match-wins". Per commit-analyzer's own `analyze-commit.js` docstring it *"[finds] all the rules matching and return[s] the highest release type"* — rule order is not load-bearing here (confirmed by swapping them).

## Verification

- `branches`, `tagFormat`, all **6 plugins**, and the release-body truncation template are untouched — verified by loading both the old and new config and diffing.
- Rule output compared old vs new under `RELEASE_DEPS=true` and `=false`.
- `actionlint` clean.