### PR TITLE
ci: migrate CodeQL to jabrown93/ci

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,29 +8,36 @@ on:
   schedule:
     - cron: '25 22 * * 5'
 
+# codeql is now a composite action, so each caller job owns runs-on and MUST
+# grant the permissions CodeQL needs (a composite action cannot declare
+# job-level permissions). AURA is multi-language: analyze Go and TypeScript
+# separately. Go has no buildless mode ("Go does not support the none build
+# mode"), so it uses autobuild — the autobuilder finds the backend/ module and
+# compiles it with cgo/sqlite on the gcc-equipped hosted runner. TypeScript
+# uses build-mode none.
 jobs:
-  # AURA is multi-language: analyze Go and TypeScript separately. Go has no
-  # buildless mode ("Go does not support the none build mode"), so it uses
-  # autobuild — the autobuilder finds the backend/ module and compiles it with
-  # cgo/sqlite on the gcc-equipped hosted runner. TypeScript uses build-mode none.
   analyze-go:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
-    with:
-      language: go
-      build-mode: autobuild
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0
+        with:
+          language: go
+          build-mode: autobuild
 
   analyze-typescript:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
-    with:
-      language: javascript-typescript
-      build-mode: none
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0
+        with:
+          language: javascript-typescript
+          build-mode: none


### PR DESCRIPTION
## Migrate CodeQL to `jabrown93/ci`

`codeql` is now a **composite action**, so each language job owns `runs-on` and the `security-events`/`packages`/`actions`/`contents` permissions.

| Job | Language | build-mode |
|---|---|---|
| `analyze-go` | `go` | `autobuild` (Go has no buildless mode) |
| `analyze-typescript` | `javascript-typescript` | `none` |

Pinned to `jabrown93/ci/actions/codeql@63fdb13 # codeql-v1.0.0`. CodeQL is not a merge-gating check (fleet convention), so required status checks are unaffected. `ci:` commit → no release.

Note: the job check names change from the reusable-workflow form `analyze-go / analyze` to the bare `analyze-go` / `analyze-typescript`; these aren't required contexts, so no branch-protection change is needed.
