### PR TITLE
fix(license): ship the MIT notice in the published image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,11 @@ COPY --from=frontend-builder /frontend/public /app/public
 # (the image's runtime) does the job instead.
 COPY docker/launcher.mjs /app/launcher.mjs
 
+# MIT requires the copyright and permission notice to ship with "all copies or
+# substantial portions of the Software" -- the published image is such a copy,
+# and the builder stages leave only compiled output behind.
+COPY LICENSE /app/LICENSE
+
 # Set environment variables
 ENV NODE_ENV=production
 ENV HOME=/tmp


### PR DESCRIPTION
## Why

`ghcr.io/jabrown93/aura` is publicly pullable, so the image is a distribution of upstream `mediux-team/AURA` code. MIT requires the copyright and permission notice to accompany "all copies or substantial portions of the Software", and a published image is such a copy.

The repo keeps `LICENSE` (Copyright (c) 2025 Moose) correctly, but the runtime stage copies only the compiled Go binary and the Next build output, so nothing carried the notice into the image.

## What

One line: `COPY LICENSE /app/LICENSE` in the final stage.

## Verification

Built `--target final` locally and pulled the file back out of the image (shell-less, so via `docker create` + `docker cp`):

```
MIT License

Copyright (c) 2025 Moose
```

Typed `fix(license)` so semantic-release cuts a patch and the corrected image actually gets published.

## Not covered here

The Go and npm dependency licenses are still unaccounted for in the image — the Go deps are statically linked into `main` with no notices, and Next's standalone tracing may drop `node_modules` `LICENSE` files. A generated third-party bundle (`go-licenses` + an npm equivalent) would close that; out of scope for this one-liner.

> Authored by Claude (AI agent) at the repo owner's direction. Not legal advice.

https://claude.ai/code/session_017qxZZoY24YG4y6KRePP6Zg