### PR TITLE
feat(auth): add OIDC sign-in to the UI and docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -36,7 +36,7 @@ Auth:
   Password: YOUR_ARGON2ID_HASH_HERE
 ```
 
-aura can also sign users in through an OpenID Connect provider such as [Authentik](https://goauthentik.io/) or Keycloak — see [Single Sign-On (OIDC)](oidc) for the full setup. Password and SSO sign-in can be enabled together, which keeps a way in when the provider is unavailable.
+aura can also sign users in through an OpenID Connect provider such as [Authentik](https://goauthentik.io/) or Keycloak — see [Single Sign-On (OIDC)](/AURA/oidc) for the full setup. Password and SSO sign-in can be enabled together, which keeps a way in when the provider is unavailable.
 
 While this password authentication method is effective, it is important to keep your password secure and not share it with others. For enhanced security, consider using solutions like [Authentik](https://goauthentik.io/), [Authelia](https://www.authelia.com/) or [Tinyauth](https://tinyauth.app/).  
 **I am not a security expert** 😅
@@ -61,7 +61,7 @@ While this password authentication method is effective, it is important to keep 
 ### OIDC
 
 - **Description**: Single sign-on through an OpenID Connect provider.
-- **Details**: Documented separately in [Single Sign-On (OIDC)](oidc).
+- **Details**: Documented separately in [Single Sign-On (OIDC)](/AURA/oidc).
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,6 +36,8 @@ Auth:
   Password: YOUR_ARGON2ID_HASH_HERE
 ```
 
+aura can also sign users in through an OpenID Connect provider such as [Authentik](https://goauthentik.io/) or Keycloak — see [Single Sign-On (OIDC)](oidc) for the full setup. Password and SSO sign-in can be enabled together, which keeps a way in when the provider is unavailable.
+
 While this password authentication method is effective, it is important to keep your password secure and not share it with others. For enhanced security, consider using solutions like [Authentik](https://goauthentik.io/), [Authelia](https://www.authelia.com/) or [Tinyauth](https://tinyauth.app/).  
 **I am not a security expert** 😅
 
@@ -54,6 +56,12 @@ While this password authentication method is effective, it is important to keep 
 - **Details**: This password is used to authenticate user when they log in to the application. It is recommended to use a strong, unique password for this purpose. You can generate a new Argon2id hash using tools like [Argon2 Online](https://argon2.online/). You can use the default settings.
   ![Argon2 Online](assets/argon2-online.png)
 - **Note**: Replace `YOUR_ARGON2ID_HASH_HERE` with the actual Argon2id hash of your desired password.
+- **Note**: The password may be left unset when `Auth.OIDC.Enabled` is `true`. Enabling authentication with neither a password nor OIDC is rejected as invalid, since it would leave the app unreachable.
+
+### OIDC
+
+- **Description**: Single sign-on through an OpenID Connect provider.
+- **Details**: Documented separately in [Single Sign-On (OIDC)](oidc).
 
 ---
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -126,12 +126,13 @@ Sign-in failures return you to the login page with a message. What each one mean
 
 | Message | Cause |
 | ------- | ----- |
-| Single sign-on is not enabled | `Auth.Enabled` or `Auth.OIDC.Enabled` is `false` |
-| The identity provider could not be reached or refused the sign-in | Discovery failed (wrong `IssuerURL`, DNS, TLS) or the provider denied the request |
-| The sign-in attempt expired or did not match | More than 10 minutes elapsed, or cookies were dropped between the two requests |
-| The identity provider rejected the authorization code | Wrong `ClientSecret`, or a `RedirectURL` that differs from the registered one |
-| The identity token could not be verified | Signature, issuer, audience or nonce mismatch |
-| Your account is not permitted to access aura | The user matched none of the configured allowlists |
+| Single sign-on is not enabled. | `Auth.Enabled` or `Auth.OIDC.Enabled` is `false` |
+| The identity provider could not be reached or refused the sign-in. | Discovery failed (wrong `IssuerURL`, DNS, TLS) or the provider denied the request |
+| The sign-in attempt expired or did not match. Please try again. | More than 10 minutes elapsed, or cookies were dropped between the two requests |
+| The identity provider rejected the authorization code. | Wrong `ClientSecret`, or a `RedirectURL` that differs from the registered one |
+| The identity token could not be verified. | Signature, issuer, audience or nonce mismatch, or an ID token with no subject |
+| Your account is not permitted to access aura. | The user matched none of the configured allowlists |
+| Something went wrong while completing sign-in. | aura could not issue a session, e.g. its signing key was unavailable |
 
 The backend log carries the underlying reason for each — the login page deliberately shows a fixed message rather than the provider's own text.
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,0 +1,138 @@
+---
+layout: default
+title: "Single Sign-On (OIDC)"
+nav_order: 6
+description: "Signing in to aura with an OpenID Connect identity provider."
+permalink: /oidc
+---
+
+# Single Sign-On (OIDC)
+
+aura can hand sign-in over to an OpenID Connect provider such as Authentik, Keycloak, Auth0, Okta or Google. It acts as a **confidential client** using the authorization code flow with PKCE: the code exchange and token verification happen in the backend, and the browser only ever receives an `HttpOnly` session cookie.
+
+Password sign-in and SSO are independent. Leaving the password hash configured alongside OIDC gives you a way in when the provider is unavailable.
+
+---
+
+## 1. Register aura with your provider
+
+Create a **confidential** (client secret) application using the **authorization code** flow, and set the redirect URI to your external aura URL followed by `/api/auth/oidc/callback`:
+
+```
+https://aura.example.com/api/auth/oidc/callback
+```
+
+If you enable [single logout](#end-provider-session-on-logout), also allow this post-logout redirect URI:
+
+```
+https://aura.example.com/login
+```
+
+Provider-specific notes:
+
+| Provider  | Issuer URL |
+| --------- | ---------- |
+| Authentik | `https://auth.example.com/application/o/<application-slug>/` |
+| Keycloak  | `https://keycloak.example.com/realms/<realm>` |
+| Auth0     | `https://<tenant>.auth0.com/` |
+| Google    | `https://accounts.google.com` |
+
+To receive groups, the provider must be configured to emit them: Authentik needs the `groups` scope mapping on the application, and Keycloak needs a group membership mapper adding the `groups` claim to the ID token.
+
+---
+
+## 2. Configure aura
+
+Through **Settings → Authentication → Single Sign-On**, or directly in `config.yaml`:
+
+```yaml
+Auth:
+  Enabled: true
+  Password: YOUR_ARGON2ID_HASH_HERE # optional once OIDC is enabled, but keep it for break-glass access
+  OIDC:
+    Enabled: true
+    IssuerURL: https://auth.example.com/application/o/aura/
+    ClientID: aura
+    ClientSecret: YOUR_CLIENT_SECRET_HERE
+    RedirectURL: https://aura.example.com/api/auth/oidc/callback
+    Scopes: [openid, profile, email, groups]
+    GroupsClaim: groups
+    AllowedGroups: [aura-users]
+    ButtonLabel: "Sign in with Authentik"
+    RPInitiatedLogout: true
+```
+
+### Enabled
+
+- **Default**: `false`
+- **Description**: Whether the login page offers SSO. `Auth.Enabled` must also be `true`.
+
+### IssuerURL
+
+- **Description**: The provider's issuer. aura appends `/.well-known/openid-configuration` to discover the endpoints and signing keys, so no other URL needs configuring.
+- **Note**: Discovery happens the first time someone signs in, not at startup — aura still boots when the provider is down.
+
+### ClientID / ClientSecret
+
+- **Description**: The credentials issued when you registered the application.
+- **Note**: The secret is masked (`***abcd`) in the settings UI and in API responses. Saving the masked value leaves the stored secret untouched; paste a new value to replace it.
+
+### RedirectURL
+
+- **Description**: The callback registered with your provider, as an absolute URL.
+- **Details**: This is never derived from the incoming request — the `Host` header is client-controlled, so guessing it would let a malicious host redirect sign-ins elsewhere. Behind a reverse proxy, use the external URL your users type.
+
+### Scopes
+
+- **Default**: `openid, profile, email`
+- **Description**: Scopes to request. `openid` is always included. Add whatever scope carries group membership if you intend to restrict by group (`groups` for Authentik and Keycloak).
+
+### GroupsClaim
+
+- **Default**: `groups`
+- **Description**: Which ID token claim holds group membership. The value may be a list or a single string.
+
+### AllowedGroups / AllowedEmails / AllowedSubjects
+
+- **Default**: empty
+- **Description**: Who may sign in.
+- **Details**: With **every** list empty, any user your provider authenticates is allowed in — which is the right setting when the provider already controls who can open the application. With **any** list set, the user must match at least one entry across the three lists. Matching ignores case.
+
+### ButtonLabel
+
+- **Default**: `Sign in with SSO`
+- **Description**: The label on the login page button.
+
+### End Provider Session on Logout
+
+- **Config key**: `RPInitiatedLogout`
+- **Default**: `false`
+- **Description**: After clearing the local session, send the browser to the provider's `end_session_endpoint` so it signs you out there too.
+- **Details**: aura does not retain the provider's ID token, so the request identifies itself with `client_id` and `post_logout_redirect_uri` rather than `id_token_hint`. Providers that require the post-logout URL to be registered need `https://aura.example.com/login` allowlisted.
+
+---
+
+## Sessions
+
+A successful sign-in issues aura's own session token, valid for 24 hours, in an `HttpOnly`, `SameSite=Lax` cookie. The `Secure` flag is set when the request arrives over HTTPS, directly or via `X-Forwarded-Proto`.
+
+The session is **not** refreshed from the provider: revoking a user at the identity provider does not end an aura session already in progress; it takes effect within 24 hours, when the session expires and the user has to sign in again.
+
+---
+
+## Troubleshooting
+
+Sign-in failures return you to the login page with a message. What each one means:
+
+| Message | Cause |
+| ------- | ----- |
+| Single sign-on is not enabled | `Auth.Enabled` or `Auth.OIDC.Enabled` is `false` |
+| The identity provider could not be reached or refused the sign-in | Discovery failed (wrong `IssuerURL`, DNS, TLS) or the provider denied the request |
+| The sign-in attempt expired or did not match | More than 10 minutes elapsed, or cookies were dropped between the two requests |
+| The identity provider rejected the authorization code | Wrong `ClientSecret`, or a `RedirectURL` that differs from the registered one |
+| The identity token could not be verified | Signature, issuer, audience or nonce mismatch |
+| Your account is not permitted to access aura | The user matched none of the configured allowlists |
+
+The backend log carries the underlying reason for each — the login page deliberately shows a fixed message rather than the provider's own text.
+
+**Locked out?** Set `Auth.Enabled: false` (or fix `Auth.Password`) in `config.yaml` and restart the container.

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { AttemptLogin, GetAuthMethods, GetSession } from "@/services/auth/login";
-import { Eye, EyeOff, Loader2, Lock } from "lucide-react";
+import type { AuthMethods_Response } from "@/services/auth/login";
+import { AttemptLogin, GetAuthMethods, GetSession, OIDC_LOGIN_PATH } from "@/services/auth/login";
+import { Eye, EyeOff, KeyRound, Loader2, Lock } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
@@ -13,24 +14,47 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+// The OIDC callback redirects here with a code rather than provider text, so the wording
+// stays under our control.
+const OIDC_ERRORS: Record<string, string> = {
+  oidc_disabled: "Single sign-on is not enabled.",
+  oidc_provider: "The identity provider could not be reached or refused the sign-in.",
+  oidc_state: "The sign-in attempt expired or did not match. Please try again.",
+  oidc_exchange: "The identity provider rejected the authorization code.",
+  oidc_verify: "The identity token could not be verified.",
+  oidc_forbidden: "Your account is not permitted to access aura.",
+  oidc_internal: "Something went wrong while completing sign-in.",
+};
+
 export default function LoginPage() {
   const router = useRouter();
   const [password, setPassword] = useState("");
   const [showPw, setShowPw] = useState(false);
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [methods, setMethods] = useState<AuthMethods_Response | null>(null);
+
+  // Surface a failed OIDC round trip. Read from the URL directly rather than through
+  // useSearchParams, which would force this page behind a Suspense boundary.
+  useEffect(() => {
+    const code = new URLSearchParams(window.location.search).get("error");
+    if (code) {
+      setErrorMsg(OIDC_ERRORS[code] ?? "Sign-in failed.");
+    }
+  }, []);
 
   // The session cookie is HttpOnly, so auth state has to come from the backend.
   useEffect(() => {
     let cancelled = false;
 
     const redirectIfSignedIn = async () => {
-      const methods = await GetAuthMethods();
+      const response = await GetAuthMethods();
       if (cancelled) return;
-      if (methods.data && !methods.data.auth_enabled) {
+      if (response.data && !response.data.auth_enabled) {
         router.replace("/");
         return;
       }
+      setMethods(response.data ?? null);
 
       const session = await GetSession();
       if (!cancelled && session.data?.authenticated) {
@@ -43,6 +67,10 @@ export default function LoginPage() {
       cancelled = true;
     };
   }, [router]);
+
+  // Until the methods load, assume a password form: it is what every existing install has.
+  const passwordEnabled = methods?.password_enabled ?? true;
+  const oidcEnabled = methods?.oidc_enabled ?? false;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -72,50 +100,80 @@ export default function LoginPage() {
           <CardTitle className="flex items-center gap-2 text-2xl">
             <Lock className="h-6 w-6" /> Sign In
           </CardTitle>
-          <CardDescription>Enter your password to access aura.</CardDescription>
+          <CardDescription>
+            {passwordEnabled
+              ? "Enter your password to access aura."
+              : "Sign in with your identity provider to access aura."}
+          </CardDescription>
         </CardHeader>
-        <form onSubmit={handleSubmit}>
-          <CardContent className="space-y-4">
-            {errorMsg && (
-              <Alert variant="destructive">
-                <AlertTitle>Error</AlertTitle>
-                <AlertDescription>{errorMsg}</AlertDescription>
-              </Alert>
-            )}
-            <div className="mb-4">
-              <Label className="mb-2 font-medium" htmlFor="password">
-                Password
-              </Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  type={showPw ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete="current-password"
-                  placeholder="••••••••"
-                  disabled={loading}
-                  className="pr-10" // add padding so text doesn't run under the icon
-                />
-                <Button
-                  variant="ghost"
-                  onClick={() => setShowPw(!showPw)}
-                  aria-label={showPw ? "Hide password" : "Show password"}
-                  className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  disabled={loading}
-                >
-                  {showPw ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </Button>
-              </div>
-            </div>
+
+        {errorMsg && (
+          <CardContent>
+            <Alert variant="destructive">
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{errorMsg}</AlertDescription>
+            </Alert>
           </CardContent>
-          <CardFooter className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {loading ? "Signing In..." : "Sign In"}
+        )}
+
+        {oidcEnabled && (
+          <CardContent className="space-y-4">
+            {/* A full navigation, not a fetch: the browser has to follow the redirect
+                chain to the provider and back. */}
+            <Button asChild variant="outline" className="w-full">
+              <a href={OIDC_LOGIN_PATH}>
+                <KeyRound className="mr-2 h-4 w-4" />
+                {methods?.oidc_button_label || "Sign in with SSO"}
+              </a>
             </Button>
-          </CardFooter>
-        </form>
+            {passwordEnabled && (
+              <div className="flex items-center gap-3">
+                <span className="h-px flex-1 bg-border" />
+                <span className="text-xs text-muted-foreground uppercase">or</span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+            )}
+          </CardContent>
+        )}
+
+        {passwordEnabled && (
+          <form onSubmit={handleSubmit}>
+            <CardContent className="space-y-4">
+              <div className="mb-4">
+                <Label className="mb-2 font-medium" htmlFor="password">
+                  Password
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="password"
+                    type={showPw ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    autoComplete="current-password"
+                    placeholder="••••••••"
+                    disabled={loading}
+                    className="pr-10" // add padding so text doesn't run under the icon
+                  />
+                  <Button
+                    variant="ghost"
+                    onClick={() => setShowPw(!showPw)}
+                    aria-label={showPw ? "Hide password" : "Show password"}
+                    className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    disabled={loading}
+                  >
+                    {showPw ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3">
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {loading ? "Signing In..." : "Sign In"}
+              </Button>
+            </CardFooter>
+          </form>
+        )}
       </Card>
     </div>
   );

--- a/frontend/src/components/layout/app-navbar.tsx
+++ b/frontend/src/components/layout/app-navbar.tsx
@@ -45,6 +45,21 @@ type AppNavbarProps = {
   version?: string;
 };
 
+/**
+ * Guards a full-page navigation to a URL the app did not compose itself. The provider's
+ * logout endpoint comes from its discovery document, so a malformed one must not be able
+ * to hand us a javascript: or data: URL.
+ */
+const externalNavigationURL = (raw?: string): string | undefined => {
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export function Navbar({ version = "dev" }: AppNavbarProps) {
   // Router
   const router = useRouter();
@@ -197,15 +212,24 @@ export function Navbar({ version = "dev" }: AppNavbarProps) {
 
   // Handle Logout
   const handleLogout = async () => {
-    // Whatever fails, the user still ends up signed out on the login page: a half-finished
-    // logout that leaves them looking at a stale page is the worse outcome.
+    // With OIDC single logout the provider has to end its session too, and that is a full
+    // navigation off this origin rather than a client-side route change.
+    let endSessionURL: string | undefined;
+
+    // Whatever fails, the user still ends up signed out: a half-finished logout that
+    // leaves them looking at a stale page is the worse outcome.
     try {
-      await Logout();
+      const resp = await Logout();
+      endSessionURL = externalNavigationURL(resp.data?.end_session_url);
       // Cached library/media data belongs to the session that just ended.
       await ClearAllStores();
     } finally {
       setIsAuthed(false);
-      router.replace("/login");
+      if (endSessionURL) {
+        window.location.href = endSessionURL;
+      } else {
+        router.replace("/login");
+      }
     }
   };
 

--- a/frontend/src/components/settings-onboarding/ConfigSectionAuth.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionAuth.tsx
@@ -10,17 +10,48 @@ import { Switch } from "@/components/ui/switch";
 
 import { cn } from "@/lib/cn";
 
-import type { AppConfigAuth } from "@/types/config/config";
+import type { AppConfigAuth, AppConfigOIDC } from "@/types/config/config";
 
 interface ConfigSectionAuthProps {
   value: AppConfigAuth;
   editing: boolean;
-  dirtyFields?: { enabled?: boolean; password?: boolean };
+  dirtyFields?: { enabled?: boolean; password?: boolean; oidc?: boolean };
   onChange: <K extends keyof AppConfigAuth>(field: K, value: AppConfigAuth[K]) => void;
   errorsUpdate?: (errors: Partial<Record<keyof AppConfigAuth, string>>) => void;
 }
 
 const hashRegex = /^\$argon2id\$v=\d+\$m=\d+,t=\d+,p=\d+\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/;
+
+const emptyOIDC: AppConfigOIDC = {
+  enabled: false,
+  issuer_url: "",
+  client_id: "",
+  client_secret: "",
+  redirect_url: "",
+  scopes: [],
+  groups_claim: "",
+  allowed_groups: [],
+  allowed_emails: [],
+  allowed_subjects: [],
+  button_label: "",
+  rp_initiated_logout: false,
+};
+
+/** Splits a comma or newline separated input into a trimmed list. */
+const parseList = (raw: string): string[] =>
+  raw
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+const isAbsoluteURL = (raw: string): boolean => {
+  try {
+    const parsed = new URL(raw);
+    return !!parsed.protocol && !!parsed.host;
+  } catch {
+    return false;
+  }
+};
 
 export const ConfigSectionAuth: React.FC<ConfigSectionAuthProps> = ({
   value,
@@ -30,21 +61,47 @@ export const ConfigSectionAuth: React.FC<ConfigSectionAuthProps> = ({
   errorsUpdate,
 }) => {
   const prevErrorRef = useRef<string>("");
+  const oidc = value.oidc ?? emptyOIDC;
+
+  const updateOIDC = <K extends keyof AppConfigOIDC>(field: K, fieldValue: AppConfigOIDC[K]) => {
+    onChange("oidc", { ...oidc, [field]: fieldValue });
+  };
 
   // Validation
   const errors = useMemo<Partial<Record<keyof AppConfigAuth, string>>>(() => {
     const errs: Partial<Record<keyof AppConfigAuth, string>> = {};
-    // Password Errors
-    if (value.enabled) {
-      const password = value.password.trim();
-      if (password.length === 0) {
-        errs.password = "Password hash is required when authentication is enabled.";
-      } else if (!hashRegex.test(password)) {
-        errs.password = "Invalid Argon2id hash format.";
+    if (!value.enabled) return errs;
+
+    // Password Errors. A password is optional once OIDC can sign users in, but leaving
+    // both off would make the app unreachable.
+    const password = value.password.trim();
+    if (password.length === 0) {
+      if (!oidc.enabled) {
+        errs.password = "Set a password hash or enable OpenID Connect when authentication is enabled.";
+      }
+    } else if (!hashRegex.test(password)) {
+      errs.password = "Invalid Argon2id hash format.";
+    }
+
+    // OIDC Errors
+    if (oidc.enabled) {
+      if (!oidc.issuer_url.trim()) {
+        errs.oidc = "Issuer URL is required.";
+      } else if (!isAbsoluteURL(oidc.issuer_url.trim())) {
+        errs.oidc = "Issuer URL must be a full URL, e.g. https://auth.example.com/application/o/aura/";
+      } else if (!oidc.client_id.trim()) {
+        errs.oidc = "Client ID is required.";
+      } else if (!oidc.client_secret.trim()) {
+        errs.oidc = "Client secret is required.";
+      } else if (!oidc.redirect_url.trim()) {
+        errs.oidc = "Redirect URL is required.";
+      } else if (!isAbsoluteURL(oidc.redirect_url.trim())) {
+        errs.oidc = "Redirect URL must be the full callback URL, e.g. https://aura.example.com/api/auth/oidc/callback";
       }
     }
+
     return errs;
-  }, [value.enabled, value.password]);
+  }, [value.enabled, value.password, oidc]);
 
   // Emit errors upward
   useEffect(() => {
@@ -116,6 +173,215 @@ export const ConfigSectionAuth: React.FC<ConfigSectionAuthProps> = ({
           </div>
           {errors.password && <p className="text-xs text-red-500">{errors.password}</p>}
         </div>
+      </div>
+
+      <div className={cn("border rounded-md p-3 space-y-3 transition", dirtyFields.oidc && "border-amber-500")}>
+        <div className="flex items-center justify-between">
+          <Label className="mr-2 text-base font-semibold">Single Sign-On (OpenID Connect)</Label>
+          <div className="flex items-center gap-2">
+            <Switch
+              disabled={!editing}
+              checked={oidc.enabled}
+              onCheckedChange={(checked) => updateOIDC("enabled", checked)}
+            />
+            {editing && (
+              <PopoverHelp ariaLabel="help-auth-oidc-enabled">
+                <p className="mb-2">
+                  Sign in through an identity provider such as Authentik, Keycloak, Auth0 or Google. Register aura as a
+                  confidential client with the authorization code flow.
+                </p>
+                <p>Leave the password hash set as well if you want a way in when the provider is unavailable.</p>
+              </PopoverHelp>
+            )}
+          </div>
+        </div>
+
+        {oidc.enabled && (
+          <>
+            <div>
+              <Label htmlFor="oidc-issuer">Issuer URL</Label>
+              <Input
+                id="oidc-issuer"
+                disabled={!editing}
+                placeholder="https://auth.example.com/application/o/aura/"
+                value={oidc.issuer_url}
+                onChange={(e) => updateOIDC("issuer_url", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="oidc-client-id">Client ID</Label>
+              <Input
+                id="oidc-client-id"
+                disabled={!editing}
+                value={oidc.client_id}
+                onChange={(e) => updateOIDC("client_id", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="oidc-client-secret">Client Secret</Label>
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-secret">
+                    <p>
+                      The stored secret is shown masked. Leave it as-is to keep it, or paste a new one to replace it.
+                    </p>
+                  </PopoverHelp>
+                )}
+              </div>
+              <Input
+                id="oidc-client-secret"
+                disabled={!editing}
+                type="text"
+                value={oidc.client_secret}
+                onChange={(e) => updateOIDC("client_secret", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="oidc-redirect">Redirect URL</Label>
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-redirect">
+                    <p>
+                      The callback registered with your provider. It must be the full external URL of this app followed
+                      by <code>/api/auth/oidc/callback</code>.
+                    </p>
+                  </PopoverHelp>
+                )}
+              </div>
+              <Input
+                id="oidc-redirect"
+                disabled={!editing}
+                placeholder="https://aura.example.com/api/auth/oidc/callback"
+                value={oidc.redirect_url}
+                onChange={(e) => updateOIDC("redirect_url", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="oidc-scopes">Scopes</Label>
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-scopes">
+                    <p>Comma separated. Defaults to openid, profile, email. openid is always requested.</p>
+                  </PopoverHelp>
+                )}
+              </div>
+              <Input
+                id="oidc-scopes"
+                disabled={!editing}
+                placeholder="openid, profile, email, groups"
+                value={(oidc.scopes ?? []).join(", ")}
+                onChange={(e) => updateOIDC("scopes", parseList(e.target.value))}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="oidc-groups-claim">Groups Claim</Label>
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-groups-claim">
+                    <p>Which ID token claim holds group membership. Defaults to groups.</p>
+                  </PopoverHelp>
+                )}
+              </div>
+              <Input
+                id="oidc-groups-claim"
+                disabled={!editing}
+                placeholder="groups"
+                value={oidc.groups_claim ?? ""}
+                onChange={(e) => updateOIDC("groups_claim", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="oidc-allowed-groups">Allowed Groups</Label>
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-allowlist">
+                    <p className="mb-2">
+                      Comma separated. Leave every allowlist empty to let anyone your provider authenticates in, which
+                      is the right choice when the provider already restricts who can open this application.
+                    </p>
+                    <p>If any list is filled in, a user must match at least one entry across the three lists.</p>
+                  </PopoverHelp>
+                )}
+              </div>
+              <Input
+                id="oidc-allowed-groups"
+                disabled={!editing}
+                placeholder="media-users, admins"
+                value={(oidc.allowed_groups ?? []).join(", ")}
+                onChange={(e) => updateOIDC("allowed_groups", parseList(e.target.value))}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="oidc-allowed-emails">Allowed Emails</Label>
+              <Input
+                id="oidc-allowed-emails"
+                disabled={!editing}
+                placeholder="you@example.com"
+                value={(oidc.allowed_emails ?? []).join(", ")}
+                onChange={(e) => updateOIDC("allowed_emails", parseList(e.target.value))}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="oidc-allowed-subjects">Allowed Subjects</Label>
+              <Input
+                id="oidc-allowed-subjects"
+                disabled={!editing}
+                value={(oidc.allowed_subjects ?? []).join(", ")}
+                onChange={(e) => updateOIDC("allowed_subjects", parseList(e.target.value))}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="oidc-button-label">Sign-In Button Label</Label>
+              <Input
+                id="oidc-button-label"
+                disabled={!editing}
+                placeholder="Sign in with SSO"
+                value={oidc.button_label ?? ""}
+                onChange={(e) => updateOIDC("button_label", e.target.value)}
+                className="w-full mt-1"
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label className="mr-2">End Provider Session on Logout</Label>
+              <div className="flex items-center gap-2">
+                <Switch
+                  disabled={!editing}
+                  checked={oidc.rp_initiated_logout}
+                  onCheckedChange={(checked) => updateOIDC("rp_initiated_logout", checked)}
+                />
+                {editing && (
+                  <PopoverHelp ariaLabel="help-auth-oidc-logout">
+                    <p>
+                      Sends you to the provider&apos;s logout endpoint after signing out here. The provider must accept
+                      the login page URL as a post-logout redirect.
+                    </p>
+                  </PopoverHelp>
+                )}
+              </div>
+            </div>
+
+            {errors.oidc && <p className="text-xs text-red-500">{errors.oidc}</p>}
+          </>
+        )}
       </div>
     </Card>
   );

--- a/frontend/src/components/settings-onboarding/ConfigSectionAuth.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionAuth.tsx
@@ -22,6 +22,12 @@ interface ConfigSectionAuthProps {
 
 const hashRegex = /^\$argon2id\$v=\d+\$m=\d+,t=\d+,p=\d+\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/;
 
+/**
+ * Mirrors the backend's masking of stored secrets. A masked value means "unchanged", so it
+ * must not be validated as if the user had typed it.
+ */
+const maskedSecretRegex = /^\*{3}[^*]+$/;
+
 const emptyOIDC: AppConfigOIDC = {
   enabled: false,
   issuer_url: "",
@@ -79,7 +85,7 @@ export const ConfigSectionAuth: React.FC<ConfigSectionAuthProps> = ({
       if (!oidc.enabled) {
         errs.password = "Set a password hash or enable OpenID Connect when authentication is enabled.";
       }
-    } else if (!hashRegex.test(password)) {
+    } else if (!maskedSecretRegex.test(password) && !hashRegex.test(password)) {
       errs.password = "Invalid Argon2id hash format.";
     }
 
@@ -144,7 +150,12 @@ export const ConfigSectionAuth: React.FC<ConfigSectionAuthProps> = ({
               {editing && (
                 <PopoverHelp ariaLabel="help-auth-password-hash">
                   <p className="mb-2">
-                    Provide an Argon2id hash. If authentication is enabled this hash must match the user's password.
+                    Provide an Argon2id hash. If authentication is enabled this hash must match the user&apos;s
+                    password.
+                  </p>
+                  <p className="mb-2">
+                    A stored hash is shown masked. Leave it as-is to keep it, paste a new hash to replace it, or clear
+                    the field to remove password sign-in once OIDC is enabled.
                   </p>
                   <p>
                     You can use a site like{" "}

--- a/frontend/src/services/auth/login.ts
+++ b/frontend/src/services/auth/login.ts
@@ -16,7 +16,12 @@ export interface Login_Response {
 export interface AuthMethods_Response {
   auth_enabled: boolean;
   password_enabled: boolean;
+  oidc_enabled: boolean;
+  oidc_button_label?: string;
 }
+
+/** Where the browser must navigate to start an OIDC sign-in. */
+export const OIDC_LOGIN_PATH = "/api/auth/oidc/login";
 
 export interface Session_Response {
   authenticated: boolean;
@@ -25,6 +30,8 @@ export interface Session_Response {
 
 export interface Logout_Response {
   logged_out: boolean;
+  /** Set when the provider session should be ended too; the UI navigates there. */
+  end_session_url?: string;
 }
 
 /**

--- a/frontend/src/types/config/config-default-app.ts
+++ b/frontend/src/types/config/config-default-app.ts
@@ -6,6 +6,20 @@ export const defaultAppConfig = (): AppConfig =>
     auth: {
       enabled: false,
       password: "",
+      oidc: {
+        enabled: false,
+        issuer_url: "",
+        client_id: "",
+        client_secret: "",
+        redirect_url: "",
+        scopes: [],
+        groups_claim: "",
+        allowed_groups: [],
+        allowed_emails: [],
+        allowed_subjects: [],
+        button_label: "",
+        rp_initiated_logout: false,
+      },
     },
     logging: {
       level: "",

--- a/frontend/src/types/config/config.ts
+++ b/frontend/src/types/config/config.ts
@@ -13,7 +13,7 @@ export interface AppConfig {
 
 export interface AppConfigAuth {
   enabled: boolean; // Whether authentication is enabled
-  password: string; // Hashed password for authentication
+  password: string; // Argon2id password hash; may be empty when OIDC is enabled. Returned masked.
   oidc: AppConfigOIDC; // Single sign-on via an OpenID Connect provider
 }
 

--- a/frontend/src/types/config/config.ts
+++ b/frontend/src/types/config/config.ts
@@ -14,6 +14,22 @@ export interface AppConfig {
 export interface AppConfigAuth {
   enabled: boolean; // Whether authentication is enabled
   password: string; // Hashed password for authentication
+  oidc: AppConfigOIDC; // Single sign-on via an OpenID Connect provider
+}
+
+export interface AppConfigOIDC {
+  enabled: boolean; // Whether OIDC sign-in is offered
+  issuer_url: string; // Provider issuer used for discovery
+  client_id: string; // Client ID registered with the provider
+  client_secret: string; // Client secret registered with the provider
+  redirect_url: string; // Callback URL registered with the provider
+  scopes?: string[]; // Scopes to request; "openid" is always included
+  groups_claim?: string; // ID token claim holding group membership
+  allowed_groups?: string[]; // Groups permitted to sign in
+  allowed_emails?: string[]; // Email addresses permitted to sign in
+  allowed_subjects?: string[]; // Subject identifiers permitted to sign in
+  button_label?: string; // Label for the sign-in button
+  rp_initiated_logout: boolean; // Whether logout also ends the provider session
 }
 
 export interface AppConfigLogging {


### PR DESCRIPTION
> Written by Claude Code (AI agent) on behalf of @jabrown93.

Third of three PRs adding OIDC support. **Stacked on #72** (which is stacked on #71) — the diff here is against `oidc-backend`.

## What changed

**Login page**
- Reads `/api/auth/methods` and renders the provider button, the password form, or both. While the methods are still loading it assumes a password form, which is what every existing install has.
- The SSO button is a plain `<a href="/api/auth/oidc/login">`, not a fetch — the browser has to follow the redirect chain to the provider and back.
- Callback failures arrive as `?error=<code>`, mapped to local wording. The backend deliberately never sends provider text for the page to display.

**Settings → Authentication**
- New Single Sign-On section: issuer, client ID/secret, redirect URL, scopes, groups claim, the three allowlists, button label, and single logout.
- The password hash is no longer required once OIDC is enabled, matching the backend's validation. Leaving both off is still an error.
- The client secret arrives masked and round-trips as "unchanged" unless you paste a new value; the help text says so.

**Logout**
- Follows the provider's end-session URL when single logout is configured, otherwise routes to `/login` as before.

**Docs**
- New [Single Sign-On (OIDC)](docs/oidc.md) page: provider registration (Authentik, Keycloak, Auth0, Google issuer URLs), every config key, session semantics, and a troubleshooting table mapping each login-page message to its cause. `config.md` links to it.

## Worth knowing

The docs state plainly that revoking a user at the provider does not end an aura session already in progress — sessions are aura's own and last 24 hours. If that is not acceptable for your setup, the fix is a shorter `SessionTTL`, not something this PR papers over.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
- Not click-tested in a browser against a real provider; there is no frontend test runner in this repo. The rendering paths (password only, SSO only, both) are driven entirely by the `/api/auth/methods` response, which is covered by backend tests.

https://claude.ai/code/session_01LwBKMigusDq7TwVou9HCv6