### PR TITLE
docs: caveman-compress CLAUDE.md and track backend/frontend guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,26 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repo.
 
 ## What this is
 
-**aura** (Automated Utility for Retrieval of Assets) is a tool for browsing MediUX image sets and applying them to a media server (Plex, Emby, or Jellyfin). It ships as a single Docker image running two processes: a Go REST API backend (`backend/`, port 8888) and a Next.js web UI (`frontend/`, port 3000). There is no separate database service — state lives in a local SQLite file under the config directory.
+**aura** (Automated Utility for Retrieval of Assets) browses MediUX image sets, applies them to media server (Plex, Emby, or Jellyfin). Ships as single Docker image, two processes: Go REST API backend (`backend/`, port 8888) and Next.js web UI (`frontend/`, port 3000). No separate database service — state lives in local SQLite file under config directory.
 
 ## Commands
 
-There is no Makefile. Run tooling directly from each subproject; see `frontend/CLAUDE.md` and `backend/CLAUDE.md` for per-side commands.
+No Makefile. Run tooling directly from each subproject; see `frontend/CLAUDE.md` and `backend/CLAUDE.md` for per-side commands.
 
 ### Full stack
-- `docker compose up` (see `docker-compose.yml`) or build the multi-stage `Dockerfile` with `--build-arg APP_VERSION=$(cat VERSION.txt)`.
+- `docker compose up` (see `docker-compose.yml`) or build multi-stage `Dockerfile` with `--build-arg APP_VERSION=$(cat VERSION.txt)`.
 
 ### Git hooks (enable manually)
-Hooks live in `.githooks/` but are **not** wired up by default. Enable with `git config core.hooksPath .githooks`. They enforce:
+Hooks live in `.githooks/`, **not** wired up by default. Enable with `git config core.hooksPath .githooks`. Enforce:
 - **commit-msg**: Conventional Commits (`feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`, optional scope/`!`). Required for all commits here.
 - **pre-commit**: frontend lint + typecheck + format when `frontend/` changes; regenerates Swagger docs when swagger-relevant backend files change.
 
 ## Release & CI
 
-- Version is a single source: `VERSION.txt` (e.g. `v0.9.100`), mirrored in `version.json`. It's baked into both binaries at build time (`-X main.APP_VERSION` for Go; `NEXT_PUBLIC_APP_VERSION` for Next).
+- Version single source: `VERSION.txt` (e.g. `v0.9.100`), mirrored in `version.json`. Baked into both binaries at build time (`-X main.APP_VERSION` for Go; `NEXT_PUBLIC_APP_VERSION` for Next).
 - `.github/workflows/aura.yml` (stable) and `aura-beta.yml` build/push multi-arch Docker images to GHCR + Docker Hub on push to `master` touching `backend/**`, `frontend/**`, or `VERSION.txt`.
 - Version suffixed `dev` enables backend dev-mode logging (`main.go#init`).
-- Docs are a Jekyll site under `docs/` published via `jekyll-gh-pages.yml`.
+- Docs: Jekyll site under `docs/`, published via `jekyll-gh-pages.yml`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md (backend)
+
+## Commands
+
+- `go build .` or `go run .` — **requires `CGO_ENABLED=1`** (SQLite via `mattn/go-sqlite3` needs cgo). Reads/writes config at `/config` default; override with `CONFIG_PATH=<dir>` for local runs.
+- `sh generate_go_docs.sh` — regenerates Swagger docs into `api-docs/` via `swag init`. Run after changing routes/handlers/models; pre-commit hook does automatically for swagger-relevant changes.
+
+## Architecture
+
+### Staged startup with hot router swap (`main.go` + `startup.go`)
+API serves *immediately* with onboarding-only routes; background goroutine runs init pipeline. Active router held in `atomic.Value` (`activeHandler`), swapped atomically once app ready. Pipeline three stages:
+1. **Bootstrap** — load `config.yaml`, validate.
+2. **PreFlight** — test media-server connection, validate MediUX token (sets `config.MediaServerValid` / `config.MediuxValid`).
+3. **Warmup** — preload in-memory caches, init DB + run migrations, VACUUM, register cron jobs, start Plex WebSocket listener.
+
+Config missing/invalid: router stays on onboarding routes. `routing.OnboardingComplete` = callback fired when user finishes onboarding through UI; re-runs preflight/warmup, swaps to full routes. `config.AppLoadingStep` = global string UI polls for boot progress.
+
+### Routing (`routing/`)
+`chi/v5`. `routes.go#AddRoutes` gates everything: `config.Loaded && config.Valid` false means **only** onboarding routes. Otherwise mounts full `/api` tree. Auth model:
+- **Public**: `/api/login`, `/api/search`, `/api/sonarr/webhook`.
+- **Protected**: everything else, behind `jwtauth.Verifier` + `middleware.Authenticator` (JWT HS256, `go-chi/jwtauth`). Passwords hashed with argon2id.
+
+Each route group delegates to sibling handler package (`routing/config`, `routing/download`, `routing/mediaserver`, etc.). HTTP response helpers in `utils/httpx`.
+
+### Media-server abstraction (`mediaserver/`)
+`MediaServerInterface` (in `mediaserver.go`) = seam over three servers. Implementations: `mediaserver/plex` and `mediaserver/ej` (shared Emby/Jellyfin). Dispatch = `switch cfg.Type` on `"Plex"` / `"Jellyfin","Emby"`. Some capabilities Plex-exclusive (labels, ratings, event listener). **Adding media-server operation: add to interface, implement in both `plex` and `ej`.** `sonarr-radarr/` follows same interface pattern (`SonarrRadarrInterface`, `SonarrApp`/`RadarrApp`).
+
+### MediUX client (`mediux/`)
+Talks to MediUX over **GraphQL**. Queries stored as `.graphql` files (`gen_*.graphql`), executed through `make_request.go`. Handles image download/URL resolution, preloading users/items-with-sets into cache.
+
+### Caching (`cache/`)
+In-memory stores populated during warmup, refreshed by cron: `LibraryStore` (sections + items), `CollectionsStore`, plus MediUX items/users. Handlers read from these, not media server per request.
+
+### Background jobs (`jobs/`)
+`robfig/cron/v3`. Always-on jobs (download queue, refresh media items/collections, refresh MediUX users, check MediUX site link, check media-item changes, handle temp-ignored items) plus configurable auto-download job (cron from config). `cron.go` owns scheduler + job-ID bookkeeping.
+
+### Database (`database/`)
+SQLite. Files prefixed `sqlite_*` by concern. Schema evolution via **hand-written numbered migrations** in `database/migration/` (`sqlite_migration_vN_vN+1.go`), run during warmup for existing DBs. DB tracks saved image sets, ignored items, auto-download selections, schema version row.
+
+### Config (`config/`)
+Single `Config` struct (`config.go`) serialized to `/config/config.yaml`. Split across `load.go`, `save.go`, `validate.go`, `defaults.go`, and `sanitize.go`/`masking.go` (latter redact secrets before logging/returning config). Global `config.Current` holds live config plus status flags (`Loaded`, `Valid`, `MediaServerValid`, `MediuxValid`, `AppFullyLoaded`).
+
+> Adding notification template touches **7 files** — see checklist comment on `Config_NotificationTemplate` in `config/config.go` (defaults, template_variables, validate, routing/config/update, routing/validation/notification, utils/variable_filler, frontend settings component).
+
+### Logging & error convention (`logging/`)
+Structured logging via `zerolog`. **Functions return `logging.LogErrorInfo` (struct), not Go `error`.** Callers check `Err.Message != ""`, not `err != nil`. Work wrapped in "logging context" with nested actions/sub-actions (`ld.AddAction`, `AddSubActionToContext`, `logAction.Complete()`, `logAction.SetError(...)`). Follow this pattern in new backend code, not idiomatic `error` returns.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md (frontend)
+
+## Commands
+
+- `npm run dev` — dev server :3000 (version from `../VERSION.txt`, proxies `/api/*` to `localhost:8888`)
+- `npm run build` — production build (Next standalone output)
+- `npm run lint` / `npm run lint:fix` — ESLint (pre-commit uses `--max-warnings=0`)
+- `npm run typecheck` — `tsc --noEmit`
+- `npm run format` / `npm run format:check` — Prettier (import-sorting plugin)
+
+No frontend test runner.
+
+## Architecture
+
+- **API access** (`src/services/`): one module per backend area (`auth`, `config`, `database`, `downloads`, `images`, `jobs`, `mediaserver`, `mediux`, `search`, ...), all on `services/api-client.ts` (axios, `baseURL: /api`). Client injects JWT from `localStorage["aura-auth-token"]` as Bearer header, redirects to `/login` on 401. In dev, `/api/*` rewritten to `http://localhost:8888` by `next.config.ts`.
+- **State** (`src/lib/stores/`): Zustand. `global-store-*` = cross-app state (library sections, media, collections, poster sets, onboarding, user preferences); `page-store-*` = per-page state. `clear-all-stores.ts` resets on logout.
+- `@/*` path alias → `src/*`. Shared helpers in `src/helper/`, types in `src/types/` (mirrors backend models).


### PR DESCRIPTION
- Compress root `CLAUDE.md` prose (caveman-compress): 1883 → 1752 chars. Code blocks, commands, paths, and technical terms untouched.
- Track previously untracked `backend/CLAUDE.md` and `frontend/CLAUDE.md` (compressed: 4893 → 4588 and 1276 → 1211 chars) so per-side agent guidance ships with the repo.

Originals backed up locally under `~/.local/share/caveman-compress/backups/`.

_This PR was authored by an AI agent (Claude)._

https://claude.ai/code/session_011CGFeXQScE14vYQKx3T7hd