### PR TITLE
chore(deps): migrate websocket client from gorilla/websocket to coder/websocket

### DIFF
--- a/backend/download/auto/websocket-mediux.go
+++ b/backend/download/auto/websocket-mediux.go
@@ -8,14 +8,14 @@ import (
 	"aura/models"
 	"aura/utils"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 )
 
 const (
@@ -37,6 +37,8 @@ func StartMediuxWebSocketClient() {
 }
 
 func connectAndSubscribeMediux() error {
+	ctx := context.Background()
+
 	// Build WebSocket URL with token
 	URL, err := buildMediuxWebSocketURL()
 	if err != nil {
@@ -48,12 +50,13 @@ func connectAndSubscribeMediux() error {
 	logging.LOGGER.Info().Timestamp().Str("url", maskedURL).
 		Msg("Mediux Event Listener: Connecting to Mediux WebSocket")
 
-	// Connect to WebSocket
-	c, _, err := websocket.DefaultDialer.Dial(URL, nil)
+	// Connect to WebSocket. Compression is disabled to preserve the wire behavior of the
+	// previous gorilla/websocket client, which never negotiated permessage-deflate here.
+	c, _, err := websocket.Dial(ctx, URL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
 	if err != nil {
 		return fmt.Errorf("failed to connect to Mediux WebSocket at %s: %w", maskedURL, err)
 	}
-	defer c.Close()
+	defer c.CloseNow()
 
 	collectionType := "show_sets"
 	subscribeMsg := map[string]any{
@@ -61,23 +64,16 @@ func connectAndSubscribeMediux() error {
 		"collection": collectionType,
 	}
 
-	if err := c.WriteJSON(subscribeMsg); err != nil {
+	if err := wsjson.Write(ctx, c, subscribeMsg); err != nil {
 		return err
 	}
 	logging.LOGGER.Debug().Timestamp().Str("collection", collectionType).Msg("Subscribed to Mediux WebSocket collection")
 
 	// Listen for messages until error/close
 	for {
-		_, message, err := c.ReadMessage()
-		if err != nil {
-			return err
-		}
-
-		// Decode message
 		var msg MediuxWebSocketResponseMessage
-		if err := json.Unmarshal(message, &msg); err != nil {
-			logging.LOGGER.Error().Timestamp().Err(err).Msg("Failed to unmarshal WebSocket message")
-			continue
+		if err := wsjson.Read(ctx, c, &msg); err != nil {
+			return err
 		}
 
 		// Handle Ping messages
@@ -85,7 +81,7 @@ func connectAndSubscribeMediux() error {
 			pongMsg := map[string]string{
 				"type": "pong",
 			}
-			if err := c.WriteJSON(pongMsg); err != nil {
+			if err := wsjson.Write(ctx, c, pongMsg); err != nil {
 				logging.LOGGER.Error().Timestamp().Err(err).Msg("Failed to send pong message")
 			}
 			continue

--- a/backend/download/auto/websocket-mediux.go
+++ b/backend/download/auto/websocket-mediux.go
@@ -52,11 +52,20 @@ func connectAndSubscribeMediux() error {
 
 	// Connect to WebSocket. Compression is disabled to preserve the wire behavior of the
 	// previous gorilla/websocket client, which never negotiated permessage-deflate here.
-	c, _, err := websocket.Dial(ctx, URL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
+	// Bound the handshake with a timeout (gorilla's DefaultDialer imposed 45s) so a stalled
+	// TCP/TLS handshake can't block this goroutine forever.
+	dialCtx, cancelDial := context.WithTimeout(ctx, 45*time.Second)
+	c, _, err := websocket.Dial(dialCtx, URL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
+	cancelDial()
 	if err != nil {
 		return fmt.Errorf("failed to connect to Mediux WebSocket at %s: %w", maskedURL, err)
 	}
 	defer c.CloseNow()
+
+	// coder/websocket defaults to a 32KiB per-message read limit; gorilla imposed none here.
+	// Raise it generously rather than disabling it outright, so a large update payload can't
+	// be truncated/dropped.
+	c.SetReadLimit(4 << 20)
 
 	collectionType := "show_sets"
 	subscribeMsg := map[string]any{

--- a/backend/download/auto/websocket-mediux.go
+++ b/backend/download/auto/websocket-mediux.go
@@ -58,7 +58,7 @@ func connectAndSubscribeMediux() error {
 	c, _, err := websocket.Dial(dialCtx, URL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
 	cancelDial()
 	if err != nil {
-		return fmt.Errorf("failed to connect to Mediux WebSocket at %s: %w", maskedURL, err)
+		return fmt.Errorf("failed to connect to Mediux WebSocket at %s: %w", maskedURL, sanitizeWSDialError(err, URL, maskedURL))
 	}
 	defer c.CloseNow()
 

--- a/backend/download/auto/websocket-plex.go
+++ b/backend/download/auto/websocket-plex.go
@@ -121,11 +121,27 @@ func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 
 	// Connect to WebSocket. Compression is disabled to preserve the wire behavior of the
 	// previous gorilla/websocket client, which never negotiated permessage-deflate here.
-	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
+	// Bound the handshake with a timeout (gorilla's DefaultDialer imposed 45s) so a stalled
+	// TCP/TLS handshake can't block this goroutine forever.
+	dialCtx, cancelDial := context.WithTimeout(ctx, 45*time.Second)
+	conn, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
+	cancelDial()
 	if err != nil {
+		select {
+		case <-stop:
+			// stop was closed while the dial was in flight; this is a clean shutdown,
+			// not a connection failure.
+			return nil
+		default:
+		}
 		return fmt.Errorf("failed to connect to Plex WebSocket at %s: %w", wsURLForLog, err)
 	}
 	defer conn.CloseNow()
+
+	// coder/websocket defaults to a 32KiB per-message read limit; gorilla imposed none here.
+	// Raise it generously rather than disabling it outright, so a busy library emitting many
+	// batched timeline entries in one notification can't be truncated/dropped.
+	conn.SetReadLimit(4 << 20)
 
 	logging.LOGGER.Info().Timestamp().
 		Msg("Plex Event Listener: Connected — watching for metadata refresh events")

--- a/backend/download/auto/websocket-plex.go
+++ b/backend/download/auto/websocket-plex.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
 
 const (
@@ -94,7 +94,10 @@ func StartOrRestartPlexWebSocketClient() {
 	}(stopChan)
 }
 
-// connectAndListenPlexWithStop is like connectAndListenPlex but returns early if stop is closed.
+// connectAndListenPlexWithStop connects to the Plex WebSocket and blocks until either the
+// connection errors (including on a 60s read idle-timeout, which drives the reconnect
+// cadence in StartOrRestartPlexWebSocketClient) or stop is closed, in which case it returns
+// a nil error to signal a clean shutdown rather than a connection failure.
 func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 	wsURL, wsURLForLog, err := buildPlexWebSocketURL()
 	if err != nil {
@@ -104,12 +107,25 @@ func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 	logging.LOGGER.Info().Timestamp().Str("url", wsURLForLog).
 		Msg("Plex Event Listener: Connecting to Plex WebSocket")
 
-	// Connect to WebSocket
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	// Derive a context from the stop channel so dial/read calls cancel promptly when the
+	// caller requests shutdown, instead of relying on a deadline-then-select pattern.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-stop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Connect to WebSocket. Compression is disabled to preserve the wire behavior of the
+	// previous gorilla/websocket client, which never negotiated permessage-deflate here.
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{CompressionMode: websocket.CompressionDisabled})
 	if err != nil {
 		return fmt.Errorf("failed to connect to Plex WebSocket at %s: %w", wsURLForLog, err)
 	}
-	defer conn.Close()
+	defer conn.CloseNow()
 
 	logging.LOGGER.Info().Timestamp().
 		Msg("Plex Event Listener: Connected — watching for metadata refresh events")
@@ -119,41 +135,19 @@ func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 		case <-stop:
 			return nil
 		default:
-			conn.SetReadDeadline(time.Now().Add(60 * time.Second))
-			_, message, err := conn.ReadMessage()
-			if err != nil {
-				return fmt.Errorf("error reading from Plex WebSocket: %w", err)
-			}
-			handleMessage(message)
 		}
-	}
-}
 
-func connectAndListenPlex() (err error) {
-	wsURL, wsURLForLog, err := buildPlexWebSocketURL()
-	if err != nil {
-		return err
-	}
-
-	logging.LOGGER.Info().Timestamp().Str("url", wsURLForLog).
-		Msg("Plex Event Listener: Connecting to Plex WebSocket")
-
-	// Connect to WebSocket
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to connect to Plex WebSocket at %s: %w", wsURLForLog, err)
-	}
-	defer conn.Close()
-
-	logging.LOGGER.Info().Timestamp().
-		Msg("Plex Event Listener: Connected — watching for metadata refresh events")
-
-	for {
-		_, message, err := conn.ReadMessage()
+		readCtx, cancelRead := context.WithTimeout(ctx, 60*time.Second)
+		_, message, err := conn.Read(readCtx)
+		cancelRead()
 		if err != nil {
+			if ctx.Err() != nil {
+				// stop was closed while the read was in flight; this is a clean shutdown,
+				// not a connection error.
+				return nil
+			}
 			return fmt.Errorf("error reading from Plex WebSocket: %w", err)
 		}
-
 		handleMessage(message)
 	}
 }

--- a/backend/download/auto/websocket-plex.go
+++ b/backend/download/auto/websocket-plex.go
@@ -11,6 +11,7 @@ import (
 	"aura/utils"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"runtime/debug"
@@ -134,7 +135,7 @@ func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 			return nil
 		default:
 		}
-		return fmt.Errorf("failed to connect to Plex WebSocket at %s: %w", wsURLForLog, err)
+		return fmt.Errorf("failed to connect to Plex WebSocket at %s: %w", wsURLForLog, sanitizeWSDialError(err, wsURL, wsURLForLog))
 	}
 	defer conn.CloseNow()
 
@@ -166,6 +167,20 @@ func connectAndListenPlexWithStop(stop <-chan struct{}) (err error) {
 		}
 		handleMessage(message)
 	}
+}
+
+// sanitizeWSDialError strips the raw dial URL -- which may embed an API token
+// in its query string -- from a failed dial's error text, replacing it with
+// the already-masked URL used elsewhere for logging. net/http's *url.Error
+// embeds the full request URL verbatim in its Error() string regardless of
+// any masking applied to the surrounding log message, so wrapping the error
+// as-is would leak the token into the log/console independent of that
+// masking.
+func sanitizeWSDialError(err error, rawURL, maskedURL string) error {
+	if err == nil || rawURL == maskedURL {
+		return err
+	}
+	return errors.New(strings.ReplaceAll(err.Error(), rawURL, maskedURL))
 }
 
 func buildPlexWebSocketURL() (wsURL string, wsURLForLog string, err error) {

--- a/backend/download/auto/websocket-plex_test.go
+++ b/backend/download/auto/websocket-plex_test.go
@@ -1,0 +1,164 @@
+package autodownload
+
+import "testing"
+
+// These tests cover the pure Plex timeline-message parsing helpers only. The
+// dial/read/reconnect loop in connectAndListenPlexWithStop talks to a real Plex
+// server and isn't exercised here — see the migration PR notes for that gap.
+
+func TestIsCompletedMetadataState(t *testing.T) {
+	tests := []struct {
+		name          string
+		metadataState string
+		timelineState int
+		want          bool
+	}{
+		{"processed string state", "processed", 0, true},
+		{"finished string state", "finished", 0, true},
+		{"numeric state 5", "", 5, true},
+		{"in-progress numeric state", "", 2, false},
+		{"unrecognized string state", "queued", 2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCompletedMetadataState(tt.metadataState, tt.timelineState); got != tt.want {
+				t.Errorf("isCompletedMetadataState(%q, %d) = %v, want %v", tt.metadataState, tt.timelineState, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPlexRefreshMessage(t *testing.T) {
+	entry := map[string]any{
+		"metadataState": "processed",
+		"title":         "Some Show S01 E02",
+		"sectionID":     float64(7),
+		"type":          float64(4),
+		"itemID":        "12345",
+	}
+
+	msg, ok := buildPlexRefreshMessage(entry)
+	if !ok {
+		t.Fatalf("buildPlexRefreshMessage() returned ok=false, want true")
+	}
+	if msg.SectionID != 7 {
+		t.Errorf("SectionID = %d, want 7", msg.SectionID)
+	}
+	if msg.ItemType != "episode" {
+		t.Errorf("ItemType = %q, want %q", msg.ItemType, "episode")
+	}
+	if msg.ItemRatingKey != "12345" {
+		t.Errorf("ItemRatingKey = %q, want %q", msg.ItemRatingKey, "12345")
+	}
+
+	// A non-completed state should be filtered out.
+	entry["metadataState"] = "queued"
+	if _, ok := buildPlexRefreshMessage(entry); ok {
+		t.Errorf("buildPlexRefreshMessage() with queued state: ok = true, want false")
+	}
+
+	// Missing sectionID should be filtered out.
+	entry["metadataState"] = "processed"
+	delete(entry, "sectionID")
+	if _, ok := buildPlexRefreshMessage(entry); ok {
+		t.Errorf("buildPlexRefreshMessage() with no sectionID: ok = true, want false")
+	}
+}
+
+func TestBuildPlexRefreshMessageFromTyped(t *testing.T) {
+	entry := PlexTimelineEntry{
+		SectionID:     "3",
+		ItemID:        "999",
+		Type:          1,
+		Title:         "Some Movie",
+		State:         5,
+		MetadataState: "",
+	}
+
+	msg, ok := buildPlexRefreshMessageFromTyped(entry)
+	if !ok {
+		t.Fatalf("buildPlexRefreshMessageFromTyped() returned ok=false, want true")
+	}
+	if msg.ItemType != "movie" {
+		t.Errorf("ItemType = %q, want %q", msg.ItemType, "movie")
+	}
+	if msg.SectionID != 3 {
+		t.Errorf("SectionID = %d, want 3", msg.SectionID)
+	}
+}
+
+func TestExtractCompletedPlexRefreshes(t *testing.T) {
+	payload := []byte(`{
+		"NotificationContainer": {
+			"type": "timeline",
+			"TimelineEntry": [
+				{
+					"metadataState": "processed",
+					"sectionID": 7,
+					"ratingKey": "111",
+					"grandparentRatingKey": "222",
+					"grandparentTitle": "Some Show",
+					"parentIndex": 1,
+					"index": 2
+				},
+				{
+					"metadataState": "queued",
+					"sectionID": 7,
+					"ratingKey": "333"
+				}
+			]
+		}
+	}`)
+
+	refreshes, err := extractCompletedPlexRefreshes(payload)
+	if err != nil {
+		t.Fatalf("extractCompletedPlexRefreshes() error = %v", err)
+	}
+	if len(refreshes) != 1 {
+		t.Fatalf("len(refreshes) = %d, want 1", len(refreshes))
+	}
+
+	got := refreshes[0]
+	if got.EpisodeRatingKey != "111" {
+		t.Errorf("EpisodeRatingKey = %q, want %q", got.EpisodeRatingKey, "111")
+	}
+	if got.SeriesRatingKey != "222" {
+		t.Errorf("SeriesRatingKey = %q, want %q", got.SeriesRatingKey, "222")
+	}
+	if got.Subtitle != "Some Show S01 E02" {
+		t.Errorf("Subtitle = %q, want %q", got.Subtitle, "Some Show S01 E02")
+	}
+}
+
+func TestExtractShowTitleAndNormalizeTitle(t *testing.T) {
+	tests := []struct {
+		subtitle string
+		want     string
+	}{
+		{"The Show S01 E02", "The Show"},
+		{"The Show S01", "The Show"},
+		{"The Movie (2024)", "The Movie"},
+		{"The Movie 2024", "The Movie"},
+		{"Plain Title", "Plain Title"},
+	}
+
+	for _, tt := range tests {
+		if got := extractShowTitle(tt.subtitle); got != tt.want {
+			t.Errorf("extractShowTitle(%q) = %q, want %q", tt.subtitle, got, tt.want)
+		}
+	}
+
+	if got := normalizeTitle("The, Show!! 123"); got != "the show 123" {
+		t.Errorf("normalizeTitle() = %q, want %q", got, "the show 123")
+	}
+}
+
+func TestParseRatingKeyFromPath(t *testing.T) {
+	if got := parseRatingKeyFromPath("/library/metadata/456"); got != "456" {
+		t.Errorf("parseRatingKeyFromPath() = %q, want %q", got, "456")
+	}
+	if got := parseRatingKeyFromPath(""); got != "" {
+		t.Errorf("parseRatingKeyFromPath(\"\") = %q, want empty", got)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,10 +3,12 @@ module aura
 go 1.26.0
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-co-op/gocron/v2 v2.22.0
 	github.com/google/uuid v1.6.0
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/lestrrat-go/jwx/v3 v3.2.0
 	github.com/rs/zerolog v1.35.1
 	github.com/swaggo/http-swagger/v2 v2.0.2
@@ -29,7 +31,6 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.5 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.3.0 // indirect
 	github.com/lestrrat-go/dsig-secp256k1 v1.0.0 // indirect
@@ -50,7 +51,6 @@ require (
 	github.com/alexedwards/argon2id v1.0.0
 	github.com/go-chi/jwtauth/v5 v5.4.0
 	github.com/go-resty/resty/v2 v2.17.2
-	github.com/gorilla/websocket v1.5.3
 	github.com/gregdel/pushover v1.4.0
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -2,6 +2,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/alexedwards/argon2id v1.0.0 h1:wJzDx66hqWX7siL/SRUmgz3F8YMrd/nfX/xHHcQQP0w=
 github.com/alexedwards/argon2id v1.0.0/go.mod h1:tYKkqIjzXvZdzPvADMWOEZ+l6+BD6CtBXMj5fnJppiw=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
 github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,8 +54,6 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregdel/pushover v1.4.0 h1:P77WAJ2zPG+b0mEsmMjWGrPMuvhkh9k3v7OviwsoveE=
 github.com/gregdel/pushover v1.4.0/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER1PthX7to=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=


### PR DESCRIPTION
Closes #91

## Summary

Migrates both of AURA's websocket dial sites off `gorilla/websocket` onto [`coder/websocket`](https://github.com/coder/websocket) (v1.8.15), per the issue's recommendation. This is **a rewrite, not a mechanical swap** — coder/websocket's API is context-native (`Dial(ctx, ...)`, `conn.Read(ctx)`), replacing gorilla's deadline-based one (`SetReadDeadline` + blocking `ReadMessage()`), so both call sites needed their cancellation/timeout plumbing reworked, not just re-pointed at new function names.

- `backend/download/auto/websocket-plex.go` (`connectAndListenPlexWithStop`, the live path wired via `StartOrRestartPlexWebSocketClient`):
  - Dial now takes a `context.Context`, derived via `context.WithCancel` and canceled by a small goroutine watching the existing `stop <-chan struct{}`, replacing the old `select`-around-blocking-read pattern.
  - The 60s idle-timeout that drives the reconnect cadence is now a per-iteration `context.WithTimeout(ctx, 60*time.Second)` wrapped around `conn.Read(ctx)`, preserving the original timing behavior.
  - `conn.Close()` → `conn.CloseNow()` (closest 1:1 — no close-frame handshake, matching prior abrupt-close behavior).
  - Compression explicitly disabled (`CompressionMode: CompressionDisabled`) to preserve prior wire behavior — gorilla never negotiated permessage-deflate here, coder does by default.
  - **Deleted `connectAndListenPlex()`** — a no-stop variant with zero callers anywhere in the codebase. Flagging this explicitly since it's a deliberate cleanup bundled into this diff, not a silent removal.
- `backend/download/auto/websocket-mediux.go` (`connectAndSubscribeMediux`):
  - Same dial/compression treatment. `WriteJSON`/manual `ReadMessage`+`json.Unmarshal` replaced with `wsjson.Write`/`wsjson.Read` from `github.com/coder/websocket/wsjson`.
  - No stop channel existed before and none was added — threaded `context.Background()` through, per the issue scope (not inventing new shutdown machinery for a path with no existing one).
  - **Behavior note:** `wsjson.Read` closes the connection and returns an error on a JSON unmarshal failure, whereas the old code logged and kept the connection open. This is a minor semantic difference worth a reviewer's eye, though low risk since this listener isn't live (see below).
- `go.mod`/`go.sum`: `gorilla/websocket` fully removed (`go mod why github.com/gorilla/websocket` confirms the main module no longer needs it).
- Added `backend/download/auto/websocket-plex_test.go` covering the pure Plex timeline-parsing helpers (`buildPlexRefreshMessage`, `buildPlexRefreshMessageFromTyped`, `extractCompletedPlexRefreshes`, `isCompletedMetadataState`, `extractShowTitle`/`normalizeTitle`, `parseRatingKeyFromPath`) — this package had zero prior test coverage. The dial/read/reconnect loop itself isn't covered; it wasn't practical to test cleanly without a live/mock server within this change's scope.

## Notes for reviewers

- **The Mediux websocket listener is not live in production today** — its start call (`autodownload.StartMediuxWebSocketClient()`) is commented out in `backend/startup.go:252`. It was still migrated (not left on the old library) per the issue, but this means the mediux dial/read path in this PR is unverified against a real server.
- **No live Plex or Mediux server was available to test the dial/reconnect/idle-timeout behavior end-to-end.** Build/vet/test/gofmt all pass, and the new unit tests cover the pure parsing logic, but the actual websocket lifecycle (connect, 60s idle reconnect, stop-channel cancellation) needs manual verification against a real Plex instance before this ships with confidence.
- Per the issue's own text: gorilla/websocket is **not actually unmaintained** — no CVEs, a recent release (v1.5.3, June 2024). This is a modernization for cleaner cancellation semantics, not an urgent security fix.
- This diff was authored by an AI agent (Claude Code) on behalf of @jabrown93.

## Verification

All run from `backend/`:
- `go build ./...` — pass
- `go vet ./...` — pass
- `gofmt -l .` — pass (no output)
- `go test ./...` — pass (all packages; `download/auto` previously had no test files, now has the parsing-helper tests above)

https://claude.ai/code/session_011YS4q3pPBvYB5pFJcNv2Ju