### PR TITLE
ci: add concurrency group, normalize on: blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     # ruleset can fast-forward the target branch once the branch is green.
     branches: [main, beta, 'renovate/**']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main, beta]
   push:
     # main/beta = post-merge run. renovate/** lets Renovate's branch-automerge
     # updates (which never open a PR) run CI on the branch so the default-branch
     # ruleset can fast-forward the target branch once the branch is green.
     branches: [main, beta, 'renovate/**']
+  pull_request:
+    branches: [main, beta]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@
 name: 'CodeQL Advanced'
 on:
   push:
-    branches: ['main', 'beta']
+    branches: [main, beta]
   pull_request:
-    branches: ['main', 'beta']
+    branches: [main, beta]
   schedule:
     - cron: '25 22 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '25 22 * * 5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # codeql is now a composite action, so each caller job owns runs-on and MUST
 # grant the permissions CodeQL needs (a composite action cannot declare
 # job-level permissions). AURA is multi-language: analyze Go and TypeScript


### PR DESCRIPTION
Adds the same `concurrency` block used across the rest of the `jabrown93/ci` build/lint template to `ci.yml` and `codeql.yml` — rapid successive pushes to the same PR/branch previously queued every run to completion instead of canceling the stale one.

Also normalizes both files' `on:` blocks to match the convention used elsewhere: unquoted plain branch names (only glob patterns like `renovate/**` are quoted), and `push` listed before `pull_request`.