### PR TITLE
fix(frontend): enable import-x baseline rules

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -68,6 +68,13 @@ export default [
       /* TypeScript */
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
+
+      /* Imports */
+      "import-x/no-unresolved": "error",
+      "import-x/named": "error",
+      "import-x/no-cycle": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-duplicates": ["error", { "prefer-inline": true }],
     },
   },
 

--- a/frontend/src/app/collection-item/collection-download-modal.tsx
+++ b/frontend/src/app/collection-item/collection-download-modal.tsx
@@ -8,8 +8,7 @@ import { Check, Download, ListEnd, LoaderIcon, User, X } from "lucide-react";
 import { toast } from "sonner";
 import { z } from "zod";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import React from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 import Link from "next/link";

--- a/frontend/src/app/download-queue/page.tsx
+++ b/frontend/src/app/download-queue/page.tsx
@@ -7,8 +7,7 @@ import { GetAllCollectionQueueItems } from "@/services/downloads/collection-queu
 import { GetAllDownloadQueueItems } from "@/services/downloads/queue-get";
 import { RemoveItemFromQueue } from "@/services/downloads/queue-remove";
 import { RetryItemInQueue } from "@/services/downloads/queue-retry";
-import type { GetDownloadQueueStatus_Response } from "@/services/downloads/queue-status";
-import { GetDownloadQueueStatus } from "@/services/downloads/queue-status";
+import { GetDownloadQueueStatus, type GetDownloadQueueStatus_Response } from "@/services/downloads/queue-status";
 import { Globe, RefreshCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { ReturnErrorMessage } from "@/services/api-error-return";
-import type { JobInfo } from "@/services/jobs/get";
-import { GetAllJobs } from "@/services/jobs/get";
+import { GetAllJobs, type JobInfo } from "@/services/jobs/get";
 import { RunJob } from "@/services/jobs/run";
 import { toast } from "sonner";
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import type { AuthMethods_Response } from "@/services/auth/login";
-import { AttemptLogin, GetAuthMethods, GetSession, OIDC_LOGIN_PATH } from "@/services/auth/login";
+import {
+  AttemptLogin,
+  type AuthMethods_Response,
+  GetAuthMethods,
+  GetSession,
+  OIDC_LOGIN_PATH,
+} from "@/services/auth/login";
 import { Eye, EyeOff, KeyRound, Loader2, Lock } from "lucide-react";
 
 import { useEffect, useState } from "react";

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -3,8 +3,7 @@
 import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
 import { ClearLogFiles } from "@/services/logs/clear";
-import type { GetLogContents_Response } from "@/services/logs/get";
-import { GetLogContents } from "@/services/logs/get";
+import { GetLogContents, type GetLogContents_Response } from "@/services/logs/get";
 import { EllipsisIcon, SaveIcon, XCircle } from "lucide-react";
 import { toast } from "sonner";
 

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -7,8 +7,7 @@ import { UpdateAppConfig } from "@/services/config/update";
 import * as yaml from "js-yaml";
 import { toast } from "sonner";
 
-import type { JSX } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
 
 import Image from "next/image";
 

--- a/frontend/src/app/saved-sets/page.tsx
+++ b/frontend/src/app/saved-sets/page.tsx
@@ -2,8 +2,7 @@
 
 import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
-import type { AutodownloadResult } from "@/services/database/autodownload-force-check";
-import { AutoDownloadForceCheck } from "@/services/database/autodownload-force-check";
+import { AutoDownloadForceCheck, type AutodownloadResult } from "@/services/database/autodownload-force-check";
 import { DeleteItemFromDB } from "@/services/database/delete";
 import { getAllItemsFromDB } from "@/services/database/get-all";
 import { AddItemToDownloadQueue } from "@/services/downloads/queue-add";

--- a/frontend/src/app/user/[username]/page.tsx
+++ b/frontend/src/app/user/[username]/page.tsx
@@ -2,8 +2,7 @@
 
 import { setRefsToFormItems } from "@/helper/download-modal/set-to-form-item";
 import { formatLastUpdatedDate } from "@/helper/format-date-last-updates";
-import type { TMDBLookupMap } from "@/helper/search-idb-for-tmdb-id";
-import { createTMDBLookupMap, searchWithLookupMap } from "@/helper/search-idb-for-tmdb-id";
+import { type TMDBLookupMap, createTMDBLookupMap, searchWithLookupMap } from "@/helper/search-idb-for-tmdb-id";
 import { ReturnErrorMessage } from "@/services/api-error-return";
 import { GetAllUserSets } from "@/services/mediux/get-user-sets";
 import { ArrowDownAZ, ArrowDownZA, ClockArrowDown, ClockArrowUp, User } from "lucide-react";

--- a/frontend/src/components/settings-onboarding/ConfigSectionMediaServer.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionMediaServer.tsx
@@ -2,15 +2,16 @@
 
 import { ValidateURL } from "@/helper/validation/validate-url";
 import { GetLibrarySectionOptions } from "@/services/mediaserver/get-library-section-options";
-import type { PlexServersResponse } from "@/services/mediaserver/plex";
-import { CheckAuthStatusWithPlex, GetPlexPinAndID } from "@/services/mediaserver/plex";
+import { CheckAuthStatusWithPlex, GetPlexPinAndID, type PlexServersResponse } from "@/services/mediaserver/plex";
 import { ValidateMediaServerInfo } from "@/services/validation/mediaserver";
 import { RefreshCcw } from "lucide-react";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
-import type { ConfigConnectionStatus } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
-import { CONNECTION_STATUS_COLORS_BG } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
+import {
+  CONNECTION_STATUS_COLORS_BG,
+  type ConfigConnectionStatus,
+} from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
 import { PopoverHelp } from "@/components/shared/popover-help";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/components/settings-onboarding/ConfigSectionMediux.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionMediux.tsx
@@ -5,8 +5,10 @@ import { ValidateMediuxInfo } from "@/services/validation/mediux";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { GetConnectionColor } from "@/components/settings-onboarding/ConfigSectionMediaServer";
-import type { ConfigConnectionStatus } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
-import { CONNECTION_STATUS_COLORS_BG } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
+import {
+  CONNECTION_STATUS_COLORS_BG,
+  type ConfigConnectionStatus,
+} from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
 import { PopoverHelp } from "@/components/shared/popover-help";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";

--- a/frontend/src/components/settings-onboarding/ConfigSectionNotifications.tsx
+++ b/frontend/src/components/settings-onboarding/ConfigSectionNotifications.tsx
@@ -7,8 +7,10 @@ import { Plus, TestTube, Trash2 } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { GetConnectionColor } from "@/components/settings-onboarding/ConfigSectionMediaServer";
-import type { ConfigConnectionStatus } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
-import { CONNECTION_STATUS_COLORS_BG } from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
+import {
+  CONNECTION_STATUS_COLORS_BG,
+  type ConfigConnectionStatus,
+} from "@/components/settings-onboarding/ConfigSectionSonarrRadarr";
 import { PopoverHelp } from "@/components/shared/popover-help";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";

--- a/frontend/src/components/shared/download-modal.tsx
+++ b/frontend/src/components/shared/download-modal.tsx
@@ -24,10 +24,8 @@ import {
 } from "lucide-react";
 import { z } from "zod";
 
-import { Fragment, useEffect, useRef, useState } from "react";
-import React from "react";
-import type { ControllerRenderProps } from "react-hook-form";
-import { useForm, useWatch } from "react-hook-form";
+import React, { Fragment, useEffect, useRef, useState } from "react";
+import { type ControllerRenderProps, useForm, useWatch } from "react-hook-form";
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/frontend/src/components/shared/download-queue-entry.tsx
+++ b/frontend/src/components/shared/download-queue-entry.tsx
@@ -12,8 +12,7 @@ import Link from "next/link";
 
 import { AssetImage } from "@/components/shared/asset-image";
 import { ConfirmDestructiveDialogActionButton } from "@/components/shared/dialog-destructive-action";
-import type { FormItemDisplay } from "@/components/shared/download-modal";
-import DownloadModal from "@/components/shared/download-modal";
+import DownloadModal, { type FormItemDisplay } from "@/components/shared/download-modal";
 import { renderTypeBadges } from "@/components/shared/saved-sets-shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/components/shared/filter-home.tsx
+++ b/frontend/src/components/shared/filter-home.tsx
@@ -26,12 +26,13 @@ import { useSearchQueryStore } from "@/lib/stores/global-store-search-query";
 import { extractInfoFromSearchQuery } from "@/hooks/search-query";
 
 import type { LibrarySection } from "@/types/media-and-posters/media-item-and-library";
-import type {
-  TYPE_FILTER_IGNORED_OPTIONS,
-  TYPE_HOME_PAGE_FILTER_HAS_SETS_AVAILABLE_OPTIONS,
-  TYPE_HOME_PAGE_FILTER_IN_DB_OPTIONS,
+import {
+  FILTER_IGNORED_OPTIONS,
+  HOME_PAGE_FILTER_IN_DB_OPTIONS,
+  type TYPE_FILTER_IGNORED_OPTIONS,
+  type TYPE_HOME_PAGE_FILTER_HAS_SETS_AVAILABLE_OPTIONS,
+  type TYPE_HOME_PAGE_FILTER_IN_DB_OPTIONS,
 } from "@/types/ui-options";
-import { FILTER_IGNORED_OPTIONS, HOME_PAGE_FILTER_IN_DB_OPTIONS } from "@/types/ui-options";
 
 type HomeFilterProps = {
   // Filtering

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -2,8 +2,7 @@ import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-re
 
 import * as React from "react";
 
-import type { Button } from "@/components/ui/button";
-import { buttonVariants } from "@/components/ui/button";
+import { type Button, buttonVariants } from "@/components/ui/button";
 
 import { cn } from "@/lib/cn";
 

--- a/frontend/src/lib/stores/global-store-onboarding.ts
+++ b/frontend/src/lib/stores/global-store-onboarding.ts
@@ -1,5 +1,4 @@
-import type { AppConfigStatus_Response } from "@/services/config/status";
-import { GetAppConfigStatus } from "@/services/config/status";
+import { type AppConfigStatus_Response, GetAppConfigStatus } from "@/services/config/status";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 

--- a/frontend/src/lib/stores/page-store-home.ts
+++ b/frontend/src/lib/stores/page-store-home.ts
@@ -5,12 +5,12 @@ import { PageStore } from "@/lib/stores/stores";
 
 import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
 import type { PaginationStore, SortStore } from "@/types/store-interfaces";
-import type {
-  TYPE_FILTER_IGNORED_OPTIONS,
-  TYPE_HOME_PAGE_FILTER_HAS_SETS_AVAILABLE_OPTIONS,
-  TYPE_SORT_ORDER_OPTIONS,
+import {
+  type TYPE_FILTER_IGNORED_OPTIONS,
+  type TYPE_HOME_PAGE_FILTER_HAS_SETS_AVAILABLE_OPTIONS,
+  type TYPE_HOME_PAGE_FILTER_IN_DB_OPTIONS,
+  type TYPE_SORT_ORDER_OPTIONS,
 } from "@/types/ui-options";
-import type { TYPE_HOME_PAGE_FILTER_IN_DB_OPTIONS } from "@/types/ui-options";
 
 type Direction = "next" | "previous";
 


### PR DESCRIPTION
## Summary
- Enable `import-x/no-unresolved`, `named`, `no-cycle`, `no-self-import`, `no-duplicates` (`prefer-inline`) in `frontend/eslint.config.mjs` — plugin was registered but had zero rules active
- `no-duplicates --fix` merged 18 files' split value/type imports from the same module into a single inline import; `no-unresolved`/`named`/`no-cycle`/`no-self-import` were already clean
- Manually fixed one autofix-generated syntax error (`import Default, type { X }` → `import Default, { type X }` in `download-queue-entry.tsx` — a known bug in `eslint-plugin-import-x`'s no-duplicates autofix when merging a default import with a type-only named import)
- Confirmed `prefer-inline` output is stable under `@trivago/prettier-plugin-sort-imports` (`npm run format` made no further changes to the touched files)

Closes #93.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format:check` — no drift on touched files (pre-existing unrelated drift elsewhere untouched)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds

https://claude.ai/code/session_017CxygvnnwfrXEEyrtSv5Cb