### PR TITLE
chore(deps): drop direct @semantic-release/commit-analyzer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "name": "aura-release-tooling",
       "devDependencies": {
         "@semantic-release/changelog": "7.0.0",
-        "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "11.0.1",
         "@semantic-release/github": "12.0.9",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "CI-only tooling for conventional-commit versioning; the app's JS lives in frontend/, not here",
   "devDependencies": {
     "@semantic-release/changelog": "7.0.0",
-    "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "11.0.1",
     "@semantic-release/github": "12.0.9",


### PR DESCRIPTION
## Why

`@semantic-release/commit-analyzer` is flagged as abandoned on the Renovate Dependency Dashboard (#6). It ships bundled as a dependency of semantic-release core (v25.0.8 lists it in its own `dependencies`), so the plugin entry in `.releaserc.js` resolves without a direct devDependency.

## What

- Removed `@semantic-release/commit-analyzer` from root `package.json` devDependencies.
- `npm install` lockfile update — package stays in the lock as a transitive dependency of `semantic-release`, unchanged version 13.0.1.

## Verification

`npx semantic-release --dry-run` after removal: `✔ Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"` — identical plugin, identical `releaseRules` config path.

---
_PR authored by AI agent (Claude Code)._

https://claude.ai/code/session_011DbCV5gPU1eDa2AkPkvDVe