### PR TITLE
feat: serve HTTPS with user-provided TLS cert and key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,9 @@ ENV XDG_CACHE_HOME=/tmp/.cache
 # Expose the ports for both the backend and frontend
 EXPOSE 3000
 EXPOSE 8888
+# HTTPS ports, active only when TLS_CERT_FILE and TLS_KEY_FILE are set
+EXPOSE 3443
+EXPOSE 8443
 
 # Run both processes under the node supervisor (shellless, so no `sh -c`).
 ENTRYPOINT ["node", "/app/launcher.mjs"]

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,11 +19,12 @@ import (
 )
 
 var (
-	APP_NAME    = "aura"
-	APP_VERSION = "dev"
-	AUTHOR      = "xmoosex"
-	LICENSE     = "MIT"
-	APP_PORT    = 8888
+	APP_NAME     = "aura"
+	APP_VERSION  = "dev"
+	AUTHOR       = "xmoosex"
+	LICENSE      = "MIT"
+	APP_PORT     = 8888
+	APP_TLS_PORT = 8443
 )
 
 var activeHandler atomic.Value

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -14,8 +14,10 @@ import (
 	"aura/mediux"
 	"aura/utils"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -259,6 +261,8 @@ func runWarmup() (success bool) {
 }
 
 func startAPI() {
+	startTLSIfConfigured()
+
 	// Start HTTP Server
 	logging.LOGGER.Info().Timestamp().Int("port", APP_PORT).
 		Bool("full_routes", config.Loaded && config.Valid).
@@ -267,6 +271,37 @@ func startAPI() {
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", APP_PORT), http.HandlerFunc(dispatch)); err != nil {
 		logging.LOGGER.Fatal().Err(err).Msg("Failed to start server")
 	}
+}
+
+// startTLSIfConfigured starts an HTTPS listener on APP_TLS_PORT when
+// TLS_CERT_FILE and TLS_KEY_FILE are set. It is an additional listener rather
+// than a replacement: the UI's build-time /api rewrite targets
+// http://localhost:8888, so the plain HTTP listener must stay up for
+// UI-to-API traffic. Certificates are loaded once at startup; a restart is
+// required to pick up rotated certs.
+func startTLSIfConfigured() {
+	certFile := os.Getenv("TLS_CERT_FILE")
+	keyFile := os.Getenv("TLS_KEY_FILE")
+	if certFile == "" && keyFile == "" {
+		return
+	}
+	// Half-configured TLS is treated as fatal: silently serving HTTP only
+	// would defeat the point of the user asking for HTTPS.
+	if certFile == "" || keyFile == "" {
+		logging.LOGGER.Fatal().Str("TLS_CERT_FILE", certFile).Str("TLS_KEY_FILE", keyFile).
+			Msg("TLS_CERT_FILE and TLS_KEY_FILE must both be set to enable HTTPS")
+	}
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+		logging.LOGGER.Fatal().Err(err).Str("TLS_CERT_FILE", certFile).Str("TLS_KEY_FILE", keyFile).
+			Msg("Failed to load TLS certificate/key pair")
+	}
+
+	go func() {
+		logging.LOGGER.Info().Timestamp().Int("port", APP_TLS_PORT).Msg("Starting HTTPS Server")
+		if err := http.ListenAndServeTLS(fmt.Sprintf(":%d", APP_TLS_PORT), certFile, keyFile, http.HandlerFunc(dispatch)); err != nil {
+			logging.LOGGER.Fatal().Err(err).Msg("Failed to start HTTPS server")
+		}
+	}()
 }
 
 // dispatch forwards to the currently active router.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
         ports:
             - "3000:3000" # Web UI PORT
             - "8888:8888" # API PORT
+            ## HTTPS ports — uncomment when TLS_CERT_FILE/TLS_KEY_FILE are set below
+            # - "3443:3443" # Web UI HTTPS PORT
+            # - "8443:8443" # API HTTPS PORT
 
         # Make sure to change these paths to match your host system
         volumes:
@@ -26,3 +29,7 @@ services:
             - PGID=100
             - UMASK=022
             - TZ=America/New_York # Set your timezone, e.g., America/New_York
+            ## HTTPS: mount your certificate and key (e.g. under /config) and point
+            ## these at them. Both must be set; restart the container after rotating.
+            # - TLS_CERT_FILE=/config/certs/tls.crt
+            # - TLS_KEY_FILE=/config/certs/tls.key

--- a/docker/launcher.mjs
+++ b/docker/launcher.mjs
@@ -12,6 +12,9 @@
 // rather than leaving a half-dead container serving a broken UI or a dead API.
 
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
 
 const SHUTDOWN_GRACE_MS = 10_000;
 
@@ -77,8 +80,88 @@ function start(name, command, args) {
   });
 }
 
+/**
+ * TLS-terminating reverse proxy in front of the Next.js UI. Next's standalone
+ * server.js cannot serve HTTPS itself, and the shellless runtime image has no
+ * nginx/caddy to lean on, so the supervisor terminates TLS with node's builtin
+ * https module and forwards to the UI's plain-HTTP port on loopback.
+ *
+ * The Go backend is NOT proxied here: it terminates TLS natively on its own
+ * HTTPS port (8443) from the same cert/key env vars.
+ *
+ * No Upgrade/WebSocket handling: no UI-facing WebSocket endpoints exist today.
+ * @param {number} listenPort
+ * @param {number} targetPort
+ * @param {{cert: Buffer, key: Buffer}} tlsOptions
+ */
+function startTlsProxy(listenPort, targetPort, tlsOptions) {
+  const server = createHttpsServer(tlsOptions, (req, res) => {
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: targetPort,
+        path: req.url,
+        method: req.method,
+        headers: {
+          ...req.headers,
+          "x-forwarded-proto": "https",
+          "x-forwarded-for": req.socket.remoteAddress ?? "",
+        },
+      },
+      (upRes) => {
+        res.writeHead(upRes.statusCode ?? 502, upRes.headers);
+        upRes.pipe(res);
+      },
+    );
+    upstream.on("error", (err) => {
+      console.error(`[launcher] https proxy upstream error: ${err.message}`);
+      if (!res.headersSent) res.writeHead(502);
+      res.end();
+    });
+    req.pipe(upstream);
+  });
+
+  server.on("error", (err) => {
+    console.error(`[launcher] https listener :${listenPort} failed: ${err.message}`);
+    shutdown(1);
+  });
+
+  server.listen(listenPort, () => {
+    console.log(`[launcher] https UI listening on :${listenPort} -> :${targetPort}`);
+  });
+}
+
+/**
+ * Read TLS_CERT_FILE/TLS_KEY_FILE and start the HTTPS UI proxy when both are
+ * set. Half-configured TLS or unreadable files are fatal: silently serving
+ * HTTP only would defeat the point of configuring HTTPS. (The Go backend
+ * applies the same rule for its own listener.)
+ */
+function startTlsIfConfigured() {
+  const certFile = process.env.TLS_CERT_FILE;
+  const keyFile = process.env.TLS_KEY_FILE;
+  if (!certFile && !keyFile) return;
+  if (!certFile || !keyFile) {
+    console.error(
+      "[launcher] TLS_CERT_FILE and TLS_KEY_FILE must both be set to enable HTTPS",
+    );
+    shutdown(1);
+    return;
+  }
+  let tlsOptions;
+  try {
+    tlsOptions = { cert: readFileSync(certFile), key: readFileSync(keyFile) };
+  } catch (err) {
+    console.error(`[launcher] failed to read TLS cert/key: ${err.message}`);
+    shutdown(1);
+    return;
+  }
+  startTlsProxy(3443, 3000, tlsOptions);
+}
+
 process.on("SIGTERM", () => shutdown(0));
 process.on("SIGINT", () => shutdown(0));
 
 start("backend", "/app/main", []);
 start("frontend", process.execPath, ["/app/server.js"]);
+startTlsIfConfigured();

--- a/docker/launcher.mjs
+++ b/docker/launcher.mjs
@@ -94,19 +94,36 @@ function start(name, command, args) {
  * @param {number} targetPort
  * @param {{cert: Buffer, key: Buffer}} tlsOptions
  */
+// RFC 9110 hop-by-hop headers: they describe the client->proxy connection and
+// must not be forwarded to the upstream (node manages its own connection
+// semantics and picks chunked encoding itself when the body has no length).
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
 function startTlsProxy(listenPort, targetPort, tlsOptions) {
   const server = createHttpsServer(tlsOptions, (req, res) => {
+    const headers = { ...req.headers };
+    for (const h of HOP_BY_HOP_HEADERS) delete headers[h];
+    headers["x-forwarded-proto"] = "https";
+    // Deliberately overwrite rather than append: this proxy is the outermost
+    // TLS endpoint, so any inbound x-forwarded-for is client-supplied and
+    // spoofable.
+    headers["x-forwarded-for"] = req.socket.remoteAddress ?? "";
     const upstream = httpRequest(
       {
         host: "127.0.0.1",
         port: targetPort,
         path: req.url,
         method: req.method,
-        headers: {
-          ...req.headers,
-          "x-forwarded-proto": "https",
-          "x-forwarded-for": req.socket.remoteAddress ?? "",
-        },
+        headers,
       },
       (upRes) => {
         res.writeHead(upRes.statusCode ?? 502, upRes.headers);
@@ -148,15 +165,16 @@ function startTlsIfConfigured() {
     shutdown(1);
     return;
   }
-  let tlsOptions;
+  // createServer also throws synchronously on malformed or mismatched
+  // cert/key PEM, so it shares the read's catch instead of crashing the
+  // supervisor with an unhandled exception.
   try {
-    tlsOptions = { cert: readFileSync(certFile), key: readFileSync(keyFile) };
+    const tlsOptions = { cert: readFileSync(certFile), key: readFileSync(keyFile) };
+    startTlsProxy(3443, 3000, tlsOptions);
   } catch (err) {
-    console.error(`[launcher] failed to read TLS cert/key: ${err.message}`);
+    console.error(`[launcher] failed to load TLS cert/key: ${err.message}`);
     shutdown(1);
-    return;
   }
-  startTlsProxy(3443, 3000, tlsOptions);
 }
 
 process.on("SIGTERM", () => shutdown(0));

--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -37,3 +37,34 @@ To install aura using Docker Compose, follow these steps:
 5. **Access the Web UI**: Open your web browser and navigate to `http://localhost:3000` to access the aura web interface.
 
 **Note**: Ensure that Docker is installed and running on your system before executing these commands. You can find more information about Docker installation on the [official Docker website](https://docs.docker.com/get-docker/).
+
+## HTTPS (optional)
+
+aura can serve HTTPS directly if you provide your own TLS certificate and key. When both environment variables below are set, two extra listeners start alongside the plain-HTTP ones:
+
+| Listener | HTTP  | HTTPS |
+| -------- | ----- | ----- |
+| Web UI   | 3000  | 3443  |
+| API      | 8888  | 8443  |
+
+1. Mount your certificate and key into the container (the `/config` volume is a convenient place, e.g. `/config/certs/`). The certificate file should contain the full chain (leaf plus intermediates) in PEM format.
+
+2. Set the environment variables and publish the HTTPS ports in `docker-compose.yml`:
+
+    ```yaml
+    ports:
+        - "3443:3443" # Web UI HTTPS
+        - "8443:8443" # API HTTPS
+    environment:
+        - TLS_CERT_FILE=/config/certs/tls.crt
+        - TLS_KEY_FILE=/config/certs/tls.key
+    ```
+
+3. Restart the container. The UI is now available at `https://<host>:3443` and the API at `https://<host>:8443`.
+
+Notes:
+
+- Both variables must be set; setting only one is treated as a configuration error and the container exits.
+- The plain-HTTP ports stay active for internal UI-to-API traffic. If you only want HTTPS exposed, simply don't publish ports 3000/8888.
+- Certificates are read at startup only — restart the container after rotating them.
+- If you already run a reverse proxy (Traefik, Caddy, nginx, ...), keep terminating TLS there instead; this option is for setups without one.


### PR DESCRIPTION
> Written by AI agent (Claude Code).

## What

Optional HTTPS support. When `TLS_CERT_FILE` and `TLS_KEY_FILE` env vars are set, two extra listeners start alongside the existing HTTP ones:

| Listener | HTTP | HTTPS |
|---|---|---|
| Web UI | 3000 | 3443 |
| API | 8888 | 8443 |

## How

- **Backend** (`backend/startup.go`): native Go `ListenAndServeTLS` on 8443, same `dispatch` handler as HTTP. Cert/key pair validated at startup.
- **UI** (`docker/launcher.mjs`): Next standalone `server.js` can't serve HTTPS, and the shellless runtime image has no nginx/caddy — so the supervisor terminates TLS with node's builtin `https` and forwards to the UI on loopback, adding `x-forwarded-proto`/`x-forwarded-for`.
- HTTP ports intentionally stay up: the UI's build-time `/api` rewrite targets `http://localhost:8888`. Users wanting HTTPS-only just don't publish 3000/8888.
- Half-configured TLS (one var set) or unreadable cert/key is fatal at startup — silently falling back to HTTP would defeat the point.
- Certs read once at startup; rotation requires restart (documented).
- Dockerfile `EXPOSE 3443/8443`, commented compose example, docs section in `docs/installation/docker-compose.md`.

## Testing

- `go build` + `go vet` clean.
- Ran backend with self-signed cert: HTTPS 8443 and HTTP 8888 respond identically; half-configured env exits 1 with clear log.
- Harness-tested launcher proxy function: path + query + `x-forwarded-proto: https` pass through to upstream.

https://claude.ai/code/session_01WYa4vAL3mqwNZpQJhdAPCB