### PR TITLE
ci(release): Verified version-bump commits via the GitHub API

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -93,14 +93,19 @@ module.exports = {
       },
     ],
     [
-      "@semantic-release/git",
+      "@semantic-release/exec",
       {
-        assets: ["VERSION.txt", "version.json", "frontend/public/CHANGELOG.md"],
-        // Keep the release notes OUT of the commit message: the first release
-        // rolls up ~1800 commits (~130 KB of notes), and inlining that via
-        // `git commit -m` overruns the OS argument limit (E2BIG). The full notes
-        // still land in CHANGELOG.md and the GitHub Release body.
-        message: "chore(release): v${nextRelease.version} [skip ci]",
+        // Version-bump commit via GitHub's GraphQL createCommitOnBranch
+        // instead of @semantic-release/git: API commits are signed by GitHub
+        // and show as Verified, which a local git commit from the CI bot
+        // never can be. The script hard-resets the checkout to the new
+        // commit so the release tag semantic-release creates points at it —
+        // and so the beta-resync push in version-release.yml still pushes
+        // the released tip.
+        prepareCmd:
+          "node scripts/release-commit.mjs --branch ${branch.name}" +
+          " --message 'chore(release): v${nextRelease.version} [skip ci]' --" +
+          " VERSION.txt version.json frontend/public/CHANGELOG.md",
       },
     ],
     [

--- a/scripts/release-commit.mjs
+++ b/scripts/release-commit.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console -- CLI script; console is its user interface */
 // Creates the semantic-release version-bump commit via GitHub's GraphQL
 // createCommitOnBranch instead of local git, so GitHub signs it and the
 // commit shows as Verified. Replaces @semantic-release/git, whose local
@@ -18,8 +19,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 
-const git = (...args) =>
-  execFileSync('git', args, { encoding: 'utf8' }).trim();
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
 
 const argv = process.argv.slice(2);
 const flags = {};
@@ -39,23 +39,25 @@ if (!flags.branch || !flags.message || paths.length === 0) {
 }
 
 const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-if (!token) throw new Error('GITHUB_TOKEN or GH_TOKEN must be set');
+if (!token) {
+  throw new Error('GITHUB_TOKEN or GH_TOKEN must be set');
+}
 const repository = process.env.GITHUB_REPOSITORY;
-if (!repository) throw new Error('GITHUB_REPOSITORY must be set');
+if (!repository) {
+  throw new Error('GITHUB_REPOSITORY must be set');
+}
 
 // --porcelain covers modified and untracked alike — a repo's first release
 // creates CHANGELOG.md rather than modifying it. Listing a path that does
 // not exist at all is fine: status prints nothing and it is skipped.
-const changed = paths.filter(
-  (p) => git('status', '--porcelain', '--', p) !== ''
-);
+const changed = paths.filter(p => git('status', '--porcelain', '--', p) !== '');
 if (changed.length === 0) {
   console.log('release-commit: no listed file changed, skipping commit');
   process.exit(0);
 }
 
 const additions = await Promise.all(
-  changed.map(async (path) => ({
+  changed.map(async path => ({
     path,
     contents: (await readFile(path)).toString('base64'),
   }))
@@ -73,7 +75,10 @@ const response = await fetch('https://api.github.com/graphql', {
     }`,
     variables: {
       input: {
-        branch: { repositoryNameWithOwner: repository, branchName: flags.branch },
+        branch: {
+          repositoryNameWithOwner: repository,
+          branchName: flags.branch,
+        },
         message: { headline: flags.message },
         expectedHeadOid: git('rev-parse', 'HEAD'),
         fileChanges: { additions },
@@ -89,6 +94,12 @@ if (!response.ok || body.errors) {
 }
 const oid = body.data.createCommitOnBranch.commit.oid;
 
-git('fetch', 'origin', `+refs/heads/${flags.branch}:refs/remotes/origin/${flags.branch}`);
+git(
+  'fetch',
+  'origin',
+  `+refs/heads/${flags.branch}:refs/remotes/origin/${flags.branch}`
+);
 git('reset', '--hard', oid);
-console.log(`release-commit: created ${oid} on ${flags.branch} (${changed.join(', ')})`);
+console.log(
+  `release-commit: created ${oid} on ${flags.branch} (${changed.join(', ')})`
+);

--- a/scripts/release-commit.mjs
+++ b/scripts/release-commit.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Creates the semantic-release version-bump commit via GitHub's GraphQL
+// createCommitOnBranch instead of local git, so GitHub signs it and the
+// commit shows as Verified. Replaces @semantic-release/git, whose local
+// commits are unsigned (no key is available to a CI bot identity).
+//
+// Run from an @semantic-release/exec prepareCmd, ordered after every other
+// prepare step so the files it commits are final:
+//   node release-commit.mjs --branch <name> --message <headline> -- <path...>
+//
+// Paths that did not change are skipped; if nothing changed, no commit is
+// made. expectedHeadOid pins the mutation to this checkout's HEAD, so a
+// concurrent push fails the release loudly instead of being overwritten.
+// On success the local checkout is hard-reset to the new commit, because
+// semantic-release re-reads HEAD after the prepare phase and tags it — the
+// tag must point at the API commit, not the pre-bump checkout.
+
+import { execFileSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+const git = (...args) =>
+  execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+const argv = process.argv.slice(2);
+const flags = {};
+const paths = [];
+for (let i = 0; i < argv.length; i += 1) {
+  if (argv[i] === '--branch' || argv[i] === '--message') {
+    flags[argv[i].slice(2)] = argv[i + 1];
+    i += 1;
+  } else if (argv[i] !== '--') {
+    paths.push(argv[i]);
+  }
+}
+if (!flags.branch || !flags.message || paths.length === 0) {
+  throw new Error(
+    'usage: release-commit.mjs --branch <name> --message <headline> -- <path...>'
+  );
+}
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+if (!token) throw new Error('GITHUB_TOKEN or GH_TOKEN must be set');
+const repository = process.env.GITHUB_REPOSITORY;
+if (!repository) throw new Error('GITHUB_REPOSITORY must be set');
+
+// --porcelain covers modified and untracked alike — a repo's first release
+// creates CHANGELOG.md rather than modifying it. Listing a path that does
+// not exist at all is fine: status prints nothing and it is skipped.
+const changed = paths.filter(
+  (p) => git('status', '--porcelain', '--', p) !== ''
+);
+if (changed.length === 0) {
+  console.log('release-commit: no listed file changed, skipping commit');
+  process.exit(0);
+}
+
+const additions = await Promise.all(
+  changed.map(async (path) => ({
+    path,
+    contents: (await readFile(path)).toString('base64'),
+  }))
+);
+
+const response = await fetch('https://api.github.com/graphql', {
+  method: 'POST',
+  headers: {
+    authorization: `bearer ${token}`,
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify({
+    query: `mutation ($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) { commit { oid } }
+    }`,
+    variables: {
+      input: {
+        branch: { repositoryNameWithOwner: repository, branchName: flags.branch },
+        message: { headline: flags.message },
+        expectedHeadOid: git('rev-parse', 'HEAD'),
+        fileChanges: { additions },
+      },
+    },
+  }),
+});
+const body = await response.json();
+if (!response.ok || body.errors) {
+  throw new Error(
+    `createCommitOnBranch failed: ${JSON.stringify(body.errors ?? body)}`
+  );
+}
+const oid = body.data.createCommitOnBranch.commit.oid;
+
+git('fetch', 'origin', `+refs/heads/${flags.branch}:refs/remotes/origin/${flags.branch}`);
+git('reset', '--hard', oid);
+console.log(`release-commit: created ${oid} on ${flags.branch} (${changed.join(', ')})`);


### PR DESCRIPTION
`@semantic-release/git` commits with local git, so every `chore(release)` commit lands unsigned. This swaps it for `scripts/release-commit.mjs` run from an `@semantic-release/exec` `prepareCmd`: the version-bump commit is created via GraphQL `createCommitOnBranch`, which GitHub signs — the commit shows **Verified**, attributed to the release app bot. `expectedHeadOid` keeps the concurrent-push failure semantics, and the script hard-resets the checkout so the release tag points at the API commit.

Verification: next release — `chore(release)` commit shows the Verified badge, tag points at it.

_PR opened by AI agent (Claude Code)._

https://claude.ai/code/session_01MVDfqm4AJGuGCXwkEftZL9