### PR TITLE
ci(release): Verified version-bump commits via the GitHub API

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Install release tooling
         run: npm ci
 
+      # Exports RELEASE_COMMIT_SCRIPT for .releaserc.js's exec prepareCmd,
+      # which creates the version-bump commit via the GitHub API (Verified)
+      # instead of @semantic-release/git.
+      - name: Stage release-commit script
+        uses: jabrown93/ci/actions/release-commit@03c962b18c0808de575db8251919e34083513387 # release-commit-v1.0.0
+
       # Publishes (tags, bumps VERSION.txt/version.json, updates CHANGELOG.md, creates
       # the GitHub Release) only when a feat/fix/breaking commit warrants it. On success
       # the @semantic-release/exec successCmd (see .releaserc.js) emits published/version

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -93,14 +93,23 @@ module.exports = {
       },
     ],
     [
-      "@semantic-release/git",
+      "@semantic-release/exec",
       {
-        assets: ["VERSION.txt", "version.json", "frontend/public/CHANGELOG.md"],
-        // Keep the release notes OUT of the commit message: the first release
-        // rolls up ~1800 commits (~130 KB of notes), and inlining that via
-        // `git commit -m` overruns the OS argument limit (E2BIG). The full notes
-        // still land in CHANGELOG.md and the GitHub Release body.
-        message: "chore(release): v${nextRelease.version} [skip ci]",
+        // Version-bump commit via GitHub's GraphQL createCommitOnBranch
+        // instead of @semantic-release/git: API commits are signed by GitHub
+        // and show as Verified, which a local git commit from the CI bot
+        // never can be. The script hard-resets the checkout to the new
+        // commit so the release tag semantic-release creates points at it —
+        // and so the beta-resync push in version-release.yml still pushes
+        // the released tip. RELEASE_COMMIT_SCRIPT is exported by the
+        // jabrown93/ci/actions/release-commit step in version-release.yml;
+        // it is written WITHOUT braces because exec runs this command
+        // through a Lodash template that would evaluate ${...} as JS —
+        // the bare form is left for the shell.
+        prepareCmd:
+          "node $RELEASE_COMMIT_SCRIPT --branch ${branch.name}" +
+          " --message 'chore(release): v${nextRelease.version} [skip ci]' --" +
+          " VERSION.txt version.json frontend/public/CHANGELOG.md",
       },
     ],
     [


### PR DESCRIPTION
Replaces jabrown93/AURA#112 (vendored script) with the centralized `jabrown93/ci/actions/release-commit@release-commit-v1.0.0` action (jabrown93/ci#65).

- `version-release.yml` stages the script before semantic-release, exporting `RELEASE_COMMIT_SCRIPT`.
- `.releaserc.js` swaps `@semantic-release/git` for an `@semantic-release/exec` `prepareCmd` calling it: version-bump commit created via GraphQL `createCommitOnBranch` — GitHub-signed, shows **Verified**, `expectedHeadOid` keeps concurrent-push failure semantics, checkout hard-reset so the tag and the beta-resync push track the API commit.

Verification: next release — `chore(release)` commit shows Verified, `vX.Y.Z` tag points at it.

_PR opened by AI agent (Claude Code)._

https://claude.ai/code/session_01MVDfqm4AJGuGCXwkEftZL9