### PR TITLE
fix(docker): use unversioned alpine DHI tags, move node to 26.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################################
 ##### Stage 1: Build the backend application
 ############################################################################
-FROM dhi.io/golang:1.27.0-alpine3.24-dev@sha256:76defbbd7307f0b09f0264c30d2e926981debf1d767ef0d93186b6c58dad539a AS backend-builder
+FROM dhi.io/golang:1.27.0-alpine-dev@sha256:76defbbd7307f0b09f0264c30d2e926981debf1d767ef0d93186b6c58dad539a AS backend-builder
 
 # cgo build deps (gcc, musl-dev) plus ca-certificates + tzdata, which are copied
 # into the shellless runtime image (which has no package manager of its own).
@@ -29,7 +29,7 @@ RUN go build -ldflags="-s -w -X main.APP_VERSION=$APP_VERSION" -o main .
 ############################################################################
 ##### Stage 2: Build the frontend application
 ############################################################################
-FROM dhi.io/node:26.4.0-alpine3.24-dev@sha256:6049c9bf9906b19c05596189887b19905471a0a88d555fc76db55ff23ee79a5a AS frontend-builder
+FROM dhi.io/node:26.7.0-alpine-dev@sha256:763d0f58436281ce84f6f95b8a7a318f74cd8c9d1cef61212efeffe2de445130 AS frontend-builder
 
 # Set the working directory
 WORKDIR /frontend
@@ -65,7 +65,7 @@ RUN find /frontend/public -type d -exec chmod 755 {} + \
 ############################################################################
 ##### Stage 3: Build the final image
 ############################################################################
-FROM dhi.io/node:26.4.0-alpine3.24@sha256:fedb4f426b8fcc707e5186f886ff6bfe2f589fc4eaf6da5b4632e51beb3a4b8f AS final
+FROM dhi.io/node:26.7.0-alpine@sha256:019a466db59568d3f50abafaa9020ea6cef74ccd4173c753e8634189c461cfd0 AS final
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
Two halves.

**golang** — `1.27.0-alpine3.24-dev` → `1.27.0-alpine-dev`. Identical digest (`sha256:76defbbd…`), pure rename.

**node** — `26.4.0-alpine3.24` → `26.7.0-alpine`. This one is a real bump, because **DHI has pruned every `26.4.0` tag from the registry**, and that is why Renovate has been silently stuck on it.

From the `renovate-ce` run log:

```
"versionCompatibility":"^(?<version>[^-]+)(?<compatibility>-.*)?$",
"currentValue":"26.4.0-alpine3.24",
"groups":{"version":"26.4.0","compatibility":"-alpine3.24"}
...
"msg":"Dependency dhi.io/node has unsupported/unversioned value 26.4.0
       (versioning=regex:^(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?-(?<compatibility>alpine|debian)...)"
```

The docker datasource split the tag at the first dash and handed bare `26.4.0` to the compound-tag `regex:` versioning from the shared preset, which requires the `-alpine<minor>` suffix. No match → `"updates":[]`, and **nothing on the dependency dashboard** to show it was stuck. golang in the same Dockerfile resolved fine; the differentiator is that its tag still exists upstream.

Dropping the suffix fixes the class of problem, not just this instance: `26.7.0-alpine` needs no custom versioning at all, so default docker versioning tracks the leading version on its own.

*Opened by an AI agent (Claude Code).*

https://claude.ai/code/session_017bqwSXAHxBVcbwqcFXWdPH
