### PR TITLE
chore: ignore Pi workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ docker_local_build.sh.old
 
 # Claude Code local settings
 .claude/settings.local.json
+.pi/


### PR DESCRIPTION
## Description

Ignore Pi's repository-local `.pi/` workspace so agent state does not appear as untracked content.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: repository tooling

## Checklist

- [x] My commits follow the Conventional Commits standard
- [ ] I have run the linter/formatter and test suite locally (not applicable: ignore-only change)
- [x] Tests added or updated where appropriate (not applicable: no runtime behavior)
- [x] Documentation updated where appropriate
- [x] This PR is focused and reasonably small to review