### PR TITLE
ci: attach a CycloneDX SBOM alongside the SPDX one

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -99,3 +99,29 @@ jobs:
             exit 1
           fi
           cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      # buildx `sbom: true` attaches SPDX only -- BuildKit cannot emit CycloneDX.
+      # Same two-format treatment as release.yml, so :edge is inspectable the same
+      # way a released tag is. syft resolves the multi-arch index to one manifest.
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        env:
+          # Default `owned-by-package` emits a purl-less, license-less `type: file`
+          # component per package-owned file -- pure ballast.
+          SYFT_FILE_METADATA_SELECTION: none
+          # Resolve licenses upstream for ecosystems that ship none in-image.
+          # Best-effort: an unreachable registry degrades coverage, never fails build.
+          SYFT_ENRICH: golang,javascript,python
+          # `enrich: python` also drives guess-unpinned-requirements, which invents
+          # versions for unpinned entries; keep it explicitly off.
+          SYFT_PYTHON_GUESS_UNPINNED_REQUIREMENTS: 'false'
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: false
+
+      - name: Attach CycloneDX SBOM attestation (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign attest --yes --type cyclonedx --predicate sbom.cdx.json "${IMAGE}@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,38 @@ jobs:
             exit 1
           fi
           cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      # buildx `sbom: true` above already attached SPDX -- BuildKit's attestation is
+      # SPDX-only and cannot emit CycloneDX. This adds the CycloneDX half so both
+      # formats hang off the same digest.
+      #
+      # syft resolves a multi-arch index to one manifest, so this SBOM describes a
+      # single architecture while buildx's SPDX is per-platform. These images differ
+      # by compiled arch, not package set.
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        env:
+          # syft's file-metadata cataloger defaults to `owned-by-package`, emitting a
+          # `type: file` component -- name, sha1, sha256, no purl, no license -- per
+          # package-owned file. They match no vulnerability and carry no license, so
+          # they are pure ballast (measured elsewhere at 7,265 of 7,506 components).
+          SYFT_FILE_METADATA_SELECTION: none
+          # Go modules and npm packages often ship no license metadata readable from
+          # the image alone. Enrichment resolves them from upstream registries.
+          # Best-effort: an unreachable registry degrades coverage, never fails build.
+          SYFT_ENRICH: golang,javascript,python
+          # Pinned, not corrective. `enrich: python` also drives
+          # guess-unpinned-requirements, which invents versions for unpinned
+          # requirements.txt entries and would feed them into vulnerability matching.
+          SYFT_PYTHON_GUESS_UNPINNED_REQUIREMENTS: 'false'
+        with:
+          # Digest, never the tag: the tag can move between push and scan.
+          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: false
+
+      - name: Attach CycloneDX SBOM attestation (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign attest --yes --type cyclonedx --predicate sbom.cdx.json "${IMAGE}@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           # Attach an SPDX SBOM + max provenance as OCI referrers on the image
           # (inspect: `docker buildx imagetools inspect --format '{{json .SBOM}}' <img>`).
-          # SPDX, not CycloneDX: BuildKit's SBOM attestation is SPDX-only. A
-          # CycloneDX copy would need a separate `cosign attest --type cyclonedx`.
+          # SPDX only here: BuildKit's SBOM attestation cannot emit CycloneDX.
+          # The CycloneDX half is attested further down, after the image is pushed.
           provenance: mode=max
           sbom: true
           cache-from: type=gha

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,8 +19,8 @@ in-cluster jobs.
 | `ci.yml` | PR → `main`, push → `main`/`renovate/**` | Backend `go build`/`vet`/`test` + gofmt gate; frontend `npm ci`/`lint`/`build`. | No |
 | `codeql.yml` | push/PR → `main`/`beta`, weekly | CodeQL for `go` and `javascript-typescript` (build-mode `none`) via the reusable `jabrown93/.github` workflow. | No |
 | `version-release.yml` | push → `main`/`beta`, weekly (Mon 09:00 UTC), manual | semantic-release computes the next version, updates `VERSION.txt`/`version.json`/`frontend/public/CHANGELOG.md`, tags + creates a GitHub Release. Builds nothing — the tag it pushes triggers `release.yml`. Also resyncs `beta` to `main` after a stable release. | No |
-| `release.yml` | GitHub Release published, manual (`publish_tag`) | Builds the multi-arch image for that release's tag and pushes `:v<version>`+`:latest` (stable) or `:v<version>-beta.N`+`:beta` (prerelease). SBOM + provenance, cosign keyless sign. | No |
-| `edge.yml` | push → `main` | Builds the rolling `:edge`+`:edge-<sha>` image from main's tip, independent of releases. SBOM + provenance, cosign keyless sign. | No |
+| `release.yml` | GitHub Release published, manual (`publish_tag`) | Builds the multi-arch image for that release's tag and pushes `:v<version>`+`:latest` (stable) or `:v<version>-beta.N`+`:beta` (prerelease). SPDX + CycloneDX SBOMs, provenance, cosign keyless sign. | No |
+| `edge.yml` | push → `main` | Builds the rolling `:edge`+`:edge-<sha>` image from main's tip, independent of releases. SPDX + CycloneDX SBOMs, provenance, cosign keyless sign. | No |
 | `fossa.yml` | push → `main`, manual | Advisory licence + dependency scan via the shared `jabrown93/ci` `fossa` action. | `FOSSA_API_KEY` |
 | `jekyll-gh-pages.yml` | push → `main` (`docs/**`), manual | Publish `docs/` to GitHub Pages. | Pages setting |
 
@@ -80,11 +80,23 @@ and version badge point at `jabrown93/AURA`, not upstream.
 ## Images
 
 Images publish to **`ghcr.io/<owner>/aura`** using the built-in `GITHUB_TOKEN`
-(`packages: write`) — no registry secrets to configure. They carry an SPDX
-SBOM + max provenance and are keyless-signed (Fulcio/rekor) by digest so the
-homelab Kyverno `verify-ghcr-images` policy can verify them. BuildKit's
-`sbom: true` attestation is SPDX-only; a CycloneDX copy would need a separate
-`cosign attest --type cyclonedx` step, and nothing consumes one here.
+(`packages: write`) — no registry secrets to configure. They carry max
+provenance and **both** SBOM formats as OCI referrers, and are keyless-signed
+(Fulcio/rekor) by digest so the homelab Kyverno `verify-ghcr-images` policy can
+verify them.
+
+Two formats because BuildKit's `sbom: true` attestation is SPDX-only and cannot
+emit CycloneDX, so a syft scan of the pushed digest is attested separately:
+
+```sh
+docker buildx imagetools inspect ghcr.io/<owner>/aura@<digest> --format '{{json .SBOM}}'   # SPDX
+cosign download attestation --predicate-type cyclonedx ghcr.io/<owner>/aura@<digest>       # CycloneDX
+```
+
+The CycloneDX pass is scanned from the digest, never the tag — a floating tag
+can move between push and scan. syft resolves the multi-arch index to a single
+manifest, so that half describes one architecture; these images differ by
+compiled arch, not package set.
 
 ## Licence scanning prerequisites (`fossa.yml`)
 
@@ -99,8 +111,8 @@ The workflow that preceded it — `dt-sbom.yml` plus the `pr-license-check.yml` 
 in-cluster ARC runner. Those never ran: the `arc-oss-aura` runner set was never
 created, so the privileged half queued until GitHub expired it. Dependency-Track
 is decommissioned (jabrown93/homelab#3167) and all three workflows are deleted.
-Image SBOM publishing is unaffected — `release.yml`/`edge.yml` attach one as an
-OCI referrer, as above.
+Image SBOM publishing is unaffected — `release.yml`/`edge.yml` attach both
+formats as OCI referrers, as above.
 
 ## Notes
 


### PR DESCRIPTION
Follow-on to #117, which merged before these two commits landed on the branch.

Images built here carried an SPDX SBOM and nothing else. This adds the CycloneDX half so both formats hang off the same digest, in both `release.yml` and `edge.yml`.

## Why it was missing

BuildKit's `sbom: true` attestation is **SPDX-only** — it has no CycloneDX output mode. Verified against a published image:

```console
$ docker buildx imagetools inspect ghcr.io/jabrown93/jellyseerr-exporter:latest --format '{{json .SBOM}}'
{ "linux/amd64": { "SPDX": { ... "Tool: syft-v1.51.0", "Tool: buildkit-v0.32.2" } } }
```

CycloneDX needs a separate syft scan plus `cosign attest --type cyclonedx`. #117 corrected the comment that wrongly claimed buildx produced CycloneDX; this actually produces it.

## Changes

- `release.yml`, `edge.yml`: two steps after the existing keyless sign — `anchore/sbom-action` scanning `${IMAGE}@${digest}`, then `cosign attest --type cyclonedx`.
- `release.yml`: the comment above `sbom: true` said a CycloneDX copy "would need" a separate step; that step is now directly below it.
- `docs/ci.md`: Images section and the workflow table record both formats, with the retrieval command for each.

No permission changes — both jobs already have `packages: write` + `id-token: write`, and cosign is already installed for signing.

## Inherited syft tuning, and why

Carried over from `jabrown93/homelab`'s `build-image.yaml` deliberately:

- **`SYFT_FILE_METADATA_SELECTION: none`** — the default `owned-by-package` emits a `type: file` component (name, sha1, sha256; no purl, no license) per package-owned file. They match no vulnerability and carry no license. Measured on homelab images: 7,265 of 7,506 components on one, 15,521 of 16,399 on another.
- **`SYFT_ENRICH: golang,javascript,python`** — Go/npm/Python packages often ship no license metadata readable from the image alone. Best-effort: an unreachable registry degrades coverage rather than failing the build.
- **`SYFT_PYTHON_GUESS_UNPINNED_REQUIREMENTS: 'false'`** — `enrich: python` also drives guess-unpinned-requirements, which invents a version for every unpinned entry and would feed fabricated versions into vulnerability matching. Explicit so an upstream fix cannot silently turn it on.

## Known limitation

syft resolves a multi-arch index to a single manifest, so the CycloneDX SBOM describes one architecture while buildx's SPDX is per-platform. Acceptable: these images differ by compiled arch, not package set. Noted in the workflow comment rather than worked around.

Scanned from the digest, never the tag — a floating tag can move between push and scan.

`ci:` type, so semantic-release will not cut a version.

Related: #117, jabrown93/ci#84 (same change for the shared `docker-release.yml`), jabrown93/ci#83.
