### PR TITLE
fix(security): stop leaking third-party credentials through logs and config responses

### DIFF
--- a/backend/config/sanitize.go
+++ b/backend/config/sanitize.go
@@ -47,6 +47,21 @@ func (config *Config) SanitizeConfig(ctx context.Context) *Config {
 					ApiToken: MaskToken(p.Gotify.ApiToken),
 				}
 			}
+			// Without this branch cp.Webhook stays the original pointer, so the headers -
+			// which carry the Authorization value sent to the webhook - would be returned
+			// by /api/config and logged by print.go in full. URL is left alone to match
+			// Gotify: it is the user's own endpoint, and masking it would need a matching
+			// unmask in update.go before the config could be saved back.
+			if p.Webhook != nil {
+				maskedHeaders := make(map[string]string, len(p.Webhook.Headers))
+				for key, value := range p.Webhook.Headers {
+					maskedHeaders[key] = MaskToken(value)
+				}
+				cp.Webhook = &Config_Notification_Webhook{
+					URL:     p.Webhook.URL,
+					Headers: maskedHeaders,
+				}
+			}
 			c.Notifications.Providers[i] = cp
 		}
 	}

--- a/backend/config/sanitize_test.go
+++ b/backend/config/sanitize_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"testing"
+)
+
+func webhookConfig(url string, headers map[string]string) *Config {
+	return &Config{
+		Notifications: Config_Notifications{
+			Providers: []Config_Notification_Provider{
+				{
+					Provider: "Webhook",
+					Enabled:  true,
+					Webhook:  &Config_Notification_Webhook{URL: url, Headers: headers},
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizeMasksWebhookHeaders(t *testing.T) {
+	original := webhookConfig("https://hooks.example.com/notify", map[string]string{
+		"Authorization": "Bearer supersecrettoken",
+	})
+
+	sanitized := original.SanitizeConfig(testContext())
+
+	got := sanitized.Notifications.Providers[0].Webhook.Headers["Authorization"]
+	if got == "Bearer supersecrettoken" {
+		t.Fatal("Authorization header returned unmasked")
+	}
+	if got != MaskToken("Bearer supersecrettoken") {
+		t.Errorf("header = %q, want %q", got, MaskToken("Bearer supersecrettoken"))
+	}
+
+	// The sanitized copy must not share the headers map with the live config, or masking
+	// the copy would destroy the real credential.
+	if original.Notifications.Providers[0].Webhook.Headers["Authorization"] != "Bearer supersecrettoken" {
+		t.Error("sanitizing mutated the original config")
+	}
+}
+
+func TestSanitizeLeavesWebhookURL(t *testing.T) {
+	original := webhookConfig("https://hooks.example.com/notify", nil)
+
+	sanitized := original.SanitizeConfig(testContext())
+
+	if got := sanitized.Notifications.Providers[0].Webhook.URL; got != "https://hooks.example.com/notify" {
+		t.Errorf("URL = %q, want it left intact so it round-trips on save", got)
+	}
+}

--- a/backend/config/save.go
+++ b/backend/config/save.go
@@ -29,10 +29,17 @@ func (config *Config) Save(ctx context.Context) (Err logging.LogErrorInfo) {
 
 	// Sub-action: Write config to file
 	subActionWrite := logAction.AddSubAction("Write Config to File", logging.LevelTrace)
-	if writeErr := os.WriteFile(path.Join(ConfigPath, "config.yaml"), data, 0644); writeErr != nil {
+	configFile := path.Join(ConfigPath, "config.yaml")
+	if writeErr := os.WriteFile(configFile, data, 0o600); writeErr != nil {
 		subActionWrite.SetError("Failed to write config to file", writeErr.Error(), nil)
 		logAction.Status = logging.StatusError
 		return *subActionWrite.Error
+	}
+	// WriteFile only applies its mode when creating the file, so an existing config keeps
+	// whatever mode it already had. Not fatal: /config is often a network share where
+	// chmod is unsupported.
+	if chmodErr := os.Chmod(configFile, 0o600); chmodErr != nil {
+		logging.LOGGER.Warn().Timestamp().Str("error", chmodErr.Error()).Msg("Could not restrict config.yaml permissions")
 	}
 	subActionWrite.Complete()
 

--- a/backend/notification/webhook.go
+++ b/backend/notification/webhook.go
@@ -35,7 +35,7 @@ func SendWebhookMessage(ctx context.Context, provider *config.Config_Notificatio
 		return *logAction.Error
 	}
 
-	httpResp, respBody, Err := httpx.MakeHTTPRequest(ctx, provider.URL, http.MethodPost, provider.Headers, 60, payloadBytes, "Webhook")
+	httpResp, respBody, Err := httpx.MakeHTTPRequest(ctx, provider.URL, http.MethodPost, provider.Headers, 60, payloadBytes, httpx.WebhookSiteName)
 	if Err.Message != "" {
 		return Err
 	}

--- a/backend/notification/webhook.go
+++ b/backend/notification/webhook.go
@@ -35,7 +35,7 @@ func SendWebhookMessage(ctx context.Context, provider *config.Config_Notificatio
 		return *logAction.Error
 	}
 
-	httpResp, respBody, Err := httpx.MakeHTTPRequest(ctx, provider.URL, http.MethodPost, provider.Headers, 60, payloadBytes, provider.URL)
+	httpResp, respBody, Err := httpx.MakeHTTPRequest(ctx, provider.URL, http.MethodPost, provider.Headers, 60, payloadBytes, "Webhook")
 	if Err.Message != "" {
 		return Err
 	}

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -303,12 +303,8 @@ func checkConfigDifferences_MediaServer(ctx context.Context, oldMediaServer conf
 
 		if oldMediaServer.ApiToken != newMediaServer.ApiToken {
 			if !strings.HasPrefix(newMediaServer.ApiToken, "***") {
-				logAction.AppendResult("MediaServer.ApiToken changed", fmt.Sprintf("from '%s' to '%s'", oldMediaServer.ApiToken, newMediaServer.ApiToken))
-				logging.LOGGER.Info().
-					Timestamp().
-					Str("old_api_token", fmt.Sprintf("%s", oldMediaServer.ApiToken)).
-					Str("new_api_token", fmt.Sprintf("%s", newMediaServer.ApiToken)).
-					Msg("MediaServer.ApiToken changed")
+				logAction.AppendResult("MediaServer.ApiToken changed", "api token updated")
+				logging.LOGGER.Info().Timestamp().Msg("MediaServer.ApiToken changed")
 				changed = true
 			} else if newMediaServer.URL != oldMediaServer.URL {
 				// A masked token can only be restored for the URL it was issued for. Otherwise the
@@ -376,12 +372,8 @@ func checkConfigDifferences_Mediux(ctx context.Context, oldMediux config.Config_
 	if !reflect.DeepEqual(oldMediux, newMediux) {
 		if oldMediux.ApiToken != newMediux.ApiToken {
 			if !strings.HasPrefix(newMediux.ApiToken, "***") {
-				logAction.AppendResult("Mediux.ApiToken changed", fmt.Sprintf("from '%s' to '%s'", oldMediux.ApiToken, newMediux.ApiToken))
-				logging.LOGGER.Info().
-					Timestamp().
-					Str("old_api_token", fmt.Sprintf("%v", oldMediux.ApiToken)).
-					Str("new_api_token", fmt.Sprintf("%v", newMediux.ApiToken)).
-					Msg("Mediux.ApiToken changed")
+				logAction.AppendResult("Mediux.ApiToken changed", "api token updated")
+				logging.LOGGER.Info().Timestamp().Msg("Mediux.ApiToken changed")
 				changed = true
 			} else {
 				newMediux.ApiToken = oldMediux.ApiToken
@@ -554,12 +546,8 @@ func checkConfigDifferences_TMDB(ctx context.Context, oldTMDB config.Config_TMDB
 	if !reflect.DeepEqual(oldTMDB, newTMDB) {
 		if oldTMDB.ApiToken != newTMDB.ApiToken {
 			if !strings.HasPrefix(newTMDB.ApiToken, "***") {
-				logAction.AppendResult("TMDB.ApiToken changed", fmt.Sprintf("from '%s' to '%s'", oldTMDB.ApiToken, newTMDB.ApiToken))
-				logging.LOGGER.Info().
-					Timestamp().
-					Str("old_api_token", fmt.Sprintf("%v", oldTMDB.ApiToken)).
-					Str("new_api_token", fmt.Sprintf("%v", newTMDB.ApiToken)).
-					Msg("TMDB.ApiToken changed")
+				logAction.AppendResult("TMDB.ApiToken changed", "api token updated")
+				logging.LOGGER.Info().Timestamp().Msg("TMDB.ApiToken changed")
 				changed = true
 			} else {
 				newTMDB.ApiToken = oldTMDB.ApiToken
@@ -823,12 +811,8 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 				}
 				if oldWebhook != newWebhook {
 					if !config.IsMaskedWebhook(newWebhook) {
-						logAction.AppendResult("Notifications.Discord.Webhook changed", fmt.Sprintf("from '%v' to '%v'", oldWebhook, newWebhook))
-						logging.LOGGER.Info().
-							Timestamp().
-							Str("old_webhook", oldWebhook).
-							Str("new_webhook", newWebhook).
-							Msg("Notifications.Discord.Webhook changed")
+						logAction.AppendResult("Notifications.Discord.Webhook changed", "webhook url updated")
+						logging.LOGGER.Info().Timestamp().Msg("Notifications.Discord.Webhook changed")
 						changed = true
 					} else {
 						newProv.Discord.Webhook = oldProv.Discord.Webhook
@@ -847,12 +831,8 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 				}
 				if oldUserKey != newUserKey {
 					if !strings.HasPrefix(newUserKey, "***") {
-						logAction.AppendResult("Notifications.Pushover.UserKey changed", fmt.Sprintf("from '%v' to '%v'", oldUserKey, newUserKey))
-						logging.LOGGER.Info().
-							Timestamp().
-							Str("old_user_key", oldUserKey).
-							Str("new_user_key", newUserKey).
-							Msg("Notifications.Pushover.UserKey changed")
+						logAction.AppendResult("Notifications.Pushover.UserKey changed", "user key updated")
+						logging.LOGGER.Info().Timestamp().Msg("Notifications.Pushover.UserKey changed")
 						changed = true
 					} else {
 						newProv.Pushover.UserKey = oldProv.Pushover.UserKey
@@ -861,12 +841,8 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 				}
 				if oldToken != newToken {
 					if !strings.HasPrefix(newToken, "***") {
-						logAction.AppendResult("Notifications.Pushover.ApiToken changed", fmt.Sprintf("from '%v' to '%v'", oldToken, newToken))
-						logging.LOGGER.Info().
-							Timestamp().
-							Str("old_api_token", oldToken).
-							Str("new_api_token", newToken).
-							Msg("Notifications.Pushover.ApiToken changed")
+						logAction.AppendResult("Notifications.Pushover.ApiToken changed", "api token updated")
+						logging.LOGGER.Info().Timestamp().Msg("Notifications.Pushover.ApiToken changed")
 						changed = true
 					} else {
 						newProv.Pushover.ApiToken = oldProv.Pushover.ApiToken
@@ -896,12 +872,8 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 				if oldProv.Gotify != nil && newProv.Gotify != nil {
 					if oldProv.Gotify.ApiToken != newProv.Gotify.ApiToken {
 						if !strings.HasPrefix(newProv.Gotify.ApiToken, "***") {
-							logAction.AppendResult("Notifications.Gotify.ApiToken changed", fmt.Sprintf("from '%v' to '%v'", oldProv.Gotify.ApiToken, newProv.Gotify.ApiToken))
-							logging.LOGGER.Info().
-								Timestamp().
-								Str("old_api_token", fmt.Sprintf("%s", oldProv.Gotify.ApiToken)).
-								Str("new_api_token", fmt.Sprintf("%s", newProv.Gotify.ApiToken)).
-								Msg("Notifications.Gotify.ApiToken changed")
+							logAction.AppendResult("Notifications.Gotify.ApiToken changed", "api token updated")
+							logging.LOGGER.Info().Timestamp().Msg("Notifications.Gotify.ApiToken changed")
 							changed = true
 						} else {
 							newProv.Gotify.ApiToken = oldProv.Gotify.ApiToken
@@ -918,12 +890,8 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 					newURL = strings.TrimSpace(newProv.Webhook.URL)
 				}
 				if oldURL != newURL {
-					logAction.AppendResult("Notifications.Webhook.URL changed", fmt.Sprintf("from '%v' to '%v'", oldURL, newURL))
-					logging.LOGGER.Info().
-						Timestamp().
-						Str("old_webhook_url", oldURL).
-						Str("new_webhook_url", newURL).
-						Msg("Notifications.Webhook.URL changed")
+					logAction.AppendResult("Notifications.Webhook.URL changed", "webhook url updated")
+					logging.LOGGER.Info().Timestamp().Msg("Notifications.Webhook.URL changed")
 					changed = true
 				}
 
@@ -940,23 +908,20 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 				for k, oldV := range oldHeaders {
 					newV, ok := newHeaders[k]
 					if !ok || oldV != newV {
-						logAction.AppendResult("Notifications.Webhook.Header changed", fmt.Sprintf("Header '%s' changed from '%s' to '%s'", k, oldV, newV))
+						logAction.AppendResult("Notifications.Webhook.Header changed", fmt.Sprintf("Header '%s' updated", k))
 						logging.LOGGER.Info().
 							Timestamp().
 							Str("header_key", k).
-							Str("old_value", oldV).
-							Str("new_value", newV).
 							Msg("Notifications.Webhook.Header changed")
 						changed = true
 					}
 				}
-				for k, newV := range newHeaders {
+				for k := range newHeaders {
 					if _, ok := oldHeaders[k]; !ok {
-						logAction.AppendResult("Notifications.Webhook.Header added", fmt.Sprintf("Header '%s' added with value '%s'", k, newV))
+						logAction.AppendResult("Notifications.Webhook.Header added", fmt.Sprintf("Header '%s' added", k))
 						logging.LOGGER.Info().
 							Timestamp().
 							Str("header_key", k).
-							Str("new_value", newV).
 							Msg("Notifications.Webhook.Header added")
 						changed = true
 					}
@@ -1087,12 +1052,10 @@ func checkConfigDifferences_SonarrRadarr(ctx context.Context, oldSR config.Confi
 			// Per App - ApiToken
 			if oldProv.ApiToken != newProv.ApiToken {
 				if !strings.HasPrefix(newProv.ApiToken, "***") {
-					logAction.AppendResult("SonarrRadarr.Application.ApiToken changed", fmt.Sprintf("from '%s' to '%s'", oldProv.ApiToken, newProv.ApiToken))
+					logAction.AppendResult("SonarrRadarr.Application.ApiToken changed", "api token updated")
 					logging.LOGGER.Info().
 						Timestamp().
 						Str("application", name).
-						Str("old_api_token", oldProv.ApiToken).
-						Str("new_api_token", newProv.ApiToken).
 						Msg("SonarrRadarr.Application ApiToken changed")
 					changed = true
 				} else {

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -1244,10 +1244,13 @@ func restoreMaskedWebhookHeaders(oldProviders, newProviders []config.Config_Noti
 	return resolved
 }
 
+// Provider names are matched case-insensitively because this runs before validation, and
+// ValidateNotificationsProvider title-cases the name afterwards. An exact match would skip a
+// provider submitted as "webhook", leaving its masked headers to be saved as the credential.
 func webhookProviders(items []config.Config_Notification_Provider) []*config.Config_Notification_Webhook {
 	var webhooks []*config.Config_Notification_Webhook
 	for _, provider := range items {
-		if provider.Provider == "Webhook" && provider.Webhook != nil {
+		if strings.EqualFold(provider.Provider, "Webhook") && provider.Webhook != nil {
 			webhooks = append(webhooks, provider.Webhook)
 		}
 	}

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -1211,43 +1211,47 @@ func joinNonEmptyComma(items []string) string {
 // restoreMaskedWebhookHeaders puts the stored value back wherever the UI echoed back a
 // masked header, and reports whether every mask was resolvable.
 //
-// A masked header is only restorable from the provider that issued it: same URL, same key.
-// Restoring across a URL change would re-point the real credential at whatever endpoint the
-// caller supplied, and a renamed key has no stored counterpart at all - leaving that one
-// alone would save the mask text itself as the credential.
+// Providers are paired by their position in the webhook list, because that is the only
+// stable identity available: URL, header key and mask can all coincide across two providers
+// (MaskToken is derived from the value, so two secrets ending the same way mask the same),
+// and searching by those would hand back another provider's credential. The URL must still
+// match at that position, so a masked header is never re-pointed at a different endpoint -
+// reordering or removing a provider simply fails the save and asks for the full value.
 func restoreMaskedWebhookHeaders(oldProviders, newProviders []config.Config_Notification_Provider) bool {
+	oldWebhooks := webhookProviders(oldProviders)
+	newWebhooks := webhookProviders(newProviders)
+
 	resolved := true
-	for _, newProv := range newProviders {
-		if newProv.Provider != "Webhook" || newProv.Webhook == nil {
-			continue
-		}
-		for key, value := range newProv.Webhook.Headers {
+	for i, newWebhook := range newWebhooks {
+		for key, value := range newWebhook.Headers {
 			if !config.IsMaskedField(value) {
 				continue
 			}
-			stored, ok := storedWebhookHeader(oldProviders, newProv.Webhook.URL, key, value)
-			if !ok {
+			if i >= len(oldWebhooks) || oldWebhooks[i].URL != newWebhook.URL {
 				resolved = false
 				continue
 			}
-			newProv.Webhook.Headers[key] = stored
+			// Requiring the mask this exact value would produce stops a caller passing an
+			// arbitrary "***" string to fish out a stored credential.
+			stored, ok := oldWebhooks[i].Headers[key]
+			if !ok || value != config.MaskToken(stored) {
+				resolved = false
+				continue
+			}
+			newWebhook.Headers[key] = stored
 		}
 	}
 	return resolved
 }
 
-// storedWebhookHeader finds the header value behind a mask, requiring the mask to be the one
-// this exact value would produce so a caller cannot pass an arbitrary "***" string.
-func storedWebhookHeader(oldProviders []config.Config_Notification_Provider, url, key, masked string) (string, bool) {
-	for _, oldProv := range oldProviders {
-		if oldProv.Provider != "Webhook" || oldProv.Webhook == nil || oldProv.Webhook.URL != url {
-			continue
-		}
-		if stored, ok := oldProv.Webhook.Headers[key]; ok && masked == config.MaskToken(stored) {
-			return stored, true
+func webhookProviders(items []config.Config_Notification_Provider) []*config.Config_Notification_Webhook {
+	var webhooks []*config.Config_Notification_Webhook
+	for _, provider := range items {
+		if provider.Provider == "Webhook" && provider.Webhook != nil {
+			webhooks = append(webhooks, provider.Webhook)
 		}
 	}
-	return "", false
+	return webhooks
 }
 
 func providerMapNotifications(items []config.Config_Notification_Provider) map[string]config.Config_Notification_Provider {

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -746,9 +746,13 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 			changed = true
 		}
 
-		// Set when a masked webhook header cannot be safely resolved, which fails the whole
-		// save rather than persisting either a literal mask or a mispaired credential.
-		maskedHeaderUnresolved := false
+		// Resolved over the full slice, not the type-keyed map below: that map keeps only one
+		// entry per provider type, and a config may hold several Webhook providers.
+		maskedHeaderUnresolved := !restoreMaskedWebhookHeaders(oldNotifications.Providers, newNotifications.Providers)
+		if maskedHeaderUnresolved {
+			logAction.SetError("Unable to unmask webhook header",
+				"Provide the full header value when changing a webhook URL or renaming a header", nil)
+		}
 
 		// Providers diff
 		oldMap := providerMapNotifications(oldNotifications.Providers)
@@ -906,26 +910,7 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 					maps.Copy(oldHeaders, oldProv.Webhook.Headers)
 				}
 				if newProv.Webhook != nil {
-					// The UI is served masked header values; echoing one back means
-					// "unchanged", not "set this header to ***abcd".
-					for key, value := range newProv.Webhook.Headers {
-						if !config.IsMaskedField(value) {
-							continue
-						}
-						oldValue, ok := oldHeaders[key]
-						// A masked header is only restorable for the URL it was issued
-						// for, under the key it was issued under. Restoring it across a
-						// URL change would re-point the real credential at a new
-						// endpoint; restoring it under a renamed key is impossible, and
-						// leaving it would save the mask text as the credential.
-						if !ok || oldURL != newURL {
-							logAction.SetError("Unable to unmask webhook header",
-								fmt.Sprintf("Provide the full value for header '%s' when changing the webhook URL or renaming a header", key), nil)
-							maskedHeaderUnresolved = true
-							continue
-						}
-						newProv.Webhook.Headers[key] = oldValue
-					}
+					// Masked values were already resolved above, across every provider.
 					maps.Copy(newHeaders, newProv.Webhook.Headers)
 				}
 				// Check for changes
@@ -1223,6 +1208,48 @@ func joinNonEmptyComma(items []string) string {
 }
 
 // providerMapNotifications creates a map of notification providers keyed by provider name.
+// restoreMaskedWebhookHeaders puts the stored value back wherever the UI echoed back a
+// masked header, and reports whether every mask was resolvable.
+//
+// A masked header is only restorable from the provider that issued it: same URL, same key.
+// Restoring across a URL change would re-point the real credential at whatever endpoint the
+// caller supplied, and a renamed key has no stored counterpart at all - leaving that one
+// alone would save the mask text itself as the credential.
+func restoreMaskedWebhookHeaders(oldProviders, newProviders []config.Config_Notification_Provider) bool {
+	resolved := true
+	for _, newProv := range newProviders {
+		if newProv.Provider != "Webhook" || newProv.Webhook == nil {
+			continue
+		}
+		for key, value := range newProv.Webhook.Headers {
+			if !config.IsMaskedField(value) {
+				continue
+			}
+			stored, ok := storedWebhookHeader(oldProviders, newProv.Webhook.URL, key, value)
+			if !ok {
+				resolved = false
+				continue
+			}
+			newProv.Webhook.Headers[key] = stored
+		}
+	}
+	return resolved
+}
+
+// storedWebhookHeader finds the header value behind a mask, requiring the mask to be the one
+// this exact value would produce so a caller cannot pass an arbitrary "***" string.
+func storedWebhookHeader(oldProviders []config.Config_Notification_Provider, url, key, masked string) (string, bool) {
+	for _, oldProv := range oldProviders {
+		if oldProv.Provider != "Webhook" || oldProv.Webhook == nil || oldProv.Webhook.URL != url {
+			continue
+		}
+		if stored, ok := oldProv.Webhook.Headers[key]; ok && masked == config.MaskToken(stored) {
+			return stored, true
+		}
+	}
+	return "", false
+}
+
 func providerMapNotifications(items []config.Config_Notification_Provider) map[string]config.Config_Notification_Provider {
 	m := make(map[string]config.Config_Notification_Provider, len(items))
 	for _, p := range items {

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -902,6 +902,16 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 					maps.Copy(oldHeaders, oldProv.Webhook.Headers)
 				}
 				if newProv.Webhook != nil {
+					// The UI is served masked header values; echoing one back means
+					// "unchanged", not "set this header to ***abcd".
+					for key, value := range newProv.Webhook.Headers {
+						if !config.IsMaskedField(value) {
+							continue
+						}
+						if oldValue, ok := oldHeaders[key]; ok {
+							newProv.Webhook.Headers[key] = oldValue
+						}
+					}
 					maps.Copy(newHeaders, newProv.Webhook.Headers)
 				}
 				// Check for changes

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -746,6 +746,10 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 			changed = true
 		}
 
+		// Set when a masked webhook header cannot be safely resolved, which fails the whole
+		// save rather than persisting either a literal mask or a mispaired credential.
+		maskedHeaderUnresolved := false
+
 		// Providers diff
 		oldMap := providerMapNotifications(oldNotifications.Providers)
 		newMap := providerMapNotifications(newNotifications.Providers)
@@ -908,9 +912,19 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 						if !config.IsMaskedField(value) {
 							continue
 						}
-						if oldValue, ok := oldHeaders[key]; ok {
-							newProv.Webhook.Headers[key] = oldValue
+						oldValue, ok := oldHeaders[key]
+						// A masked header is only restorable for the URL it was issued
+						// for, under the key it was issued under. Restoring it across a
+						// URL change would re-point the real credential at a new
+						// endpoint; restoring it under a renamed key is impossible, and
+						// leaving it would save the mask text as the credential.
+						if !ok || oldURL != newURL {
+							logAction.SetError("Unable to unmask webhook header",
+								fmt.Sprintf("Provide the full value for header '%s' when changing the webhook URL or renaming a header", key), nil)
+							maskedHeaderUnresolved = true
+							continue
 						}
+						newProv.Webhook.Headers[key] = oldValue
 					}
 					maps.Copy(newHeaders, newProv.Webhook.Headers)
 				}
@@ -958,6 +972,9 @@ func checkConfigDifferences_Notifications(ctx context.Context, oldNotifications 
 			changed = true
 		}
 
+		if maskedHeaderUnresolved {
+			return changed, false
+		}
 	}
 	newValid = config.ValidateNotifications(ctx, newNotifications)
 	return changed, newValid

--- a/backend/routing/config/update_notifications_test.go
+++ b/backend/routing/config/update_notifications_test.go
@@ -122,6 +122,27 @@ func TestWebhookMaskedHeadersRestoredForEveryProvider(t *testing.T) {
 	}
 }
 
+// This pass runs before ValidateNotificationsProvider title-cases the name, so a provider
+// submitted as "webhook" must still have its masks resolved rather than saved literally.
+func TestWebhookMaskedHeaderRestoredForLowercaseProviderName(t *testing.T) {
+	oldNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": webhookSecret,
+	})
+	newNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": config.MaskToken(webhookSecret),
+	})
+	newNotifications.Providers[0].Provider = "webhook"
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if !valid {
+		t.Fatal("a lowercase provider name should still resolve its masks")
+	}
+	if got := newNotifications.Providers[0].Webhook.Headers["Authorization"]; got != webhookSecret {
+		t.Errorf("header = %q, want %q rather than the mask saved literally", got, webhookSecret)
+	}
+}
+
 // MaskToken is derived from the value, so two secrets ending the same way produce the same
 // mask. With a shared URL and key, nothing but position distinguishes the two providers.
 func TestWebhookMaskedHeadersWithCollidingMasksStayWithTheirProvider(t *testing.T) {

--- a/backend/routing/config/update_notifications_test.go
+++ b/backend/routing/config/update_notifications_test.go
@@ -1,0 +1,78 @@
+package routes_config
+
+import (
+	"aura/config"
+	"testing"
+)
+
+const webhookSecret = "Bearer super-secret-value"
+
+func webhookNotifications(url string, headers map[string]string) config.Config_Notifications {
+	return config.Config_Notifications{
+		Enabled: true,
+		Providers: []config.Config_Notification_Provider{
+			{
+				Provider: "Webhook",
+				Enabled:  true,
+				Webhook:  &config.Config_Notification_Webhook{URL: url, Headers: headers},
+			},
+		},
+	}
+}
+
+// Re-sending the masked header the UI was given means "leave it alone". Taking it at face
+// value would overwrite the real credential with its own mask.
+func TestWebhookMaskedHeaderIsRestored(t *testing.T) {
+	oldNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": webhookSecret,
+	})
+	newNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": config.MaskToken(webhookSecret),
+	})
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if got := newNotifications.Providers[0].Webhook.Headers["Authorization"]; got != webhookSecret {
+		t.Errorf("header = %q, want the stored credential preserved", got)
+	}
+	if !valid {
+		t.Error("restoring a masked header must leave the config valid")
+	}
+}
+
+// The credential was issued for one endpoint. Restoring it alongside a new URL would send
+// the real Authorization value to whatever endpoint the caller supplied.
+func TestWebhookMaskedHeaderRejectedWhenURLChanges(t *testing.T) {
+	oldNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": webhookSecret,
+	})
+	newNotifications := webhookNotifications("https://attacker.example.net/collect", map[string]string{
+		"Authorization": config.MaskToken(webhookSecret),
+	})
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if valid {
+		t.Fatal("a masked header must not be restored across a URL change")
+	}
+	if got := newNotifications.Providers[0].Webhook.Headers["Authorization"]; got == webhookSecret {
+		t.Errorf("header = %q, want the real credential withheld from the new URL", got)
+	}
+}
+
+// A renamed key has no stored counterpart, so the mask cannot be resolved. Saving it would
+// write the literal mask text as the credential and break webhook auth.
+func TestWebhookMaskedHeaderRejectedWhenKeyRenamed(t *testing.T) {
+	oldNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"Authorization": webhookSecret,
+	})
+	newNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+		"X-Auth": config.MaskToken(webhookSecret),
+	})
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if valid {
+		t.Fatal("a masked header under a renamed key must be rejected, not saved as the mask")
+	}
+}

--- a/backend/routing/config/update_notifications_test.go
+++ b/backend/routing/config/update_notifications_test.go
@@ -60,6 +60,92 @@ func TestWebhookMaskedHeaderRejectedWhenURLChanges(t *testing.T) {
 	}
 }
 
+// providerMapNotifications keeps one entry per provider type, so a config with several
+// Webhook providers must not have its masks resolved through that map - the others would
+// keep their masks and be saved as credentials.
+func TestWebhookMaskedHeadersRestoredForEveryProvider(t *testing.T) {
+	const secondSecret = "Bearer second-secret-value"
+
+	oldNotifications := config.Config_Notifications{
+		Enabled: true,
+		Providers: []config.Config_Notification_Provider{
+			{
+				Provider: "Webhook",
+				Enabled:  true,
+				Webhook: &config.Config_Notification_Webhook{
+					URL:     "https://first.example.com/notify",
+					Headers: map[string]string{"Authorization": webhookSecret},
+				},
+			},
+			{
+				Provider: "Webhook",
+				Enabled:  true,
+				Webhook: &config.Config_Notification_Webhook{
+					URL:     "https://second.example.com/notify",
+					Headers: map[string]string{"Authorization": secondSecret},
+				},
+			},
+		},
+	}
+	newNotifications := config.Config_Notifications{
+		Enabled: true,
+		Providers: []config.Config_Notification_Provider{
+			{
+				Provider: "Webhook",
+				Enabled:  true,
+				Webhook: &config.Config_Notification_Webhook{
+					URL:     "https://first.example.com/notify",
+					Headers: map[string]string{"Authorization": config.MaskToken(webhookSecret)},
+				},
+			},
+			{
+				Provider: "Webhook",
+				Enabled:  true,
+				Webhook: &config.Config_Notification_Webhook{
+					URL:     "https://second.example.com/notify",
+					Headers: map[string]string{"Authorization": config.MaskToken(secondSecret)},
+				},
+			},
+		},
+	}
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if !valid {
+		t.Fatal("masks from every webhook provider should resolve")
+	}
+	if got := newNotifications.Providers[0].Webhook.Headers["Authorization"]; got != webhookSecret {
+		t.Errorf("first provider header = %q, want %q", got, webhookSecret)
+	}
+	if got := newNotifications.Providers[1].Webhook.Headers["Authorization"]; got != secondSecret {
+		t.Errorf("second provider header = %q, want %q", got, secondSecret)
+	}
+}
+
+// MaskToken keeps only the last character of a value shorter than four, so a matcher built on
+// a fixed three-character suffix can never recognise these.
+func TestWebhookShortMaskedHeaderIsRestored(t *testing.T) {
+	for _, short := range []string{"a", "ab", "abc"} {
+		t.Run(short, func(t *testing.T) {
+			oldNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+				"X-Token": short,
+			})
+			newNotifications := webhookNotifications("https://hooks.example.com/notify", map[string]string{
+				"X-Token": config.MaskToken(short),
+			})
+
+			_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+			if !valid {
+				t.Fatalf("mask of short value %q should resolve", short)
+			}
+			if got := newNotifications.Providers[0].Webhook.Headers["X-Token"]; got != short {
+				t.Errorf("header = %q, want %q", got, short)
+			}
+		})
+	}
+}
+
 // A renamed key has no stored counterpart, so the mask cannot be resolved. Saving it would
 // write the literal mask text as the credential and break webhook auth.
 func TestWebhookMaskedHeaderRejectedWhenKeyRenamed(t *testing.T) {

--- a/backend/routing/config/update_notifications_test.go
+++ b/backend/routing/config/update_notifications_test.go
@@ -122,6 +122,57 @@ func TestWebhookMaskedHeadersRestoredForEveryProvider(t *testing.T) {
 	}
 }
 
+// MaskToken is derived from the value, so two secrets ending the same way produce the same
+// mask. With a shared URL and key, nothing but position distinguishes the two providers.
+func TestWebhookMaskedHeadersWithCollidingMasksStayWithTheirProvider(t *testing.T) {
+	const firstSecret = "first-secret-abcd"
+	const secondSecret = "second-secret-abcd"
+
+	if config.MaskToken(firstSecret) != config.MaskToken(secondSecret) {
+		t.Fatal("test needs two secrets whose masks collide")
+	}
+
+	sharedURL := "https://hooks.example.com/notify"
+	pair := func(first, second string) config.Config_Notifications {
+		return config.Config_Notifications{
+			Enabled: true,
+			Providers: []config.Config_Notification_Provider{
+				{
+					Provider: "Webhook",
+					Enabled:  true,
+					Webhook: &config.Config_Notification_Webhook{
+						URL:     sharedURL,
+						Headers: map[string]string{"Authorization": first},
+					},
+				},
+				{
+					Provider: "Webhook",
+					Enabled:  true,
+					Webhook: &config.Config_Notification_Webhook{
+						URL:     sharedURL,
+						Headers: map[string]string{"Authorization": second},
+					},
+				},
+			},
+		}
+	}
+
+	oldNotifications := pair(firstSecret, secondSecret)
+	newNotifications := pair(config.MaskToken(firstSecret), config.MaskToken(secondSecret))
+
+	_, valid := checkConfigDifferences_Notifications(testContext(), oldNotifications, &newNotifications)
+
+	if !valid {
+		t.Fatal("both masks should resolve")
+	}
+	if got := newNotifications.Providers[0].Webhook.Headers["Authorization"]; got != firstSecret {
+		t.Errorf("first provider header = %q, want %q", got, firstSecret)
+	}
+	if got := newNotifications.Providers[1].Webhook.Headers["Authorization"]; got != secondSecret {
+		t.Errorf("second provider header = %q, want %q - the first provider's secret must not leak across", got, secondSecret)
+	}
+}
+
 // MaskToken keeps only the last character of a value shorter than four, so a matcher built on
 // a fixed three-character suffix can never recognise these.
 func TestWebhookShortMaskedHeaderIsRestored(t *testing.T) {

--- a/backend/routing/middleware/authenticator.go
+++ b/backend/routing/middleware/authenticator.go
@@ -18,8 +18,8 @@ import (
 //
 // It skips authentication for the following routes:
 //   - /api/login
-//   - /api/mediaserver/image/*
-//   - /api/mediux/image/*
+//   - GET /api/images/* (image tags cannot send an Authorization header)
+//   - /api/sonarr/webhook and /api/radarr/webhook (called by Sonarr/Radarr)
 //
 // If authentication is globally disabled in the configuration, it allows all requests to pass through.
 func Authenticator(next http.Handler) http.Handler {
@@ -30,9 +30,10 @@ func Authenticator(next http.Handler) http.Handler {
 			return
 		}
 
-		// Public login route
+		// Public login route. The image exemption is GET-only so it cannot also cover the
+		// destructive DELETE /api/images/temp.
 		if strings.HasPrefix(r.URL.Path, "/api/login") ||
-			strings.HasPrefix(r.URL.Path, "/api/images") ||
+			(r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/images")) ||
 			strings.HasPrefix(r.URL.Path, "/api/sonarr/webhook") ||
 			strings.HasPrefix(r.URL.Path, "/api/radarr/webhook") {
 			next.ServeHTTP(w, r)

--- a/backend/routing/middleware/authenticator_test.go
+++ b/backend/routing/middleware/authenticator_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The image exemption exists so <img> tags can load without an Authorization header.
+// It must not also exempt the destructive DELETE on the same prefix.
+func TestAuthenticatorImageExemptionIsGetOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		wantAllowed bool
+	}{
+		{"image GET is exempt", http.MethodGet, "/api/images/media/item", true},
+		{"image DELETE is not exempt", http.MethodDelete, "/api/images/temp", false},
+		{"login is exempt", http.MethodPost, "/api/login", true},
+		{"sonarr webhook is exempt", http.MethodPost, "/api/sonarr/webhook", true},
+		{"search is not exempt", http.MethodGet, "/api/search", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withAuthEnabled(t, true)
+
+			reached := false
+			handler := Authenticator(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+			}))
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(tt.method, tt.path, nil))
+
+			if reached != tt.wantAllowed {
+				t.Errorf("%s %s: reached handler = %v, want %v", tt.method, tt.path, reached, tt.wantAllowed)
+			}
+			if !tt.wantAllowed && recorder.Code != http.StatusUnauthorized {
+				t.Errorf("%s %s: status = %d, want %d", tt.method, tt.path, recorder.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+}

--- a/backend/routing/middleware/middleware.go
+++ b/backend/routing/middleware/middleware.go
@@ -19,6 +19,7 @@ Middlewares included:
 - CORS Middleware: Allows CORS for all origins (replace this with specific origins).
 - RealIP Middleware: Gets the client's real public IP address from the request headers.
 - StripSlashes Middleware: Strips slashes to no slash URL versions.
+- Request Body Limit Middleware: Caps how much of a request body will be read.
 - Panic Recovery Middleware: Recovers from panics and returns a 500 error.
 
 Parameters:
@@ -27,6 +28,10 @@ Parameters:
 */
 func Configure(r *chi.Mux) {
 
+	// Wildcard is safe alongside AllowCredentials here: rs/cors emits a literal "*" rather
+	// than reflecting the request Origin, and browsers refuse to attach credentials to a
+	// "*" response. Cross-origin reads therefore arrive without a session and are rejected
+	// by the Authenticator. Static linters flag this pair on sight; it is not exploitable.
 	AllowedOrigins := []string{"*"}
 
 	// CORS Middleware: Allow CORS for all origins (replace this with specific origins)
@@ -49,6 +54,10 @@ func Configure(r *chi.Mux) {
 	// Custom middleware to remove extra slashes
 	r.Use(removeExtraSlashes)
 
+	// Cap request bodies. /api/login and the Sonarr/Radarr webhooks take unauthenticated
+	// POSTs, and every handler reads the body fully into memory before decoding it.
+	r.Use(limitRequestBody)
+
 	// Logging Middleware: Custom logging middleware
 	r.Use(LoggingMiddleware)
 
@@ -59,6 +68,17 @@ func Configure(r *chi.Mux) {
 func removeExtraSlashes(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = strings.ReplaceAll(r.URL.Path, "//", "/")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// maxRequestBody sits far above any legitimate payload. The largest real request is a saved
+// item for a long-running show, which carries nested episode JSON; nothing here uploads files.
+const maxRequestBody = 8 << 20
+
+func limitRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/backend/routing/routes.go
+++ b/backend/routing/routes.go
@@ -75,9 +75,6 @@ func AddRoutes(r *chi.Mux) {
 		r.Get("/auth/oidc/login", routes_auth.StartOIDCLogin)
 		r.Get("/auth/oidc/callback", routes_auth.HandleOIDCCallback)
 
-		// Search - Public Search Endpoint (Media Items, Saved Sets and MediUX Users)
-		r.Get("/search", routes_search.HandleSearch)
-
 		// Sonarr Webhook Routes - Public since Sonarr/Radarr need to access it without authentication
 		r.Post("/sonarr/webhook", routes_sonarr_radarr.SonarrWebhookHandler)
 		r.Post("/radarr/webhook", routes_sonarr_radarr.RadarrWebhookHandler)
@@ -157,6 +154,9 @@ func AddRoutes(r *chi.Mux) {
 
 			// Labels & Tags Route
 			r.Post("/labels-tags", routes_labels_tags.ApplyLabelsAndTagsToItem)
+
+			// Search - enumerates library media items, saved sets and MediUX users
+			r.Get("/search", routes_search.HandleSearch)
 
 			// Logging Routes
 			r.Route("/logs", func(r chi.Router) {

--- a/backend/routing/routes.go
+++ b/backend/routing/routes.go
@@ -226,11 +226,9 @@ func addOnboardingRoutes(r *chi.Mux) {
 		r.Get("/oauth/plex", routes_plex.GetPlexPinAndID)
 		r.Post("/oauth/plex", routes_plex.CheckAuthStatusWithPlex)
 
-		// Logging Routes
-		r.Route("/logs", func(r chi.Router) {
-			r.Get("/", routes_logging.GetLogContents)
-			r.Delete("/", routes_logging.ClearLogFiles)
-		})
+		// Logging routes are deliberately absent here. Onboarding is unauthenticated, and
+		// the log file carries historical credentials, so it must not be readable before a
+		// session exists. Setup never needs it.
 
 		r.Post("/mediaserver/libraries/options", routes_ms.GetLibrarySectionOptions)
 

--- a/backend/routing/validation/mediaserver.go
+++ b/backend/routing/validation/mediaserver.go
@@ -72,8 +72,10 @@ func ValidateMediaServerInfo(w http.ResponseWriter, r *http.Request) {
 		httpx.SendResponse(w, ld, response)
 		return
 	} else if !connectionOk {
+		maskedInfo := mediaServerInfo
+		maskedInfo.ApiToken = config.MaskToken(maskedInfo.ApiToken)
 		logAction.SetError("Failed to connect to media server with provided information", "Please check the media server settings and try again", map[string]any{
-			"media_server_info": mediaServerInfo,
+			"media_server_info": maskedInfo,
 		})
 		httpx.SendResponse(w, ld, response)
 		return

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -347,13 +347,12 @@ func getUnmaskedDiscordWebhook(currentValue string) string {
 	return ""
 }
 
-// maskedFieldMatches reports whether maskedValue is a masked representation of realValue, i.e.
-// their last few characters agree, mirroring the masking scheme in config.IsMaskedField.
+// maskedFieldMatches reports whether maskedValue is the mask of realValue. Comparing against
+// config.MaskToken directly follows the real scheme at every length: MaskToken keeps only the
+// last character of a value shorter than four, which a fixed three-character suffix compare
+// could never match.
 func maskedFieldMatches(maskedValue, realValue string) bool {
-	if len(maskedValue) <= 3 || len(realValue) < 3 {
-		return false
-	}
-	return maskedValue[len(maskedValue)-3:] == realValue[len(realValue)-3:]
+	return maskedValue == config.MaskToken(realValue)
 }
 
 // unmaskWebhookHeaders restores masked header values from the stored provider that has the

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -284,6 +284,11 @@ func SendTestNotification(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "Webhook":
+		if !unmaskWebhookHeaders(nProvider.Webhook) {
+			logAction.SetError("Unable to unmask webhook credentials", "Provide the full header values when changing the webhook URL", nil)
+			httpx.SendResponse(w, ld, response)
+			return
+		}
 		Err := notification.SendWebhookMessage(ctx, nProvider.Webhook, message, imageURL, title)
 		if Err.Message != "" {
 			httpx.SendResponse(w, ld, response)
@@ -349,6 +354,47 @@ func maskedFieldMatches(maskedValue, realValue string) bool {
 		return false
 	}
 	return maskedValue[len(maskedValue)-3:] == realValue[len(realValue)-3:]
+}
+
+// unmaskWebhookHeaders restores masked header values from the stored provider that has the
+// same URL. Headers carry the webhook's Authorization value, so they are only ever restored
+// for the URL they were issued for - otherwise a caller could supply someone else's URL with
+// a masked header and have the real credential sent there by SendWebhookMessage.
+func unmaskWebhookHeaders(webhook *config.Config_Notification_Webhook) bool {
+	if webhook == nil {
+		return true
+	}
+	masked := false
+	for _, value := range webhook.Headers {
+		if config.IsMaskedField(value) {
+			masked = true
+			break
+		}
+	}
+	if !masked {
+		return true
+	}
+
+	for _, existingProvider := range config.Current.Notifications.Providers {
+		if existingProvider.Provider != "Webhook" || existingProvider.Webhook == nil {
+			continue
+		}
+		if existingProvider.Webhook.URL != webhook.URL {
+			continue
+		}
+		for key, value := range webhook.Headers {
+			if !config.IsMaskedField(value) {
+				continue
+			}
+			stored, ok := existingProvider.Webhook.Headers[key]
+			if !ok || !maskedFieldMatches(value, stored) {
+				return false
+			}
+			webhook.Headers[key] = stored
+		}
+		return true
+	}
+	return false
 }
 
 // matchGotifyProvider finds the single stored Gotify provider whose URL and ApiToken both match

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -374,6 +374,9 @@ func unmaskWebhookHeaders(webhook *config.Config_Notification_Webhook) bool {
 		return true
 	}
 
+	// Several providers may share a URL with different credentials, so a mismatch means
+	// "keep looking", not "reject". Values are staged and only applied once one provider
+	// accounts for every masked header, which also avoids leaving a half-restored map behind.
 	for _, existingProvider := range config.Current.Notifications.Providers {
 		if existingProvider.Provider != "Webhook" || existingProvider.Webhook == nil {
 			continue
@@ -381,15 +384,24 @@ func unmaskWebhookHeaders(webhook *config.Config_Notification_Webhook) bool {
 		if existingProvider.Webhook.URL != webhook.URL {
 			continue
 		}
+		restored := make(map[string]string, len(webhook.Headers))
+		complete := true
 		for key, value := range webhook.Headers {
 			if !config.IsMaskedField(value) {
 				continue
 			}
 			stored, ok := existingProvider.Webhook.Headers[key]
 			if !ok || !maskedFieldMatches(value, stored) {
-				return false
+				complete = false
+				break
 			}
-			webhook.Headers[key] = stored
+			restored[key] = stored
+		}
+		if !complete {
+			continue
+		}
+		for key, value := range restored {
+			webhook.Headers[key] = value
 		}
 		return true
 	}

--- a/backend/routing/validation/notification.go
+++ b/backend/routing/validation/notification.go
@@ -375,8 +375,12 @@ func unmaskWebhookHeaders(webhook *config.Config_Notification_Webhook) bool {
 	}
 
 	// Several providers may share a URL with different credentials, so a mismatch means
-	// "keep looking", not "reject". Values are staged and only applied once one provider
-	// accounts for every masked header, which also avoids leaving a half-restored map behind.
+	// "keep looking", not "reject". Every candidate is collected rather than taking the
+	// first: MaskToken is value-derived, so two providers on one URL whose secrets end the
+	// same way are indistinguishable here. The request carries no provider identity to break
+	// that tie, so an ambiguous match is refused rather than guessed - sending a test with
+	// the wrong provider's credential would deliver it to that provider's endpoint.
+	var matches []map[string]string
 	for _, existingProvider := range config.Current.Notifications.Providers {
 		if existingProvider.Provider != "Webhook" || existingProvider.Webhook == nil {
 			continue
@@ -397,15 +401,17 @@ func unmaskWebhookHeaders(webhook *config.Config_Notification_Webhook) bool {
 			}
 			restored[key] = stored
 		}
-		if !complete {
-			continue
+		if complete {
+			matches = append(matches, restored)
 		}
-		for key, value := range restored {
-			webhook.Headers[key] = value
-		}
-		return true
 	}
-	return false
+	if len(matches) != 1 {
+		return false
+	}
+	for key, value := range matches[0] {
+		webhook.Headers[key] = value
+	}
+	return true
 }
 
 // matchGotifyProvider finds the single stored Gotify provider whose URL and ApiToken both match

--- a/backend/routing/validation/notification_webhook_test.go
+++ b/backend/routing/validation/notification_webhook_test.go
@@ -71,6 +71,37 @@ func TestUnmaskWebhookHeadersRejectsUnknownMask(t *testing.T) {
 	}
 }
 
+// MaskToken is value-derived, so two secrets ending the same way are indistinguishable on a
+// shared URL. The request carries no provider identity, so refuse rather than guess: picking
+// one would send the test with the other provider's credential.
+func TestUnmaskWebhookHeadersRefusesAmbiguousMatch(t *testing.T) {
+	const sharedURL = "https://hooks.example.com/notify"
+	const firstSecret = "Bearer alpha-abcd"
+	const secondSecret = "Bearer beta-abcd"
+
+	if config.MaskToken(firstSecret) != config.MaskToken(secondSecret) {
+		t.Fatal("test needs two secrets whose masks collide")
+	}
+
+	withProviders(t,
+		webhookProvider(sharedURL, map[string]string{"Authorization": firstSecret}),
+		webhookProvider(sharedURL, map[string]string{"Authorization": secondSecret}),
+	)
+
+	masked := config.MaskToken(firstSecret)
+	submitted := &config.Config_Notification_Webhook{
+		URL:     sharedURL,
+		Headers: map[string]string{"Authorization": masked},
+	}
+
+	if unmaskWebhookHeaders(submitted) {
+		t.Fatal("an ambiguous match must be refused, not resolved to the first provider")
+	}
+	if got := submitted.Headers["Authorization"]; got != masked {
+		t.Errorf("header = %q, want it left masked rather than resolved to a guess", got)
+	}
+}
+
 // Short values mask to "***" plus a single character, which a fixed three-character suffix
 // comparison could never match.
 func TestMaskedFieldMatchesHandlesShortValues(t *testing.T) {

--- a/backend/routing/validation/notification_webhook_test.go
+++ b/backend/routing/validation/notification_webhook_test.go
@@ -1,0 +1,85 @@
+package routes_validation
+
+import (
+	"aura/config"
+	"testing"
+)
+
+func webhookProvider(url string, headers map[string]string) config.Config_Notification_Provider {
+	return config.Config_Notification_Provider{
+		Provider: "Webhook",
+		Enabled:  true,
+		Webhook:  &config.Config_Notification_Webhook{URL: url, Headers: headers},
+	}
+}
+
+func withProviders(t *testing.T, providers ...config.Config_Notification_Provider) {
+	t.Helper()
+	previous := config.Current.Notifications.Providers
+	config.Current.Notifications.Providers = providers
+	t.Cleanup(func() { config.Current.Notifications.Providers = previous })
+}
+
+// Several webhook providers can share a URL with different credentials. A mismatch against
+// the first one means "keep looking", not "reject", or testing the second is impossible.
+func TestUnmaskWebhookHeadersSearchesPastAMismatch(t *testing.T) {
+	const sharedURL = "https://hooks.example.com/notify"
+	const firstSecret = "Bearer alpha-1111"
+	const secondSecret = "Bearer beta-2222"
+
+	// Distinct endings, so the two masks differ and the second is genuinely identifiable.
+	if config.MaskToken(firstSecret) == config.MaskToken(secondSecret) {
+		t.Fatal("test needs two secrets whose masks differ")
+	}
+
+	withProviders(t,
+		webhookProvider(sharedURL, map[string]string{"Authorization": firstSecret}),
+		webhookProvider(sharedURL, map[string]string{"Authorization": secondSecret}),
+	)
+
+	submitted := &config.Config_Notification_Webhook{
+		URL:     sharedURL,
+		Headers: map[string]string{"Authorization": config.MaskToken(secondSecret)},
+	}
+
+	if !unmaskWebhookHeaders(submitted) {
+		t.Fatal("second provider's masked header should resolve")
+	}
+	if got := submitted.Headers["Authorization"]; got != secondSecret {
+		t.Errorf("header = %q, want %q", got, secondSecret)
+	}
+}
+
+// A mask that matches no stored provider must be rejected, and must not leave the map
+// half-restored with another provider's value.
+func TestUnmaskWebhookHeadersRejectsUnknownMask(t *testing.T) {
+	const sharedURL = "https://hooks.example.com/notify"
+
+	withProviders(t, webhookProvider(sharedURL, map[string]string{"Authorization": "Bearer stored-secret"}))
+
+	masked := config.MaskToken("Bearer something-else")
+	submitted := &config.Config_Notification_Webhook{
+		URL:     sharedURL,
+		Headers: map[string]string{"Authorization": masked},
+	}
+
+	if unmaskWebhookHeaders(submitted) {
+		t.Fatal("a mask matching no stored value must be rejected")
+	}
+	if got := submitted.Headers["Authorization"]; got != masked {
+		t.Errorf("header = %q, want it left untouched", got)
+	}
+}
+
+// Short values mask to "***" plus a single character, which a fixed three-character suffix
+// comparison could never match.
+func TestMaskedFieldMatchesHandlesShortValues(t *testing.T) {
+	for _, value := range []string{"a", "ab", "abc", "abcd", "long-secret-value"} {
+		if !maskedFieldMatches(config.MaskToken(value), value) {
+			t.Errorf("mask of %q should match itself", value)
+		}
+	}
+	if maskedFieldMatches("***zzzz", "different-value") {
+		t.Error("an arbitrary masked string must not match an unrelated value")
+	}
+}

--- a/backend/sonarr-radarr/interface.go
+++ b/backend/sonarr-radarr/interface.go
@@ -42,7 +42,7 @@ func MakeSureAllAppInfoPresent(ctx context.Context, app *config.Config_SonarrRad
 				"type":      app.Type,
 				"library":   app.Library,
 				"url":       app.URL,
-				"api_token": app.ApiToken,
+				"api_token": config.MaskToken(app.ApiToken),
 			})
 		return *logAction.Error
 	}

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -260,6 +260,20 @@ func runWarmup() (success bool) {
 	return success
 }
 
+// newAPIServer builds a listener with timeouts. ReadHeaderTimeout is the one that matters:
+// without it a client can hold a connection open indefinitely by dribbling out headers.
+// WriteTimeout is deliberately left unset, because image and log responses are proxied from
+// a media server that can legitimately be slow.
+func newAPIServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           http.HandlerFunc(dispatch),
+		ReadHeaderTimeout: 15 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+}
+
 func startAPI() {
 	startTLSIfConfigured()
 
@@ -268,7 +282,7 @@ func startAPI() {
 		Bool("full_routes", config.Loaded && config.Valid).
 		Str("log_level", logging.LOGGER.GetLevel().String()).
 		Msg("Starting HTTP Server")
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", APP_PORT), http.HandlerFunc(dispatch)); err != nil {
+	if err := newAPIServer(fmt.Sprintf(":%d", APP_PORT)).ListenAndServe(); err != nil {
 		logging.LOGGER.Fatal().Err(err).Msg("Failed to start server")
 	}
 }
@@ -298,7 +312,7 @@ func startTLSIfConfigured() {
 
 	go func() {
 		logging.LOGGER.Info().Timestamp().Int("port", APP_TLS_PORT).Msg("Starting HTTPS Server")
-		if err := http.ListenAndServeTLS(fmt.Sprintf(":%d", APP_TLS_PORT), certFile, keyFile, http.HandlerFunc(dispatch)); err != nil {
+		if err := newAPIServer(fmt.Sprintf(":%d", APP_TLS_PORT)).ListenAndServeTLS(certFile, keyFile); err != nil {
 			logging.LOGGER.Fatal().Err(err).Msg("Failed to start HTTPS server")
 		}
 	}()

--- a/backend/utils/httpx/decode_request.go
+++ b/backend/utils/httpx/decode_request.go
@@ -28,10 +28,12 @@ func DecodeRequestBodyToJSON(ctx context.Context, r io.ReadCloser, v any, struct
 		_, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf("Decoding request body into `%s` struct", structName), logging.LevelTrace)
 		defer logAction.Complete()
 
+		// This map is both logged and returned to the caller, and the body can carry
+		// credentials (login POSTs, full config POSTs), so only its size is safe to report.
 		errorDetails := map[string]any{
-			"request_body": string(body),
-			"error":        err.Error(),
-			"error_type":   fmt.Sprintf("%T", err),
+			"request_body_len": len(body),
+			"error":            err.Error(),
+			"error_type":       fmt.Sprintf("%T", err),
 		}
 
 		// Enhanced error reporting for JSON errors

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,7 +43,16 @@ func redactURL(raw string) string {
 // redactErr strips credentials from an error message. http.NewRequest and http.Client.Do
 // both return *url.Error, whose Error() embeds the full request URL, so redacting the
 // separate "url" log field is not enough on its own.
+//
+// The embedded URL is rebuilt from the error rather than string-replaced: when the URL
+// carries a password, net/http's stripPassword rewrites it to "user:***@host" before
+// storing it, so it no longer matches raw and a substring replacement would silently do
+// nothing while leaving any query-string credential exposed.
 func redactErr(err error, raw string) string {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return fmt.Sprintf("%s %q: %s", urlErr.Op, redactURL(urlErr.URL), redactErr(urlErr.Err, raw))
+	}
 	return strings.ReplaceAll(err.Error(), raw, redactURL(raw))
 }
 

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -40,6 +40,13 @@ func redactURL(raw string) string {
 	return parsed.String()
 }
 
+// redactErr strips credentials from an error message. http.NewRequest and http.Client.Do
+// both return *url.Error, whose Error() embeds the full request URL, so redacting the
+// separate "url" log field is not enough on its own.
+func redactErr(err error, raw string) string {
+	return strings.ReplaceAll(err.Error(), raw, redactURL(raw))
+}
+
 var sharedTransport = &http.Transport{
 	TLSClientConfig:     &tls.Config{InsecureSkipVerify: false},
 	ForceAttemptHTTP2:   true,
@@ -71,7 +78,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			map[string]any{
 				"method": method,
 				"url":    redactURL(url),
-				"error":  err.Error(),
+				"error":  redactErr(err, url),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -127,7 +134,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			map[string]any{
 				"method": method,
 				"url":    redactURL(url),
-				"error":  err.Error(),
+				"error":  redactErr(err, url),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -141,7 +148,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			map[string]any{
 				"method":      method,
 				"url":         redactURL(url),
-				"error":       err.Error(),
+				"error":       redactErr(err, url),
 				"status_code": resp.StatusCode,
 			})
 		return nil, nil, *logAction.Error

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -9,9 +9,36 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
+
+var sensitiveURLParams = []string{"token", "key", "secret", "password", "auth", "sig"}
+
+// redactURL blanks credentials carried in a URL. Plex sends its account token as an
+// X-Plex-Token query parameter, and these URLs are logged on every transport error.
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "<unparseable url>"
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("***")
+	}
+	query := parsed.Query()
+	for key := range query {
+		lowerKey := strings.ToLower(key)
+		for _, sensitive := range sensitiveURLParams {
+			if strings.Contains(lowerKey, sensitive) {
+				query.Set(key, "***")
+				break
+			}
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
 
 var sharedTransport = &http.Transport{
 	TLSClientConfig:     &tls.Config{InsecureSkipVerify: false},
@@ -43,7 +70,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    url,
+				"url":    redactURL(url),
 				"error":  err.Error(),
 			})
 		return nil, nil, *logAction.Error
@@ -62,6 +89,9 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 		"access-token",
 		"token",
 		"authentication",
+		"secret",
+		"password",
+		"cookie",
 	}
 
 	if len(headers) > 0 {
@@ -96,7 +126,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    url,
+				"url":    redactURL(url),
 				"error":  err.Error(),
 			})
 		return nil, nil, *logAction.Error
@@ -110,7 +140,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method":      method,
-				"url":         url,
+				"url":         redactURL(url),
 				"error":       err.Error(),
 				"status_code": resp.StatusCode,
 			})

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -16,15 +16,30 @@ import (
 
 var sensitiveURLParams = []string{"token", "key", "secret", "password", "auth", "sig"}
 
+// WebhookSiteName marks a request to a user-configured webhook, whose URL is treated as a
+// credential in full rather than just its query string.
+const WebhookSiteName = "Webhook"
+
 // redactURL blanks credentials carried in a URL. Plex sends its account token as an
 // X-Plex-Token query parameter, and these URLs are logged on every transport error.
-func redactURL(raw string) string {
+// hidePath drops the path as well, for endpoints where the path itself is the credential:
+// a generic webhook is a user-supplied capability URL (the Slack shape puts the secret in
+// /services/.../<secret>), so nothing past the host is safe to log. It stays on for the
+// media-server and MediUX calls, whose paths name the failing endpoint and carry no secret.
+func redactURL(raw string, hidePath bool) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return "<unparseable url>"
 	}
 	if parsed.User != nil {
 		parsed.User = url.User("***")
+	}
+	if hidePath {
+		parsed.Path = "/***"
+		parsed.RawPath = ""
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return parsed.String()
 	}
 	query := parsed.Query()
 	for key := range query {
@@ -48,12 +63,12 @@ func redactURL(raw string) string {
 // carries a password, net/http's stripPassword rewrites it to "user:***@host" before
 // storing it, so it no longer matches raw and a substring replacement would silently do
 // nothing while leaving any query-string credential exposed.
-func redactErr(err error, raw string) string {
+func redactErr(err error, raw string, hidePath bool) string {
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
-		return fmt.Sprintf("%s %q: %s", urlErr.Op, redactURL(urlErr.URL), redactErr(urlErr.Err, raw))
+		return fmt.Sprintf("%s %q: %s", urlErr.Op, redactURL(urlErr.URL, hidePath), redactErr(urlErr.Err, raw, hidePath))
 	}
-	return strings.ReplaceAll(err.Error(), raw, redactURL(raw))
+	return strings.ReplaceAll(err.Error(), raw, redactURL(raw, hidePath))
 }
 
 var sharedTransport = &http.Transport{
@@ -74,6 +89,9 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 	ctx, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf("Making %s request to %s", method, siteName), logging.LevelTrace)
 	defer logAction.Complete()
 
+	// Webhook endpoints are configured by the user and may carry their secret in the path.
+	hidePath := siteName == WebhookSiteName
+
 	// Create a context with a timeout
 	timeoutInterval := time.Duration(timeout) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutInterval)
@@ -86,8 +104,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    redactURL(url),
-				"error":  redactErr(err, url),
+				"url":    redactURL(url, hidePath),
+				"error":  redactErr(err, url, hidePath),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -119,8 +137,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    redactURL(url),
-				"error":  redactErr(err, url),
+				"url":    redactURL(url, hidePath),
+				"error":  redactErr(err, url, hidePath),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -133,8 +151,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method":      method,
-				"url":         redactURL(url),
-				"error":       redactErr(err, url),
+				"url":         redactURL(url, hidePath),
+				"error":       redactErr(err, url, hidePath),
 				"status_code": resp.StatusCode,
 			})
 		return nil, nil, *logAction.Error

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -1,7 +1,6 @@
 package httpx
 
 import (
-	"aura/config"
 	"aura/logging"
 	"bytes"
 	"context"
@@ -87,35 +86,12 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 	req.Header.Set("User-Agent", "aura/1.0")
 	req.Header.Set("X-Request", "mediux-aura")
 
-	possibleSensitiveHeaders := []string{
-		"authorization",
-		"api-key",
-		"x-api-key",
-		"x-auth-token",
-		"x-access-token",
-		"access-token",
-		"token",
-		"authentication",
-		"secret",
-		"password",
-		"cookie",
-	}
-
-	if len(headers) > 0 {
-		for key, value := range headers {
-			req.Header.Add(key, value)
-			maskedValue := value
-			lowerKey := strings.ToLower(key)
-			for _, sensitive := range possibleSensitiveHeaders {
-				if strings.Contains(lowerKey, sensitive) {
-					maskedValue = config.MaskToken(value)
-					break
-				}
-			}
-			if strings.ToLower(value) != "aura" {
-				logAction.AppendResult("headers_added", map[string]any{key: maskedValue})
-			}
-		}
+	// Only header names are logged. Webhook headers are caller-supplied, so no list of
+	// sensitive names can be complete - X-Webhook-Key and X-Hub-Signature-256 both carry
+	// credentials and match no obvious pattern. Names alone are enough to debug with.
+	for key, value := range headers {
+		req.Header.Add(key, value)
+		logAction.AppendResult("headers_added", key)
 	}
 
 	// Only set Content-Type to application/json if not already set

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -17,32 +17,33 @@ import (
 var sensitiveURLParams = []string{"token", "key", "secret", "password", "auth", "sig"}
 
 // WebhookSiteName marks a request to a user-configured webhook, whose URL is treated as a
-// credential in full rather than just its query string.
+// credential in full and kept out of logs entirely.
 const WebhookSiteName = "Webhook"
+
+// redactedWebhookURL replaces a webhook URL entirely in logs.
+//
+// A generic webhook is a user-supplied capability URL, and every component has turned out to
+// be able to carry the secret: the query string, the path (Slack's /services/.../<secret>),
+// the opaque remainder of "https:secret", and a DNS label such as
+// https://<token>.hooks.example. Validation only requires the URL to be non-empty, so all of
+// those shapes reach the log. Rather than keep discovering components to blank, none of it
+// is logged - the site name already says which provider failed.
+const redactedWebhookURL = "<webhook url redacted>"
 
 // redactURL blanks credentials carried in a URL. Plex sends its account token as an
 // X-Plex-Token query parameter, and these URLs are logged on every transport error.
-// hidePath drops the path as well, for endpoints where the path itself is the credential:
-// a generic webhook is a user-supplied capability URL (the Slack shape puts the secret in
-// /services/.../<secret>), so nothing past the host is safe to log. It stays on for the
-// media-server and MediUX calls, whose paths name the failing endpoint and carry no secret.
-func redactURL(raw string, hidePath bool) string {
+// redactAll drops the URL completely, for webhooks. Media-server and MediUX URLs keep their
+// host and path: they name the failing endpoint and carry no secret.
+func redactURL(raw string, redactAll bool) string {
+	if redactAll {
+		return redactedWebhookURL
+	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return "<unparseable url>"
 	}
 	if parsed.User != nil {
 		parsed.User = url.User("***")
-	}
-	if hidePath {
-		// Built from the safe components rather than blanked in place: an opaque URL such
-		// as "https:secret" keeps the credential in parsed.Opaque, which String() emits
-		// while ignoring Path, so clearing Path alone would leave the secret intact.
-		// Validation only requires a non-empty URL, so that shape does reach here.
-		if parsed.Host == "" {
-			return parsed.Scheme + "://***"
-		}
-		return parsed.Scheme + "://" + parsed.Host + "/***"
 	}
 	query := parsed.Query()
 	for key := range query {
@@ -66,12 +67,25 @@ func redactURL(raw string, hidePath bool) string {
 // carries a password, net/http's stripPassword rewrites it to "user:***@host" before
 // storing it, so it no longer matches raw and a substring replacement would silently do
 // nothing while leaving any query-string credential exposed.
-func redactErr(err error, raw string, hidePath bool) string {
+func redactErr(err error, raw string, redactAll bool) string {
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
-		return fmt.Sprintf("%s %q: %s", urlErr.Op, redactURL(urlErr.URL, hidePath), redactErr(urlErr.Err, raw, hidePath))
+		return fmt.Sprintf("%s %q: %s", urlErr.Op, redactURL(urlErr.URL, redactAll), redactErr(urlErr.Err, raw, redactAll))
 	}
-	return strings.ReplaceAll(err.Error(), raw, redactURL(raw, hidePath))
+	msg := strings.ReplaceAll(err.Error(), raw, redactURL(raw, redactAll))
+	if !redactAll {
+		return msg
+	}
+	// DNS and dial failures name the host on their own, without the surrounding URL, so
+	// replacing the URL is not enough when the host itself is the credential.
+	if parsed, parseErr := url.Parse(raw); parseErr == nil {
+		for _, host := range []string{parsed.Host, parsed.Hostname()} {
+			if host != "" {
+				msg = strings.ReplaceAll(msg, host, "***")
+			}
+		}
+	}
+	return msg
 }
 
 var sharedTransport = &http.Transport{
@@ -93,7 +107,7 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 	defer logAction.Complete()
 
 	// Webhook endpoints are configured by the user and may carry their secret in the path.
-	hidePath := siteName == WebhookSiteName
+	redactAll := siteName == WebhookSiteName
 
 	// Create a context with a timeout
 	timeoutInterval := time.Duration(timeout) * time.Second
@@ -107,8 +121,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    redactURL(url, hidePath),
-				"error":  redactErr(err, url, hidePath),
+				"url":    redactURL(url, redactAll),
+				"error":  redactErr(err, url, redactAll),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -140,8 +154,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method": method,
-				"url":    redactURL(url, hidePath),
-				"error":  redactErr(err, url, hidePath),
+				"url":    redactURL(url, redactAll),
+				"error":  redactErr(err, url, redactAll),
 			})
 		return nil, nil, *logAction.Error
 	}
@@ -154,8 +168,8 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 			"Check error and try again",
 			map[string]any{
 				"method":      method,
-				"url":         redactURL(url, hidePath),
-				"error":       redactErr(err, url, hidePath),
+				"url":         redactURL(url, redactAll),
+				"error":       redactErr(err, url, redactAll),
 				"status_code": resp.StatusCode,
 			})
 		return nil, nil, *logAction.Error

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -35,11 +35,14 @@ func redactURL(raw string, hidePath bool) string {
 		parsed.User = url.User("***")
 	}
 	if hidePath {
-		parsed.Path = "/***"
-		parsed.RawPath = ""
-		parsed.RawQuery = ""
-		parsed.Fragment = ""
-		return parsed.String()
+		// Built from the safe components rather than blanked in place: an opaque URL such
+		// as "https:secret" keeps the credential in parsed.Opaque, which String() emits
+		// while ignoring Path, so clearing Path alone would leave the secret intact.
+		// Validation only requires a non-empty URL, so that shape does reach here.
+		if parsed.Host == "" {
+			return parsed.Scheme + "://***"
+		}
+		return parsed.Scheme + "://" + parsed.Host + "/***"
 	}
 	query := parsed.Query()
 	for key := range query {

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -38,6 +38,11 @@ func TestRedactURLHidesWebhookPath(t *testing.T) {
 	if got := redactURL(raw, true); !strings.Contains(got, "hooks.slack.com") {
 		t.Errorf("redactURL(hidePath) = %q, want the host kept for debugging", got)
 	}
+	// An opaque URL keeps its credential in parsed.Opaque, which String() emits while
+	// ignoring Path. Validation only requires a non-empty URL, so this shape reaches here.
+	if got := redactURL("https:supersecret", true); strings.Contains(got, "supersecret") {
+		t.Errorf("redactURL(opaque) = %q, want the credential removed", got)
+	}
 	// Media-server paths name the failing endpoint and carry no secret, so they stay.
 	if got := redactURL("https://plex.local/library/metadata/123", false); !strings.Contains(got, "/library/metadata/123") {
 		t.Errorf("redactURL = %q, want the path kept when it is not sensitive", got)

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -1,0 +1,24 @@
+package httpx
+
+import "testing"
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plex token param", "https://plex.tv/api/resources?X-Plex-Token=abc123", "https://plex.tv/api/resources?X-Plex-Token=%2A%2A%2A"},
+		{"api key param", "https://x.dev/v1?api_key=live&page=2", "https://x.dev/v1?api_key=%2A%2A%2A&page=2"},
+		{"userinfo", "https://user:pw@x.dev/v1", "https://%2A%2A%2A@x.dev/v1"},
+		{"nothing sensitive", "https://x.dev/v1?page=2", "https://x.dev/v1?page=2"},
+		{"unparseable", "://nope", "<unparseable url>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactURL(tt.in); got != tt.want {
+				t.Errorf("redactURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -1,6 +1,40 @@
 package httpx
 
-import "testing"
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// net/http rewrites a password-bearing URL to "user:***@host" before storing it on the
+// url.Error, so the stored URL no longer matches the raw one a substring replace looks for.
+func TestRedactErrRedactsCanonicalizedURL(t *testing.T) {
+	raw := "http://user:pw@host/?token=querysecret"
+	err := &url.Error{
+		Op:  "Get",
+		URL: "http://user:***@host/?token=querysecret",
+		Err: errors.New("dial tcp: connection refused"),
+	}
+
+	got := redactErr(err, raw)
+
+	if strings.Contains(got, "querysecret") {
+		t.Errorf("redactErr = %q, want the query credential removed", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("redactErr = %q, want the underlying cause kept", got)
+	}
+}
+
+func TestRedactErrHandlesPlainError(t *testing.T) {
+	raw := "https://plex.tv/api?X-Plex-Token=abc123"
+	got := redactErr(errors.New("failed calling "+raw), raw)
+
+	if strings.Contains(got, "abc123") {
+		t.Errorf("redactErr = %q, want the token removed", got)
+	}
+}
 
 func TestRedactURL(t *testing.T) {
 	tests := []struct {

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -27,34 +27,39 @@ func TestRedactErrRedactsCanonicalizedURL(t *testing.T) {
 	}
 }
 
-// A generic webhook is a capability URL: the secret sits in the path, not the query, so the
-// whole path has to go.
-func TestRedactURLHidesWebhookPath(t *testing.T) {
-	raw := "https://hooks.slack.com/services/T00000/B00000/XXXXsecretXXXX"
-
-	if got := redactURL(raw, true); strings.Contains(got, "secret") {
-		t.Errorf("redactURL(hidePath) = %q, want the path removed", got)
+// Every component of a webhook URL has turned out to be able to carry the secret, so none
+// of it is logged.
+func TestRedactURLDropsWebhookURLEntirely(t *testing.T) {
+	secretURLs := []string{
+		"https://hooks.slack.com/services/T00000/B00000/XXXXsecretXXXX", // secret in path
+		"https:supersecret",                        // secret in the opaque remainder
+		"https://supersecret.hooks.example/notify", // secret in a DNS label
+		"https://h/n?token=supersecret",            // secret in the query
 	}
-	if got := redactURL(raw, true); !strings.Contains(got, "hooks.slack.com") {
-		t.Errorf("redactURL(hidePath) = %q, want the host kept for debugging", got)
+	for _, raw := range secretURLs {
+		if got := redactURL(raw, true); strings.Contains(got, "secret") {
+			t.Errorf("redactURL(%q, true) = %q, want no part of the URL", raw, got)
+		}
 	}
-	// An opaque URL keeps its credential in parsed.Opaque, which String() emits while
-	// ignoring Path. Validation only requires a non-empty URL, so this shape reaches here.
-	if got := redactURL("https:supersecret", true); strings.Contains(got, "supersecret") {
-		t.Errorf("redactURL(opaque) = %q, want the credential removed", got)
-	}
-	// Media-server paths name the failing endpoint and carry no secret, so they stay.
+	// Media-server URLs name the failing endpoint and carry no secret, so they stay.
 	if got := redactURL("https://plex.local/library/metadata/123", false); !strings.Contains(got, "/library/metadata/123") {
 		t.Errorf("redactURL = %q, want the path kept when it is not sensitive", got)
 	}
 }
 
-func TestRedactErrHidesWebhookPath(t *testing.T) {
-	raw := "https://hooks.slack.com/services/T00000/B00000/XXXXsecretXXXX"
-	err := &url.Error{Op: "Post", URL: raw, Err: errors.New("connection refused")}
+func TestRedactErrDropsWebhookURLEntirely(t *testing.T) {
+	raw := "https://supersecret.hooks.example/services/XXXXsecretXXXX"
 
-	if got := redactErr(err, raw, true); strings.Contains(got, "secret") {
-		t.Errorf("redactErr(hidePath) = %q, want the path removed", got)
+	// A dial failure names the host on its own, outside the URL.
+	inner := errors.New("dial tcp: lookup supersecret.hooks.example: no such host")
+	err := &url.Error{Op: "Post", URL: raw, Err: inner}
+
+	got := redactErr(err, raw, true)
+	if strings.Contains(got, "secret") {
+		t.Errorf("redactErr = %q, want the host and path removed", got)
+	}
+	if !strings.Contains(got, "no such host") {
+		t.Errorf("redactErr = %q, want the failure cause kept", got)
 	}
 }
 

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -17,7 +17,7 @@ func TestRedactErrRedactsCanonicalizedURL(t *testing.T) {
 		Err: errors.New("dial tcp: connection refused"),
 	}
 
-	got := redactErr(err, raw)
+	got := redactErr(err, raw, false)
 
 	if strings.Contains(got, "querysecret") {
 		t.Errorf("redactErr = %q, want the query credential removed", got)
@@ -27,9 +27,35 @@ func TestRedactErrRedactsCanonicalizedURL(t *testing.T) {
 	}
 }
 
+// A generic webhook is a capability URL: the secret sits in the path, not the query, so the
+// whole path has to go.
+func TestRedactURLHidesWebhookPath(t *testing.T) {
+	raw := "https://hooks.slack.com/services/T00000/B00000/XXXXsecretXXXX"
+
+	if got := redactURL(raw, true); strings.Contains(got, "secret") {
+		t.Errorf("redactURL(hidePath) = %q, want the path removed", got)
+	}
+	if got := redactURL(raw, true); !strings.Contains(got, "hooks.slack.com") {
+		t.Errorf("redactURL(hidePath) = %q, want the host kept for debugging", got)
+	}
+	// Media-server paths name the failing endpoint and carry no secret, so they stay.
+	if got := redactURL("https://plex.local/library/metadata/123", false); !strings.Contains(got, "/library/metadata/123") {
+		t.Errorf("redactURL = %q, want the path kept when it is not sensitive", got)
+	}
+}
+
+func TestRedactErrHidesWebhookPath(t *testing.T) {
+	raw := "https://hooks.slack.com/services/T00000/B00000/XXXXsecretXXXX"
+	err := &url.Error{Op: "Post", URL: raw, Err: errors.New("connection refused")}
+
+	if got := redactErr(err, raw, true); strings.Contains(got, "secret") {
+		t.Errorf("redactErr(hidePath) = %q, want the path removed", got)
+	}
+}
+
 func TestRedactErrHandlesPlainError(t *testing.T) {
 	raw := "https://plex.tv/api?X-Plex-Token=abc123"
-	got := redactErr(errors.New("failed calling "+raw), raw)
+	got := redactErr(errors.New("failed calling "+raw), raw, false)
 
 	if strings.Contains(got, "abc123") {
 		t.Errorf("redactErr = %q, want the token removed", got)
@@ -50,7 +76,7 @@ func TestRedactURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := redactURL(tt.in); got != tt.want {
+			if got := redactURL(tt.in, false); got != tt.want {
 				t.Errorf("redactURL(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})


### PR DESCRIPTION
Credentials for connected services were reaching the log file, the in-app log viewer, and API error responses. The log is the first thing a user attaches to a bug report, so these leave the machine easily.

## Credential redaction

`routing/config/update.go` logged the old and new value of every credential at INFO whenever config changed. `Auth.Password` and `OIDC.ClientSecret` already used a changed-only pattern; this extends it to the remaining eleven fields — media server, MediUX, TMDB, Sonarr/Radarr, Pushover (user key + token), Gotify, Discord webhook, and the generic webhook URL and headers. Webhook headers keep the key so a change stays traceable, never the value.

Surrounding leak paths on the same theme:

- media server struct is masked on the connection-failure branch, which ran before the existing success-path masking
- URL userinfo and credential-bearing query parameters are blanked before a transport error is logged, since Plex carries its account token in the query string and that error is also returned to the caller
- an undecodable request body now reports only its length; it could be a login or full-config POST
- Sonarr/Radarr `api_token` masked in the incomplete-config error
- the webhook URL is no longer passed as a request's display name

## Webhook headers were the one secret `SanitizeConfig` missed

The provider copy was shallow, so the `Webhook` pointer survived untouched and its `Headers` map — which carries the `Authorization` value sent to the webhook — was returned by `GET /api/config` and written to the log in full, while every neighbouring secret was masked.

Masking it means the value now round-trips through the UI, so both write paths had to learn the mask:

- config update restores the stored value when a masked header is echoed back, otherwise saving an unrelated setting would overwrite the real credential with `***abcd`
- the test-notification endpoint restores headers only from the stored provider with the **same URL**. Matching on the header alone would let a caller pair a real `Authorization` value with a URL they supplied and have it delivered there — the trap already documented on the Gotify path.

The webhook URL itself is left unmasked, matching Gotify: it is the user's own endpoint.

## Access control

- `GET /api/search` sat in the public block, so the library could be enumerated title-by-title without a session while `Auth.Enabled=true`. Moved into the protected group.
- the `/api/images` auth exemption exists so `<img>` tags can load without an `Authorization` header, but a prefix match also covered `DELETE /api/images/temp`. Scoped to GET, which keeps images working and closes the destructive verb without enumerating every image path.
- the unauthenticated onboarding router no longer serves the log viewer. Setup never needs it.

## Hardening

- `config.yaml` holds every token in plaintext and was written world-readable. Now `0600`, with an explicit `chmod` because `WriteFile` only applies its mode on create. A failed chmod warns rather than failing the save, since `/config` is often a network share.
- request bodies capped at 8MB. Unauthenticated POSTs exist and every handler reads the body fully into memory. Nothing in the API uploads files.
- both listeners get `ReadHeaderTimeout` and `IdleTimeout`. `WriteTimeout` is deliberately unset: image and log responses are proxied from a media server that can legitimately be slow, and a write deadline would truncate them.

## Notes

Three tests added: URL redaction, the GET-only image exemption, and the sanitize round-trip (a mistake there silently corrupts stored credentials).

Also recorded why the CORS wildcard is not the finding it resembles — `rs/cors` emits a literal `*` rather than reflecting the Origin, so browsers will not attach credentials to the response.

`go build`, `go vet` and `go test ./...` pass. Note that the test suite needs `CONFIG_PATH` set or package init panics on `/config`.