### PR TITLE
fix(jobs): guard manualPrevRun write with the scheduler mutex

### DIFF
--- a/backend/jobs/cron.go
+++ b/backend/jobs/cron.go
@@ -197,8 +197,9 @@ func TriggerJob(jobName string, jobID string) error {
 		return fmt.Errorf("job not found or not scheduled: %s", jobName)
 	}
 
+	manualPrevRun[entryID] = time.Now().Format("2006-01-02 15:04:05")
+
 	go func() {
-		manualPrevRun[entryID] = time.Now().Format("2006-01-02 15:04:05")
 		if err := job.RunNow(); err != nil {
 			logging.LOGGER.Error().Timestamp().Err(err).Str("job_name", jobName).
 				Msg("Failed to trigger job")

--- a/backend/jobs/cron_trigger_test.go
+++ b/backend/jobs/cron_trigger_test.go
@@ -1,0 +1,67 @@
+package jobs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/google/uuid"
+)
+
+// TestTriggerJob_ManualPrevRunGuardedAgainstGetListOfJobs pins the manualPrevRun
+// map access pattern: GetListOfJobs reads it under mu on every /api/jobs poll
+// while TriggerJob records a manual run. A concurrent map read/write is an
+// unrecoverable Go runtime fatal, so this must stay inside the lock. Run with
+// -race to see an unguarded write reported as a data race rather than as a
+// nondeterministic process kill.
+func TestTriggerJob_ManualPrevRunGuardedAgainstGetListOfJobs(t *testing.T) {
+	const jobName = "Download Queue Processing Job"
+
+	prevSched, prevJob, prevID, prevRuns := sched, downloadQueueJob, downloadQueueJobID, manualPrevRun
+	t.Cleanup(func() {
+		sched, downloadQueueJob, downloadQueueJobID, manualPrevRun = prevSched, prevJob, prevID, prevRuns
+	})
+
+	s, err := gocron.NewScheduler()
+	if err != nil {
+		t.Fatalf("failed to create scheduler: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Shutdown(); err != nil {
+			t.Errorf("scheduler shutdown failed: %v", err)
+		}
+	})
+
+	job, err := s.NewJob(
+		gocron.CronJob("0 0 * * *", false),
+		gocron.NewTask(func() {}),
+		gocron.WithName(jobName),
+	)
+	if err != nil {
+		t.Fatalf("failed to schedule job: %v", err)
+	}
+	s.Start()
+
+	sched, downloadQueueJob, downloadQueueJobID = s, job, job.ID()
+	manualPrevRun = map[uuid.UUID]string{}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := TriggerJob(jobName, ""); err != nil {
+				t.Errorf("TriggerJob() error: %v", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			GetListOfJobs()
+		}()
+	}
+	wg.Wait()
+
+	if _, ok := manualPrevRun[job.ID()]; !ok {
+		t.Errorf("TriggerJob did not record a manual previous run for job %s", job.ID())
+	}
+}


### PR DESCRIPTION
## Root cause

`TriggerJob` holds `mu` for its whole body, but it recorded the manual-run timestamp *inside* the goroutine it spawns — and that goroutine runs after `TriggerJob` has already returned and released the lock. `GetListOfJobs` reads the same `manualPrevRun` map under `mu` on every `/api/jobs` poll (the UI polls it every 2s), so clicking "Run now" concurrently with a poll was an unsynchronized map read/write.

That is a Go runtime fatal (`fatal error: concurrent map read and map write`), not a recoverable panic — the `recover()` guards in the job tasks cannot catch it, so it takes down the entire backend process.

Fix is to move the write above the `go func()`, where `mu` is still held. The timestamp now reflects trigger time instead of goroutine-start time, a difference of microseconds.

## Scope check

Audited every other shared-map access in the package. `manualPrevRun` had exactly three sites (declaration, the guarded read at `cron.go:98`, and this write). The sibling `jobSpecs` map is written in all eight `Start*Job` functions, and every one of them already takes `mu` — no other unguarded access to fix.

## Verification

`backend/jobs/cron_trigger_test.go` drives 50 concurrent `TriggerJob` / `GetListOfJobs` pairs. Reverting the one-line fix makes it report 4 data races and fail; with the fix it passes.

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./jobs/...` — pass
- `go test ./...` — all 11 packages pass

Closes #120