### PR TITLE
fix(frontend): normalize poster sets in saved-sets table and fix overlap check

### DIFF
--- a/frontend/src/components/shared/saved-sets-cards.tsx
+++ b/frontend/src/components/shared/saved-sets-cards.tsx
@@ -44,15 +44,15 @@ import type { IncludedItem, SetRef } from "@/types/media-and-posters/sets";
 export function hasSelectedTypesOverlapOnAutoDownload(
   posterSets: { selected_types: SelectedTypes; auto_download: boolean }[]
 ): boolean {
-  const typeToAutoDownloadSet = new Map<string, boolean>();
+  const seenTypes = new Set<string>();
   for (const set of posterSets) {
-    if (!set.auto_download) continue;
-    if (!Array.isArray(set.selected_types)) continue;
-    for (const type of set.selected_types) {
-      if (type && typeToAutoDownloadSet.has(type)) {
+    if (!set.auto_download || !set.selected_types) continue;
+    for (const [type, isSelected] of Object.entries(set.selected_types)) {
+      if (!isSelected) continue;
+      if (seenTypes.has(type)) {
         return true;
       }
-      typeToAutoDownloadSet.set(type, true);
+      seenTypes.add(type);
     }
   }
   return false;

--- a/frontend/src/components/shared/saved-sets-table.tsx
+++ b/frontend/src/components/shared/saved-sets-table.tsx
@@ -153,7 +153,7 @@ const SavedSetsTableRow: React.FC<{
         </TableCell>
         <TableCell>
           <div>
-            {savedSet.poster_sets.some((set) => set.auto_download) ? (
+            {posterSets.some((set) => set.auto_download) ? (
               <Popover>
                 <PopoverTrigger asChild>
                   <RefreshCcw className="text-green-500 cursor-help" size={24} />
@@ -178,7 +178,7 @@ const SavedSetsTableRow: React.FC<{
                 </PopoverContent>
               </Popover>
             )}
-            {hasSelectedTypesOverlapOnAutoDownload(savedSet.poster_sets) && (
+            {hasSelectedTypesOverlapOnAutoDownload(posterSets) && (
               <Popover>
                 <PopoverTrigger asChild>
                   <AlertTriangle className="text-yellow-500 cursor-help" size={24} />
@@ -274,11 +274,11 @@ const SavedSetsTableRow: React.FC<{
                 {isRefreshing ? "Refreshing..." : "Edit"}
               </DropdownMenuItem>
 
-              {savedSet.poster_sets.some((set) => set.auto_download || savedSet.media_item.type === "movie") && (
+              {posterSets.some((set) => set.auto_download || normalizedSavedSet.media_item.type === "movie") && (
                 <DropdownMenuItem
                   className="cursor-pointer"
                   onClick={() => {
-                    handleRecheckItem(savedSet.media_item.title, savedSet);
+                    handleRecheckItem(normalizedSavedSet.media_item.title, normalizedSavedSet);
                   }}
                 >
                   <RefreshCcw className="ml-2" />
@@ -350,10 +350,10 @@ const SavedSetsTableRow: React.FC<{
             setIsMounted,
           })
         }
-        title={savedSet.media_item.title}
+        title={normalizedSavedSet.media_item.title}
         confirmDelete={() =>
           savedSetsConfirmDelete({
-            savedSet,
+            savedSet: normalizedSavedSet,
             onUpdate,
             isMounted,
             setIsMounted,


### PR DESCRIPTION
## Root cause

`saved-sets-table.tsx` and `saved-sets-cards.tsx` are near-identical clones, and hardening applied to the card view never reached the table. The table computed the normalized `posterSets` at line 68 but still read raw `savedSet.poster_sets` at five call sites. `poster_sets` is declared non-optional in `db-poster-set.ts:11`, yet the backend tags it `json:"poster_sets,omitempty"` (`backend/models/db_item.go:9`), so an item with zero poster sets omits the key entirely — `.some(...)` then throws a `TypeError` and takes down the whole saved-sets table render.

While fixing that I found a second, independent bug: `hasSelectedTypesOverlapOnAutoDownload` iterated `selected_types` as an array, but `SelectedTypes` is an object of five booleans (`media-item-and-library.ts:84`). The `Array.isArray` guard was therefore always false, the function always returned `false`, and the overlapping-types warning never rendered in **either** view. Rewrote it over `Object.entries` so it flags a type selected by more than one auto-download set.

## Verification

`npm run typecheck`, `npm run lint` and `prettier -l` all clean. No frontend test harness exists in this repo, so the typecheck is the proof; adding one for a 12-line fix was out of scope.

Closes #119