### PR TITLE
fix(auto-download): gate season posters on season number

### DIFF
--- a/backend/download/auto/handle-show.go
+++ b/backend/download/auto/handle-show.go
@@ -273,7 +273,7 @@ func handleShow(ctx context.Context, mediaItem models.MediaItem, dbItem models.D
 				check.Reason = "Backdrop not selected for this set"
 				actionImageChecks.AppendResult(imageName, check)
 				continue
-			} else if image.Type == "season_poster" && !dbSet.SelectedTypes.SeasonPoster && !dbSet.SelectedTypes.SpecialSeasonPoster {
+			} else if image.Type == "season_poster" && !seasonPosterSelected(dbSet.SelectedTypes, image) {
 				check.Reason = "Season Poster not selected for this set"
 				actionImageChecks.AppendResult(imageName, check)
 				continue
@@ -484,6 +484,20 @@ func handleShow(ctx context.Context, mediaItem models.MediaItem, dbItem models.D
 
 	getOverallResults(&result)
 	return result
+}
+
+// seasonPosterSelected reports whether a season_poster image is selected by the set's types.
+// Season 0 is a special season and requires SpecialSeasonPoster; every other season requires
+// SeasonPoster. Checking only that one of the two is set lets a set download the season kind
+// the user did not select.
+func seasonPosterSelected(selectedTypes models.SelectedTypes, image models.ImageFile) bool {
+	if image.SeasonNumber == nil {
+		return false
+	}
+	if *image.SeasonNumber == 0 {
+		return selectedTypes.SpecialSeasonPoster
+	}
+	return selectedTypes.SeasonPoster
 }
 
 func getShowInfoChangeReason(changes ShowChangeDetails) string {

--- a/backend/download/auto/handle-show_test.go
+++ b/backend/download/auto/handle-show_test.go
@@ -1,0 +1,37 @@
+package autodownload
+
+import (
+	"testing"
+
+	"aura/models"
+)
+
+// Regression test for the drifted season-poster gate in handleShow: it previously admitted an
+// image when either SeasonPoster or SpecialSeasonPoster was selected, so a set selecting only
+// one of the two downloaded both kinds.
+func TestSeasonPosterSelected(t *testing.T) {
+	seasonNumber := func(n int) *int { return &n }
+
+	tests := []struct {
+		name          string
+		selectedTypes models.SelectedTypes
+		seasonNumber  *int
+		want          bool
+	}{
+		{"season 0 with special selected", models.SelectedTypes{SpecialSeasonPoster: true}, seasonNumber(0), true},
+		{"season 0 with only regular selected", models.SelectedTypes{SeasonPoster: true}, seasonNumber(0), false},
+		{"season 1 with regular selected", models.SelectedTypes{SeasonPoster: true}, seasonNumber(1), true},
+		{"season 1 with only special selected", models.SelectedTypes{SpecialSeasonPoster: true}, seasonNumber(1), false},
+		{"nil season with both selected", models.SelectedTypes{SeasonPoster: true, SpecialSeasonPoster: true}, nil, false},
+		{"season 1 with neither selected", models.SelectedTypes{}, seasonNumber(1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			image := models.ImageFile{Type: "season_poster", SeasonNumber: tt.seasonNumber}
+			if got := seasonPosterSelected(tt.selectedTypes, image); got != tt.want {
+				t.Errorf("seasonPosterSelected() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

The "special season poster" selection rule exists in five places. Four gate a `season_poster` image on its season number: season `0` requires `SpecialSeasonPoster`, any other season requires `SeasonPoster`. The copy in `handle-show.go` had drifted to `!SeasonPoster && !SpecialSeasonPoster`, which only skips an image when *neither* type is selected.

A set that selected just one of the two therefore passed both kinds of season poster through the auto-download check: selecting only "Season Poster" still downloaded the season 0 specials poster, and selecting only "Special Season Poster" still downloaded every regular season poster.

The fix extracts `seasonPosterSelected` in the same package and swaps the condition, so the gate now matches `download/queue/process.go`. Images with no season number are skipped, as they were before via the season/episode-info check immediately below.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all clean.
- New table-driven test `TestSeasonPosterSelected` covers season 0, season > 0, and nil season. Confirmed it fails on the pre-fix logic (3 of 6 subtests) and passes after.

Closes #118