### PR TITLE
fix: wave 2 trivials — queue panic, dropped re-apply log, uncancellable HTTP requests

### DIFF
--- a/backend/download/auto/websocket-plex.go
+++ b/backend/download/auto/websocket-plex.go
@@ -421,7 +421,7 @@ func reApplySavedImages(item PlexRefreshedItem) {
 	logCtx, ld := logging.CreateLoggingContext(context.Background(), "Plex Event Listener")
 	logAction := ld.AddAction("Re-Apply Saved Images After Metadata Refresh", logging.LevelInfo)
 	logCtx = logging.WithCurrentAction(logCtx, logAction)
-	//defer ld.Log()
+	defer ld.Log()
 
 	savedItems, Err := database.GetAllSavedSets(logCtx, models.DBFilter{
 		ItemTMDB_ID:      item.MediaItem.TMDB_ID,

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -123,7 +124,7 @@ func ProcessQueueItems() {
 		}
 
 		// If a file starts with "error_" or "warning_", skip it
-		if len(file.Name()) > 6 && (file.Name()[:6] == "error_" || file.Name()[:8] == "warning_") {
+		if strings.HasPrefix(file.Name(), "error_") || strings.HasPrefix(file.Name(), "warning_") {
 			continue
 		}
 

--- a/backend/utils/httpx/make_http_request.go
+++ b/backend/utils/httpx/make_http_request.go
@@ -109,9 +109,11 @@ func MakeHTTPRequest(ctx context.Context, url, method string, headers map[string
 	// Webhook endpoints are configured by the user and may carry their secret in the path.
 	redactAll := siteName == WebhookSiteName
 
-	// Create a context with a timeout
+	// Bound the request by the timeout while still honoring the caller's context, so an
+	// abandoned caller (cancelled request, shutdown) cancels the outbound call instead of
+	// leaving it to run out its full timeout.
 	timeoutInterval := time.Duration(timeout) * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutInterval)
+	ctx, cancel := context.WithTimeout(ctx, timeoutInterval)
 	defer cancel()
 
 	// Create a new request with context

--- a/backend/utils/httpx/make_http_request_test.go
+++ b/backend/utils/httpx/make_http_request_test.go
@@ -1,11 +1,34 @@
 package httpx
 
 import (
+	"aura/logging"
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
+
+func TestMakeHTTPRequestHonorsCallerContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, ld := logging.CreateLoggingContext(context.Background(), "test")
+	ctx = logging.WithCurrentAction(ctx, ld.AddAction("test", logging.LevelTrace))
+
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, _, errInfo := MakeHTTPRequest(ctx, server.URL, http.MethodGet, nil, 60, nil, "Test")
+
+	if errInfo.Message == "" {
+		t.Fatal("MakeHTTPRequest succeeded on a cancelled caller context, so the caller context is being discarded")
+	}
+}
 
 // net/http rewrites a password-bearing URL to "user:***@host" before storing it on the
 // url.Error, so the stored URL no longer matches the raw one a substring replace looks for.


### PR DESCRIPTION
Three independent Wave 2 fixes, one commit each. No filed issues.

### `fix(queue)` — panic stalls the download queue
`backend/download/queue/process.go:126` guarded the slice length with `len(name) > 6` but then evaluated `name[:8]` for the `"warning_"` comparison. Go's `||` only short-circuits when the first operand is true, so any 7-character `.json` file in the queue directory reached `name[:8]` and panicked with a slice-bounds error, permanently stalling queue processing. Replaced with `strings.HasPrefix`, matching the already-correct sibling check at `collection_process.go:98` — this was the lone drifted copy.

### `fix(plex)` — every re-apply error silently discarded
`backend/download/auto/websocket-plex.go:424` built a logging context but its `defer ld.Log()` was commented out, so the `LogData` was never emitted. The saved-set lookup failure and each per-image apply failure on the Plex auto-reapply path were recorded and then dropped. Sibling handlers on the same listener (`handlePotentialNewMovie:366`, `processPlexRefreshMessage:308`) already flush. The existing `logAction.Complete()` calls are idempotent, so the added flush does not double-log.

### `fix(httpx)` — no outbound request was cancellable
`backend/utils/httpx/make_http_request.go:114` derived its timeout from `context.Background()` rather than the caller's context, discarding caller cancellation entirely. An abandoned caller — a disconnected client, a shutdown — left the request running for its full 60s timeout while holding a connection from the shared transport. Now derives the timeout from the caller's context, so both the deadline and the cancellation apply.

All ten `MakeHTTPRequest` call sites were checked for reliance on the detached behavior: every background goroutine (`webhook_sonarr.go:189`, `webhook_radarr.go:106`, `process.go:433`, `add.go:157`) already builds its own `context.Background()`. The one goroutine that does capture a request context (`routing/database/add.go:144`) makes DB calls only, never HTTP.

### Verification
`go build ./...`, `go vet ./...` and `go test ./...` all pass (`CONFIG_PATH` must point at a writable directory locally; `config.init()` hardcodes `/config` otherwise).

`TestMakeHTTPRequestHonorsCallerContext` is a real regression test — it fails against the previous `context.Background()` code and passes with the fix.
