### PR TITLE
fix(database): fail startup on migration error and on a newer schema

### DIFF
--- a/backend/database/migration/migrate.go
+++ b/backend/database/migration/migrate.go
@@ -4,7 +4,29 @@ import (
 	"aura/database"
 	"aura/logging"
 	"context"
+	"fmt"
 )
+
+// checkSchemaSupported rejects an on-disk schema newer than this binary understands.
+// Migrations are one-way and destructive (v4_v5 rewrites IgnoredItems.mode values under a new
+// CHECK constraint, then drops the old table), so a downgraded binary that boots against a newer
+// schema writes rows the schema rejects. Refusing to start keeps the per-migration backup usable.
+func checkSchemaSupported(currentVersion, latestVersion int) logging.LogErrorInfo {
+	if currentVersion <= latestVersion {
+		return logging.LogErrorInfo{}
+	}
+	return logging.LogErrorInfo{
+		Message: fmt.Sprintf("Database schema version %d is newer than this build supports (%d)", currentVersion, latestVersion),
+		Help: fmt.Sprintf(
+			"This build was started against a database written by a newer version of aura. Redeploy the newer image, or restore the backup taken before that upgrade (*_backup_v%d_to_v%d_*.db in the config directory) before running this version.",
+			latestVersion, latestVersion+1,
+		),
+		Detail: map[string]any{
+			"database_version":  currentVersion,
+			"supported_version": latestVersion,
+		},
+	}
+}
 
 func RunMigrations() (migrationsPerformed int, Err logging.LogErrorInfo) {
 	ctx, ld := logging.CreateLoggingContext(context.Background(), "Database Migration")
@@ -20,6 +42,12 @@ func RunMigrations() (migrationsPerformed int, Err logging.LogErrorInfo) {
 	currentVersion, getCurrentVersionErr := database.GetCurrentVersion(ctx)
 	if getCurrentVersionErr.Message != "" {
 		return migrationsPerformed, getCurrentVersionErr
+	}
+
+	// Refuse to run against a database newer than this binary (accidental downgrade)
+	if unsupportedErr := checkSchemaSupported(currentVersion, database.LATEST_DB_VERSION); unsupportedErr.Message != "" {
+		logAction.SetErrorFromInfo(unsupportedErr)
+		return migrationsPerformed, unsupportedErr
 	}
 
 	// If the current version is already the latest, nothing to do

--- a/backend/database/migration/migrate_test.go
+++ b/backend/database/migration/migrate_test.go
@@ -1,0 +1,52 @@
+package migration
+
+import (
+	"aura/database"
+	"strings"
+	"testing"
+)
+
+func TestCheckSchemaSupported(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion int
+		latestVersion  int
+		wantErr        bool
+	}{
+		{"fresh database", 0, 6, false},
+		{"needs migration", 4, 6, false},
+		{"up to date", 6, 6, false},
+		{"one version ahead", 7, 6, true},
+		{"several versions ahead", 12, 6, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkSchemaSupported(tt.currentVersion, tt.latestVersion)
+			if gotErr := got.Message != ""; gotErr != tt.wantErr {
+				t.Fatalf("checkSchemaSupported(%d, %d) error = %v, want error = %v (message %q)",
+					tt.currentVersion, tt.latestVersion, gotErr, tt.wantErr, got.Message)
+			}
+			if !tt.wantErr {
+				return
+			}
+			if got.Detail["database_version"] != tt.currentVersion {
+				t.Errorf("detail database_version = %v, want %d", got.Detail["database_version"], tt.currentVersion)
+			}
+			// The operator's only recovery path is the backup written before the
+			// migration that took the DB past this binary, so name it.
+			if !strings.Contains(got.Help, "_backup_v6_to_v7_") {
+				t.Errorf("help does not name the recovery backup file: %q", got.Help)
+			}
+		})
+	}
+}
+
+// The guard is only correct if every schema version the binary can produce is
+// accepted; a LATEST_DB_VERSION bump without a matching migration case would
+// otherwise start refusing its own databases.
+func TestCheckSchemaSupportedAcceptsLatestVersion(t *testing.T) {
+	if err := checkSchemaSupported(database.LATEST_DB_VERSION, database.LATEST_DB_VERSION); err.Message != "" {
+		t.Fatalf("current binary rejects its own schema version %d: %s", database.LATEST_DB_VERSION, err.Message)
+	}
+}

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -160,8 +160,19 @@ func runWarmup() (success bool) {
 	// Database-Migration: If not a new DB, run migrations
 	if !newDB {
 		config.AppLoadingStep = "Running Database Migrations"
-		migrationsCompleted, _ := migration.RunMigrations()
+		migrationsCompleted, migrateErr := migration.RunMigrations()
 		logging.LOGGER.Info().Timestamp().Msgf("%d database migrations performed", migrationsCompleted)
+		if migrateErr.Message != "" {
+			// A failed migration leaves the schema partially applied and the VERSION row
+			// unbumped, so booting on would run every query against a schema that does not
+			// match the code. Fail warmup instead of half-booting.
+			config.AppLoadingStep = "Database Migration Failed"
+			logging.LOGGER.Error().Timestamp().
+				Str("help", migrateErr.Help).
+				Interface("detail", migrateErr.Detail).
+				Msgf("Database migration failed: %s", migrateErr.Message)
+			return false
+		}
 	}
 
 	// Cache: Add all media server sections and items


### PR DESCRIPTION
Closes #130
Closes #131

## Root cause

**#130** — `startup.go:163` discarded the second return value of `RunMigrations`. Every failure path inside `RunMigrations` returns a populated `LogErrorInfo`, but `runWarmup` still returned `true`. `main.go` then set `AppFullyLoaded`, started cron, and served queries against a schema that did not match the code. Because `UpdateVersionTable` never ran, restarts silently retried the same failure — the only trace was `0 database migrations performed`.

**#131** — `RunMigrations` compared with `==` against `LATEST_DB_VERSION` and looped while `v < LATEST_DB_VERSION`. When the on-disk version is *greater*, both branches no-op with no warning. A rolled-back image tag booted clean, then failed every write using a value a newer migration had removed (`v4_v5` rewrites `IgnoredItems.mode` under a new `CHECK` and drops the old table).

## Change

- `backend/database/migration/migrate.go` — new `checkSchemaSupported(currentVersion, latestVersion)` returning a `LogErrorInfo` that names the recovery backup file; called in `RunMigrations` before the existing version checks.
- `backend/startup.go` — capture the migration error, log message/help/detail, set `AppLoadingStep = "Database Migration Failed"`, return `false`. That routes into the pre-existing `main.go:74` `Warmup failed. Exiting application.` fatal path, so both cases now refuse to boot instead of half-booting.
- `backend/database/migration/migrate_test.go` — new test.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` (13 packages ok), `gofmt -l` clean. Run with `CGO_ENABLED=1 CONFIG_PATH=$(mktemp -d)` — without `CONFIG_PATH`, `config.init()` panics on `mkdir /config: read-only file system` for 10 packages (pre-existing, unrelated).

Mutation-tested the guard: forcing `checkSchemaSupported` to always return no error makes `TestCheckSchemaSupported` fail, so the test catches a regression rather than passing trivially.

## Deliberately skipped

- No readiness/status endpoint change — the process calls `LOGGER.Fatal()` + `os.Exit(1)`, so nothing is left running to report to. The `AppLoadingStep` write only feeds the log line before exit.
- Pre-existing bug left alone: `migrate.go` default case passes an unformatted verb in `LogErrorInfo{Message: "No migration path for database version %d"}`. Out of scope, and now unreachable for high versions since the new guard returns first.
- No backup *restore* tooling. #131 notes nothing restores the backups; the guard only names the file. Separate feature.

> Conflicts with #123's branch on `backend/startup.go` — whichever merges second needs a rebase.