### PR TITLE
fix(download-queue): guard LatestInfo with a mutex

### DIFF
--- a/backend/download/queue/collection_process.go
+++ b/backend/download/queue/collection_process.go
@@ -103,10 +103,12 @@ func ProcessCollectionQueueItems() {
 		subAction := ld.AddAction(fmt.Sprintf("Processing file: %s", file.Name()), logging.LevelInfo)
 		ctx = logging.WithCurrentAction(ctx, subAction)
 
-		LatestInfo.Status = LAST_STATUS_PROCESSING
-		LatestInfo.Message = fmt.Sprintf("Processing collection file: %s", file.Name())
-		LatestInfo.Errors = []string{}
-		LatestInfo.Warnings = []string{}
+		UpdateLatestInfo(func(info *LatestInfo) {
+			info.Status = LAST_STATUS_PROCESSING
+			info.Message = fmt.Sprintf("Processing collection file: %s", file.Name())
+			info.Errors = []string{}
+			info.Warnings = []string{}
+		})
 
 		fileErrors := []string{}
 		fileWarnings := []string{}
@@ -157,7 +159,9 @@ func ProcessCollectionQueueItems() {
 			continue
 		}
 
-		LatestInfo.Message = fmt.Sprintf("Collection: %s", queueItem.CollectionItem.Title)
+		UpdateLatestInfo(func(info *LatestInfo) {
+			info.Message = fmt.Sprintf("Collection: %s", queueItem.CollectionItem.Title)
+		})
 
 		collectionItem := queueItem.CollectionItem
 		for _, image := range queueItem.Images {

--- a/backend/download/queue/init.go
+++ b/backend/download/queue/init.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"os"
 	"path"
+	"slices"
+	"sync"
 	"time"
 )
 
@@ -20,14 +22,20 @@ const (
 	LAST_STATUS_PROCESSING Status = "Processing"
 )
 
+// LatestInfo is the most recent download queue processing status. The queue
+// cron goroutines write it while the status handler reads it (the UI polls
+// every 2s), so all access goes through GetLatestInfo/UpdateLatestInfo.
+type LatestInfo struct {
+	Time     time.Time
+	Status   Status
+	Message  string
+	Errors   []string
+	Warnings []string
+}
+
 var (
-	LatestInfo = struct {
-		Time     time.Time
-		Status   Status
-		Message  string
-		Errors   []string
-		Warnings []string
-	}{}
+	latestInfoMu sync.RWMutex
+	latestInfo   LatestInfo
 
 	FolderPath string = ""
 
@@ -42,6 +50,23 @@ var (
 type FileIssues struct {
 	Errors   []string
 	Warnings []string
+}
+
+func GetLatestInfo() LatestInfo {
+	latestInfoMu.RLock()
+	defer latestInfoMu.RUnlock()
+	return latestInfo
+}
+
+// UpdateLatestInfo applies mutate under the write lock. Errors and Warnings are
+// cloned because callers keep appending to the slices they hand over, which
+// would otherwise mutate the published backing array from another goroutine.
+func UpdateLatestInfo(mutate func(info *LatestInfo)) {
+	latestInfoMu.Lock()
+	defer latestInfoMu.Unlock()
+	mutate(&latestInfo)
+	latestInfo.Errors = slices.Clone(latestInfo.Errors)
+	latestInfo.Warnings = slices.Clone(latestInfo.Warnings)
 }
 
 // setLatestInfoTerminal records the terminal status of a processed queue entry on
@@ -60,11 +85,13 @@ func setLatestInfoTerminal(message string, fileErrors, fileWarnings []string) {
 	if message == "" {
 		message = "Unknown"
 	}
-	LatestInfo.Time = time.Now()
-	LatestInfo.Status = status
-	LatestInfo.Message = message
-	LatestInfo.Errors = fileErrors
-	LatestInfo.Warnings = fileWarnings
+	UpdateLatestInfo(func(info *LatestInfo) {
+		info.Time = time.Now()
+		info.Status = status
+		info.Message = message
+		info.Errors = fileErrors
+		info.Warnings = fileWarnings
+	})
 }
 
 func init() {

--- a/backend/download/queue/init_test.go
+++ b/backend/download/queue/init_test.go
@@ -2,19 +2,10 @@ package downloadqueue
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
 )
-
-func TestMain(m *testing.M) {
-	code := m.Run()
-	// The package init() creates the queue folders relative to the (unset)
-	// config path when running under `go test`.
-	os.RemoveAll(FolderPath)
-	os.Exit(code)
-}
 
 // Queue processors keep appending to the error/warning slices after handing
 // them to UpdateLatestInfo, so the stored copy must not alias the caller's

--- a/backend/download/queue/init_test.go
+++ b/backend/download/queue/init_test.go
@@ -1,0 +1,81 @@
+package downloadqueue
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	// The package init() creates the queue folders relative to the (unset)
+	// config path when running under `go test`.
+	os.RemoveAll(FolderPath)
+	os.Exit(code)
+}
+
+// Queue processors keep appending to the error/warning slices after handing
+// them to UpdateLatestInfo, so the stored copy must not alias the caller's
+// backing array.
+func TestUpdateLatestInfoClonesSlices(t *testing.T) {
+	errors := make([]string, 1, 4)
+	errors[0] = "first"
+
+	UpdateLatestInfo(func(info *LatestInfo) {
+		info.Errors = errors
+		info.Warnings = nil
+	})
+
+	errors = append(errors, "second")
+	errors[0] = "mutated"
+
+	stored := GetLatestInfo().Errors
+	if len(stored) != 1 || stored[0] != "first" {
+		t.Fatalf("stored errors alias the caller slice: got %v", stored)
+	}
+}
+
+func TestLatestInfoConcurrentAccess(t *testing.T) {
+	var wg sync.WaitGroup
+
+	for writer := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				errors := make([]string, 1, 4)
+				errors[0] = fmt.Sprintf("error-%d-%d", writer, i)
+
+				UpdateLatestInfo(func(info *LatestInfo) {
+					info.Time = time.Now()
+					info.Status = LAST_STATUS_PROCESSING
+					info.Message = fmt.Sprintf("processing %d", i)
+					info.Errors = errors
+					info.Warnings = []string{}
+				})
+
+				errors = append(errors, "appended after publishing")
+			}
+		}()
+	}
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				info := GetLatestInfo()
+				for _, message := range info.Errors {
+					_ = message
+				}
+				for _, message := range info.Warnings {
+					_ = message
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/backend/download/queue/process.go
+++ b/backend/download/queue/process.go
@@ -133,10 +133,12 @@ func ProcessQueueItems() {
 		ctx = logging.WithCurrentAction(ctx, subAction)
 
 		// Reset the Latest Info for this file
-		LatestInfo.Status = LAST_STATUS_PROCESSING
-		LatestInfo.Message = fmt.Sprintf("Processing file: %s", file.Name())
-		LatestInfo.Errors = []string{}
-		LatestInfo.Warnings = []string{}
+		UpdateLatestInfo(func(info *LatestInfo) {
+			info.Status = LAST_STATUS_PROCESSING
+			info.Message = fmt.Sprintf("Processing file: %s", file.Name())
+			info.Errors = []string{}
+			info.Warnings = []string{}
+		})
 
 		// Create an array of errors and warnings for this file
 		fileErrors := []string{}
@@ -289,7 +291,9 @@ func ProcessQueueItems() {
 				continue
 			}
 
-			LatestInfo.Message = fmt.Sprintf("%s (Set: %s)", queueItem.MediaItem.Title, posterSet.ID)
+			UpdateLatestInfo(func(info *LatestInfo) {
+				info.Message = fmt.Sprintf("%s (Set: %s)", queueItem.MediaItem.Title, posterSet.ID)
+			})
 
 			// When the set is flagged to force-preload missing seasons/episodes, Kometa asset
 			// mode is enabled, and the show exists on the server with at least one episode, we

--- a/backend/download/queue/send_notification.go
+++ b/backend/download/queue/send_notification.go
@@ -74,11 +74,13 @@ func SendNotification(
 	}
 
 	// Update the Global LatestInfo
-	LatestInfo.Time = time.Now()
-	LatestInfo.Status = result
-	LatestInfo.Message = fmt.Sprintf("%s (Set: %s)", mediaItem.Title, posterSet.ID)
-	LatestInfo.Errors = fileIssues.Errors
-	LatestInfo.Warnings = fileIssues.Warnings
+	UpdateLatestInfo(func(info *LatestInfo) {
+		info.Time = time.Now()
+		info.Status = result
+		info.Message = fmt.Sprintf("%s (Set: %s)", mediaItem.Title, posterSet.ID)
+		info.Errors = fileIssues.Errors
+		info.Warnings = fileIssues.Warnings
+	})
 
 	ctx, ld := logging.CreateLoggingContext(context.Background(), "Notification - Send Download Queue Update")
 	logAction := ld.AddAction("Sending Download Queue Notification", logging.LevelInfo)

--- a/backend/routing/download/queue_status.go
+++ b/backend/routing/download/queue_status.go
@@ -32,12 +32,14 @@ func GetDownloadQueueStatus(w http.ResponseWriter, r *http.Request) {
 	logAction := ld.AddAction("Download Queue - Get Status", logging.LevelInfo)
 	ctx = logging.WithCurrentAction(ctx, logAction)
 
+	latestInfo := downloadqueue.GetLatestInfo()
+
 	var response GetDownloadQueueStatus_Response
-	response.Time = downloadqueue.LatestInfo.Time
-	response.Status = downloadqueue.LatestInfo.Status
-	response.Message = downloadqueue.LatestInfo.Message
-	response.Warnings = downloadqueue.LatestInfo.Warnings
-	response.Errors = downloadqueue.LatestInfo.Errors
+	response.Time = latestInfo.Time
+	response.Status = latestInfo.Status
+	response.Message = latestInfo.Message
+	response.Warnings = latestInfo.Warnings
+	response.Errors = latestInfo.Errors
 
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -195,14 +195,18 @@ func runWarmup() (success bool) {
 	err := jobs.StartDownloadQueueJob()
 	if err != nil {
 		logging.LOGGER.Error().Timestamp().Err(err).Msg("Failed to schedule Download Queue Processing cron job")
-		downloadqueue.LatestInfo.Time = time.Now()
-		downloadqueue.LatestInfo.Status = downloadqueue.LAST_STATUS_ERROR
-		downloadqueue.LatestInfo.Message = "Failed to schedule Download Queue Processing"
-		downloadqueue.LatestInfo.Errors = []string{err.Error()}
-		downloadqueue.LatestInfo.Warnings = []string{}
+		downloadqueue.UpdateLatestInfo(func(info *downloadqueue.LatestInfo) {
+			info.Time = time.Now()
+			info.Status = downloadqueue.LAST_STATUS_ERROR
+			info.Message = "Failed to schedule Download Queue Processing"
+			info.Errors = []string{err.Error()}
+			info.Warnings = []string{}
+		})
 	} else {
-		downloadqueue.LatestInfo.Time = time.Now()
-		downloadqueue.LatestInfo.Status = downloadqueue.LAST_STATUS_IDLE
+		downloadqueue.UpdateLatestInfo(func(info *downloadqueue.LatestInfo) {
+			info.Time = time.Now()
+			info.Status = downloadqueue.LAST_STATUS_IDLE
+		})
 	}
 
 	// Cronjob: Refresh Media Items and Collections


### PR DESCRIPTION
Closes #123

## Root cause

Two defects, not one.

The lock was the obvious half: `LatestInfo` was an unsynchronized package global written by queue cron goroutines and read by the status handler the UI polls every 2s.

Grepping the writers found the second half: `process.go` hands `fileErrors` to `setLatestInfoTerminal` at line 161, then keeps `append`ing to that same slice at line 413. The slice has spare capacity, so those appends write into the backing array already published to readers. **A mutex alone would still have raced.** `UpdateLatestInfo` now clones `Errors`/`Warnings` on write, so the stored copy is never aliased by a caller.

## Change

All 5 write sites (across 2 packages) and the 1 read site route through `GetLatestInfo`/`UpdateLatestInfo`. The global is unexported, so no site can bypass them. A mutator-closure API preserves exact semantics at the partial-update sites (`process.go:292` sets only `Message`; the reset blocks deliberately leave `Time` stale).

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean. `go test ./...` and `go test -race ./...` both pass.

Negative control: stripping the mutex and the clones makes both new tests fail — 6× `WARNING: DATA RACE`, plus `stored errors alias the caller slice: got [mutated]`.

## Deliberately skipped

Did not add `-race` to `.github/workflows/ci.yml` as the issue suggests. The issue names a second unfixed race at `cron.go:200`, so enabling it now could redden CI on a race this PR does not fix. Worth a follow-up once that lands.

Note: `go test ./...` fails in any environment without `CONFIG_PATH` set — `config.init()` panics on `mkdir /config`. Pre-existing; CI sets it.

> Conflicts with the #130/#131 branch on `backend/startup.go` — whichever merges second needs a rebase.