### PR TITLE
fix(startup): allow startup during MediUX outage

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -5492,6 +5492,14 @@ const docTemplate = `{
                     "description": "Friendly name of the media server",
                     "type": "string"
                 },
+                "media_server_reachable": {
+                    "description": "Whether the media server answered the last check",
+                    "type": "boolean"
+                },
+                "mediux_reachable": {
+                    "description": "Whether MediUX answered the last check",
+                    "type": "boolean"
+                },
                 "mediux_site_link": {
                     "description": "Current Mediux site link",
                     "type": "string"

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -5484,6 +5484,14 @@
                     "description": "Friendly name of the media server",
                     "type": "string"
                 },
+                "media_server_reachable": {
+                    "description": "Whether the media server answered the last check",
+                    "type": "boolean"
+                },
+                "mediux_reachable": {
+                    "description": "Whether MediUX answered the last check",
+                    "type": "boolean"
+                },
                 "mediux_site_link": {
                     "description": "Current Mediux site link",
                     "type": "string"

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -1302,6 +1302,12 @@ definitions:
       media_server_name:
         description: Friendly name of the media server
         type: string
+      media_server_reachable:
+        description: Whether the media server answered the last check
+        type: boolean
+      mediux_reachable:
+        description: Whether MediUX answered the last check
+        type: boolean
       mediux_site_link:
         description: Current Mediux site link
         type: string

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -12,13 +12,15 @@ var (
 	ConfigPath string = ""
 
 	// Flags to track config loading and validation status
-	Loaded           bool   = false
-	Valid            bool   = false
-	MediaServerValid bool   = true
-	MediaServerName  string = ""
-	MediuxValid      bool   = true
-	AppFullyLoaded   bool   = false
-	AppLoadingStep   string = ""
+	Loaded               bool   = false
+	Valid                bool   = false
+	MediaServerValid     bool   = true
+	MediaServerReachable bool   = true
+	MediaServerName      string = ""
+	MediuxValid          bool   = true
+	MediuxReachable      bool   = true
+	AppFullyLoaded       bool   = false
+	AppLoadingStep       string = ""
 
 	// App Details
 	AppName    string = ""
@@ -27,6 +29,14 @@ var (
 	AppPort    int    = 0
 	AppVersion string = ""
 )
+
+// NeedsSetup reports whether the user still has to complete onboarding. It
+// deliberately covers config well-formedness only: an unreachable media server
+// or MediUX is a degraded runtime state the UI flags separately, not a reason to
+// send the user back through setup while the app is otherwise serving.
+func NeedsSetup() bool {
+	return !(Loaded && Valid)
+}
 
 type Config struct {
 	Auth          Config_Auth              `json:"auth" yaml:"Auth,omitempty"`                     // Authentication settings.

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,6 +11,7 @@ import (
 	"aura/logging"
 	"aura/notification"
 	"aura/routing"
+	"context"
 	"os"
 	"strings"
 	"sync"
@@ -110,6 +111,13 @@ func main() {
 		// Config is valid. Attempt preflight; on success, activate the full routes.
 		if runPreFlight() {
 			activateFullRoutes()
+			if !config.MediuxReachable {
+				// Activated in a degraded state. Preflight only runs again at
+				// onboarding, and activated is already closed so the retry loop below
+				// would exit immediately, so the MediUX flags would stay false until a
+				// restart. Poll MediUX on its own until the outage clears.
+				go recheckMediuxUntilReachable()
+			}
 			return
 		}
 
@@ -154,6 +162,26 @@ func retryPreFlightUntilReady(activateFullRoutes func(), activated <-chan struct
 				activateFullRoutes()
 				return
 			}
+		}
+	}
+}
+
+// recheckMediuxUntilReachable re-validates the MediUX token on an interval after
+// the app came up with MediUX unreachable, so its flags recover once the outage
+// ends. It re-checks MediUX alone rather than re-running preflight, which would
+// overwrite config.AppLoadingStep on an already-loaded app.
+func recheckMediuxUntilReachable() {
+	ticker := time.NewTicker(preflightRetryInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		ctx, ld := logging.CreateLoggingContext(context.Background(), "MediUX Recheck")
+		action := ld.AddAction("Rechecking MediUX Availability", logging.LevelInfo)
+		ctx = logging.WithCurrentAction(ctx, action)
+		result := validateMediuxToken(ctx)
+		action.Complete()
+		ld.Log()
+		if result != mediuxUnreachable {
+			return
 		}
 	}
 }

--- a/backend/routing/config/reload.go
+++ b/backend/routing/config/reload.go
@@ -37,11 +37,13 @@ func ReloadAppConfig(w http.ResponseWriter, r *http.Request) {
 	sanitizedConfig := config.Current.SanitizeConfig(ctx)
 
 	response.Status = AppConfigStatus{
-		ConfigLoaded:    config.Loaded,
-		ConfigValid:     (config.Valid && config.MediuxValid && config.MediaServerValid),
-		NeedsSetup:      !(config.Loaded && config.Valid && config.MediuxValid && config.MediaServerValid),
-		CurrentSetup:    *sanitizedConfig,
-		MediaServerName: config.MediaServerName,
+		ConfigLoaded:         config.Loaded,
+		ConfigValid:          config.Valid,
+		NeedsSetup:           config.NeedsSetup(),
+		MediaServerReachable: config.MediaServerReachable,
+		MediuxReachable:      config.MediuxReachable,
+		CurrentSetup:         *sanitizedConfig,
+		MediaServerName:      config.MediaServerName,
 	}
 
 	httpx.SendResponse(w, ld, response)

--- a/backend/routing/config/status.go
+++ b/backend/routing/config/status.go
@@ -10,15 +10,17 @@ import (
 
 // AppConfigStatus represents the current status of the onboarding process and app config
 type AppConfigStatus struct {
-	ConfigLoaded    bool          `json:"config_loaded"`               // Whether a config file is loaded
-	ConfigValid     bool          `json:"config_valid"`                // Whether the loaded config is valid
-	NeedsSetup      bool          `json:"needs_setup"`                 // Whether the app needs initial setup
-	CurrentSetup    config.Config `json:"current_setup"`               // The current (sanitized) configuration
-	MediaServerName string        `json:"media_server_name,omitempty"` // Friendly name of the media server
-	MediuxSiteLink  string        `json:"mediux_site_link,omitempty"`  // Current Mediux site link
-	AppFullyLoaded  bool          `json:"app_fully_loaded"`            // Whether the app is fully loaded and ready to use
-	AppVersion      string        `json:"app_version"`                 // Current version of the app
-	AppLoadingStep  string        `json:"app_loading_step"`            // Current loading step of the app
+	ConfigLoaded         bool          `json:"config_loaded"`               // Whether a config file is loaded
+	ConfigValid          bool          `json:"config_valid"`                // Whether the loaded config is valid
+	NeedsSetup           bool          `json:"needs_setup"`                 // Whether the app needs initial setup
+	MediaServerReachable bool          `json:"media_server_reachable"`      // Whether the media server answered the last check
+	MediuxReachable      bool          `json:"mediux_reachable"`            // Whether MediUX answered the last check
+	CurrentSetup         config.Config `json:"current_setup"`               // The current (sanitized) configuration
+	MediaServerName      string        `json:"media_server_name,omitempty"` // Friendly name of the media server
+	MediuxSiteLink       string        `json:"mediux_site_link,omitempty"`  // Current Mediux site link
+	AppFullyLoaded       bool          `json:"app_fully_loaded"`            // Whether the app is fully loaded and ready to use
+	AppVersion           string        `json:"app_version"`                 // Current version of the app
+	AppLoadingStep       string        `json:"app_loading_step"`            // Current loading step of the app
 }
 
 type configStatusResponse struct {
@@ -43,15 +45,17 @@ func GetAppConfigStatus(w http.ResponseWriter, r *http.Request) {
 	currentConfig := config.Current // Make a local copy of the current config for sanitization
 
 	response.Status = AppConfigStatus{
-		ConfigLoaded:    config.Loaded,
-		ConfigValid:     (config.Valid && config.MediuxValid && config.MediaServerValid),
-		NeedsSetup:      !(config.Loaded && config.Valid && config.MediuxValid && config.MediaServerValid),
-		CurrentSetup:    *currentConfig.SanitizeConfig(ctx),
-		MediaServerName: config.MediaServerName,
-		MediuxSiteLink:  mediux.MediuxSiteLink,
-		AppFullyLoaded:  config.AppFullyLoaded,
-		AppVersion:      config.AppVersion,
-		AppLoadingStep:  config.AppLoadingStep,
+		ConfigLoaded:         config.Loaded,
+		ConfigValid:          config.Valid,
+		NeedsSetup:           config.NeedsSetup(),
+		MediaServerReachable: config.MediaServerReachable,
+		MediuxReachable:      config.MediuxReachable,
+		CurrentSetup:         *currentConfig.SanitizeConfig(ctx),
+		MediaServerName:      config.MediaServerName,
+		MediuxSiteLink:       mediux.MediuxSiteLink,
+		AppFullyLoaded:       config.AppFullyLoaded,
+		AppVersion:           config.AppVersion,
+		AppLoadingStep:       config.AppLoadingStep,
 	}
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/routing/config/update.go
+++ b/backend/routing/config/update.go
@@ -129,8 +129,10 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 	config.Loaded = true
 	config.Valid = true
 	config.MediaServerValid = true
+	config.MediaServerReachable = true
 	config.MediaServerName = newMediaServerName
 	config.MediuxValid = true
+	config.MediuxReachable = true
 
 	if autoDownloadChanged {
 		jobs.StartAutoDownloadJob()
@@ -147,11 +149,13 @@ func UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.Status = AppConfigStatus{
-		ConfigLoaded:    config.Loaded,
-		ConfigValid:     (config.Valid && config.MediuxValid && config.MediaServerValid),
-		NeedsSetup:      !(config.Loaded && config.Valid && config.MediuxValid && config.MediaServerValid),
-		CurrentSetup:    *newConfig.SanitizeConfig(ctx),
-		MediaServerName: config.MediaServerName,
+		ConfigLoaded:         config.Loaded,
+		ConfigValid:          config.Valid,
+		NeedsSetup:           config.NeedsSetup(),
+		MediaServerReachable: config.MediaServerReachable,
+		MediuxReachable:      config.MediuxReachable,
+		CurrentSetup:         *newConfig.SanitizeConfig(ctx),
+		MediaServerName:      config.MediaServerName,
 	}
 
 	httpx.SendResponse(w, ld, response)

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -109,10 +109,7 @@ func runPreFlight() (success bool) {
 	// Validate MediUX Token
 	config.AppLoadingStep = "Validating MediUX Token"
 	mediuxTokenValid, mediuxErr := mediux.ValidateToken(ctx, config.Current.Mediux.ApiToken)
-	if mediuxErr.Message != "" || !mediuxTokenValid {
-		config.MediuxValid = false
-		return success
-	}
+	config.MediuxValid = mediuxErr.Message == "" && mediuxTokenValid
 
 	if config.MediaServerValid || config.MediuxValid {
 		success = true

--- a/backend/startup.go
+++ b/backend/startup.go
@@ -84,6 +84,7 @@ func runPreFlight() (success bool) {
 	connectionOk, serverName, serverVersion, msErr := mediaserver.TestConnection(ctx, &config.Current.MediaServer)
 	if msErr.Message != "" || !connectionOk || serverVersion == "" || serverName == "" {
 		config.MediaServerValid = false
+		config.MediaServerReachable = false
 		return success
 	}
 	if config.Current.MediaServer.Type == "Jellyfin" || config.Current.MediaServer.Type == "Emby" {
@@ -92,9 +93,11 @@ func runPreFlight() (success bool) {
 		ejUserID, initErr := mediaserver.GetAdminUser(ctx, &config.Current.MediaServer)
 		if initErr.Message != "" {
 			config.MediaServerValid = false
+			config.MediaServerReachable = false
 			return success
 		} else if ejUserID == "" {
 			config.MediaServerValid = false
+			config.MediaServerReachable = false
 			logging.LOGGER.Error().Timestamp().Msg("Failed to retrieve admin user ID from Emby/Jellyfin server")
 			return success
 		}
@@ -105,17 +108,60 @@ func runPreFlight() (success bool) {
 		Str("media_server_version", serverVersion).
 		Msg("Media Server connection validated successfully")
 	config.MediaServerValid = true
+	config.MediaServerReachable = true
 
 	// Validate MediUX Token
 	config.AppLoadingStep = "Validating MediUX Token"
-	mediuxTokenValid, mediuxErr := mediux.ValidateToken(ctx, config.Current.Mediux.ApiToken)
-	config.MediuxValid = mediuxErr.Message == "" && mediuxTokenValid
+	if validateMediuxToken(ctx) == mediuxTokenRejected {
+		// MediUX answered and refused the token, so the configured token is wrong.
+		// Fail preflight to keep the app on onboarding until the user fixes it,
+		// rather than starting degraded as we do for an outage.
+		return success
+	}
 
 	if config.MediaServerValid || config.MediuxValid {
 		success = true
 	}
 
 	return success
+}
+
+type mediuxTokenResult int
+
+const (
+	mediuxTokenAccepted mediuxTokenResult = iota
+	mediuxTokenRejected
+	mediuxUnreachable
+)
+
+// validateMediuxToken checks the configured MediUX token and records the outcome
+// on the config package's flags. It separates "MediUX said no" from "MediUX did
+// not answer": the first is a config problem the user must fix, the second is an
+// outage the app can run through in a degraded state.
+func validateMediuxToken(ctx context.Context) mediuxTokenResult {
+	tokenValid, mediuxErr := mediux.ValidateToken(ctx, config.Current.Mediux.ApiToken)
+	switch {
+	case mediuxErr.Message == "" && tokenValid:
+		config.MediuxValid = true
+		config.MediuxReachable = true
+		return mediuxTokenAccepted
+	case mediuxAuthRejected(mediuxErr):
+		config.MediuxValid = false
+		config.MediuxReachable = true
+		return mediuxTokenRejected
+	default:
+		config.MediuxValid = false
+		config.MediuxReachable = false
+		return mediuxUnreachable
+	}
+}
+
+// mediuxAuthRejected reports whether MediUX explicitly refused the token rather
+// than failing to answer. mediux.makeRequest records the response status under
+// status_code in the error detail; a transport failure carries no status at all.
+func mediuxAuthRejected(err logging.LogErrorInfo) bool {
+	status, ok := err.Detail["status_code"].(int)
+	return ok && (status == http.StatusUnauthorized || status == http.StatusForbidden)
 }
 
 func runWarmup() (success bool) {

--- a/backend/startup_test.go
+++ b/backend/startup_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"aura/config"
+	"aura/mediux"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func preservePreFlightState(t *testing.T) {
+	t.Helper()
+	current := config.Current
+	mediaServerValid := config.MediaServerValid
+	mediaServerName := config.MediaServerName
+	mediuxValid := config.MediuxValid
+	appLoadingStep := config.AppLoadingStep
+	mediuxAPIURL := mediux.MediuxApiURL
+	t.Cleanup(func() {
+		config.Current = current
+		config.MediaServerValid = mediaServerValid
+		config.MediaServerName = mediaServerName
+		config.MediuxValid = mediuxValid
+		config.AppLoadingStep = appLoadingStep
+		mediux.MediuxApiURL = mediuxAPIURL
+	})
+}
+
+func TestRunPreFlightAllowsHealthyMediaServerWhenMediUXValidationFails(t *testing.T) {
+	preservePreFlightState(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/users/me" {
+			http.Error(w, "MediUX unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"MediaContainer":{"friendlyName":"Plex","version":"1.0.0"}}`))
+	}))
+	defer server.Close()
+
+	mediux.MediuxApiURL = server.URL
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-token"}
+	config.Current.Mediux = config.Config_Mediux{ApiToken: "mediux-token"}
+	config.MediaServerValid = false
+	config.MediuxValid = true
+
+	if !runPreFlight() {
+		t.Fatal("runPreFlight() = false, want true when only MediUX validation fails")
+	}
+	if !config.MediaServerValid {
+		t.Error("config.MediaServerValid = false, want true")
+	}
+	if config.MediuxValid {
+		t.Error("config.MediuxValid = true, want false")
+	}
+}
+
+func TestRunPreFlightMarksValidMediUXToken(t *testing.T) {
+	preservePreFlightState(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"MediaContainer":{"friendlyName":"Plex","version":"1.0.0"}}`))
+	}))
+	defer server.Close()
+
+	mediux.MediuxApiURL = server.URL
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-token"}
+	config.Current.Mediux = config.Config_Mediux{ApiToken: "mediux-token"}
+	config.MediaServerValid = false
+	config.MediuxValid = false
+
+	if !runPreFlight() {
+		t.Fatal("runPreFlight() = false, want true when both services validate")
+	}
+	if !config.MediuxValid {
+		t.Error("config.MediuxValid = false, want true")
+	}
+}
+
+func TestRunPreFlightRejectsInvalidMediaServer(t *testing.T) {
+	preservePreFlightState(t)
+	config.Current.MediaServer = config.Config_MediaServer{Type: "unsupported"}
+	config.MediaServerValid = true
+
+	if runPreFlight() {
+		t.Fatal("runPreFlight() = true, want false when media server is invalid")
+	}
+	if config.MediaServerValid {
+		t.Error("config.MediaServerValid = true, want false")
+	}
+}

--- a/backend/startup_test.go
+++ b/backend/startup_test.go
@@ -11,69 +11,123 @@ import (
 func preservePreFlightState(t *testing.T) {
 	t.Helper()
 	current := config.Current
+	loaded := config.Loaded
+	valid := config.Valid
 	mediaServerValid := config.MediaServerValid
+	mediaServerReachable := config.MediaServerReachable
 	mediaServerName := config.MediaServerName
 	mediuxValid := config.MediuxValid
+	mediuxReachable := config.MediuxReachable
 	appLoadingStep := config.AppLoadingStep
 	mediuxAPIURL := mediux.MediuxApiURL
 	t.Cleanup(func() {
 		config.Current = current
+		config.Loaded = loaded
+		config.Valid = valid
 		config.MediaServerValid = mediaServerValid
+		config.MediaServerReachable = mediaServerReachable
 		config.MediaServerName = mediaServerName
 		config.MediuxValid = mediuxValid
+		config.MediuxReachable = mediuxReachable
 		config.AppLoadingStep = appLoadingStep
 		mediux.MediuxApiURL = mediuxAPIURL
 	})
 }
 
-func TestRunPreFlightAllowsHealthyMediaServerWhenMediUXValidationFails(t *testing.T) {
-	preservePreFlightState(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/users/me" {
-			http.Error(w, "MediUX unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"MediaContainer":{"friendlyName":"Plex","version":"1.0.0"}}`))
-	}))
-	defer server.Close()
-
-	mediux.MediuxApiURL = server.URL
-	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-token"}
-	config.Current.Mediux = config.Config_Mediux{ApiToken: "mediux-token"}
-	config.MediaServerValid = false
-	config.MediuxValid = true
-
-	if !runPreFlight() {
-		t.Fatal("runPreFlight() = false, want true when only MediUX validation fails")
+// TestRunPreFlightSeparatesMediuxOutageFromRejectedToken pins the distinction the
+// status response depends on: MediUX refusing the token is a config problem that
+// must fail preflight and send the user to onboarding, while MediUX not
+// answering is an outage the app starts through in a degraded state.
+func TestRunPreFlightSeparatesMediuxOutageFromRejectedToken(t *testing.T) {
+	tests := []struct {
+		name                string
+		mediuxStatus        int
+		wantSuccess         bool
+		wantMediuxValid     bool
+		wantMediuxReachable bool
+		wantNeedsSetup      bool
+	}{
+		{
+			name:                "both healthy",
+			mediuxStatus:        http.StatusOK,
+			wantSuccess:         true,
+			wantMediuxValid:     true,
+			wantMediuxReachable: true,
+			wantNeedsSetup:      false,
+		},
+		{
+			name:                "mediux unreachable starts degraded",
+			mediuxStatus:        http.StatusServiceUnavailable,
+			wantSuccess:         true,
+			wantMediuxValid:     false,
+			wantMediuxReachable: false,
+			wantNeedsSetup:      false,
+		},
+		{
+			name:                "mediux rejects token",
+			mediuxStatus:        http.StatusUnauthorized,
+			wantSuccess:         false,
+			wantMediuxValid:     false,
+			wantMediuxReachable: true,
+			wantNeedsSetup:      true,
+		},
 	}
-	if !config.MediaServerValid {
-		t.Error("config.MediaServerValid = false, want true")
-	}
-	if config.MediuxValid {
-		t.Error("config.MediuxValid = true, want false")
-	}
-}
 
-func TestRunPreFlightMarksValidMediUXToken(t *testing.T) {
-	preservePreFlightState(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"MediaContainer":{"friendlyName":"Plex","version":"1.0.0"}}`))
-	}))
-	defer server.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preservePreFlightState(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/users/me" {
+					if tt.mediuxStatus != http.StatusOK {
+						http.Error(w, "MediUX rejected the request", tt.mediuxStatus)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{}`))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"MediaContainer":{"friendlyName":"Plex","version":"1.0.0"}}`))
+			}))
+			defer server.Close()
 
-	mediux.MediuxApiURL = server.URL
-	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-token"}
-	config.Current.Mediux = config.Config_Mediux{ApiToken: "mediux-token"}
-	config.MediaServerValid = false
-	config.MediuxValid = false
+			mediux.MediuxApiURL = server.URL
+			config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-token"}
+			config.Current.Mediux = config.Config_Mediux{ApiToken: "mediux-token"}
+			config.Loaded = true
+			config.Valid = true
+			config.MediaServerValid = false
+			config.MediaServerReachable = false
+			config.MediuxValid = false
+			config.MediuxReachable = false
 
-	if !runPreFlight() {
-		t.Fatal("runPreFlight() = false, want true when both services validate")
-	}
-	if !config.MediuxValid {
-		t.Error("config.MediuxValid = false, want true")
+			gotSuccess := runPreFlight()
+
+			if gotSuccess != tt.wantSuccess {
+				t.Errorf("runPreFlight() = %v, want %v", gotSuccess, tt.wantSuccess)
+			}
+			if !config.MediaServerValid {
+				t.Error("config.MediaServerValid = false, want true")
+			}
+			if !config.MediaServerReachable {
+				t.Error("config.MediaServerReachable = false, want true")
+			}
+			if config.MediuxValid != tt.wantMediuxValid {
+				t.Errorf("config.MediuxValid = %v, want %v", config.MediuxValid, tt.wantMediuxValid)
+			}
+			if config.MediuxReachable != tt.wantMediuxReachable {
+				t.Errorf("config.MediuxReachable = %v, want %v", config.MediuxReachable, tt.wantMediuxReachable)
+			}
+
+			// Mirrors main.go: a failed preflight marks the config invalid and leaves
+			// the app on onboarding-only routes.
+			if !gotSuccess {
+				config.Valid = false
+			}
+			if config.NeedsSetup() != tt.wantNeedsSetup {
+				t.Errorf("config.NeedsSetup() = %v, want %v", config.NeedsSetup(), tt.wantNeedsSetup)
+			}
+		})
 	}
 }
 
@@ -81,11 +135,15 @@ func TestRunPreFlightRejectsInvalidMediaServer(t *testing.T) {
 	preservePreFlightState(t)
 	config.Current.MediaServer = config.Config_MediaServer{Type: "unsupported"}
 	config.MediaServerValid = true
+	config.MediaServerReachable = true
 
 	if runPreFlight() {
 		t.Fatal("runPreFlight() = true, want false when media server is invalid")
 	}
 	if config.MediaServerValid {
 		t.Error("config.MediaServerValid = true, want false")
+	}
+	if config.MediaServerReachable {
+		t.Error("config.MediaServerReachable = true, want false")
 	}
 }

--- a/frontend/src/components/layout/app-navbar.tsx
+++ b/frontend/src/components/layout/app-navbar.tsx
@@ -13,6 +13,7 @@ import {
   Logs,
   MenuIcon,
   Sparkles,
+  TriangleAlert,
 } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
@@ -128,6 +129,11 @@ export function Navbar({ version = "dev" }: AppNavbarProps) {
     // Reset redirect lock once app is ready
     hasRedirectedToLoadingRef.current = false;
   }, [hasHydrated, status, isAppLoadingPage, router]);
+
+  // A dependency that is merely unreachable is a degraded runtime state, not a
+  // setup problem, so it gets an indicator rather than an onboarding redirect.
+  const unreachableDependency =
+    status?.media_server_reachable === false ? "Media server" : status?.mediux_reachable === false ? "MediUX" : null;
 
   // Onboarding Redirect Logic
   useEffect(() => {
@@ -261,6 +267,15 @@ export function Navbar({ version = "dev" }: AppNavbarProps) {
 
       {/* Right: Arrows and/or Settings */}
       <div className="flex items-center gap-2 flex-shrink-0">
+        {unreachableDependency && (
+          <span
+            role="status"
+            aria-label={`${unreachableDependency} is unreachable`}
+            title={`${unreachableDependency} is unreachable. aura is running with reduced functionality and will reconnect automatically.`}
+          >
+            <TriangleAlert className="h-6 w-6 text-yellow-500" />
+          </span>
+        )}
         {isMediaPage && (
           <>
             <ArrowLeftCircle

--- a/frontend/src/types/config/response-status.ts
+++ b/frontend/src/types/config/response-status.ts
@@ -4,6 +4,8 @@ export interface AppStatusResponse {
   config_loaded: boolean;
   config_valid: boolean;
   needs_setup: boolean;
+  media_server_reachable: boolean;
+  mediux_reachable: boolean;
   current_setup: AppConfig;
   media_server_name?: string;
   mediux_site_link?: string;


### PR DESCRIPTION
## Summary
- let failed MediUX validation fall through to existing media-server validity decision
- set `config.MediuxValid` from each validation result
- cover MediUX outage, valid token, and invalid media-server preflight paths

## Verification
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go test -run '^TestRunPreFlight' -count=1 .`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go test ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go vet ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build ./...`
- `gofmt -l .` (clean)

Closes #132
