### PR TITLE
docs: add contributor development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to AURA
+
+AURA can be built and tested without a MediUX token or media server. Running the
+complete application requires both services; see [External services](#external-services).
+
+## Prerequisites
+
+- Go 1.26.0 (from `backend/go.mod`)
+- A C compiler and `CGO_ENABLED=1` for the SQLite driver
+- Node.js 24.20.0 (from `.nvmrc`) and npm
+- Git
+
+## Install dependencies
+
+From a fresh clone:
+
+```sh
+git clone https://github.com/jabrown93/AURA.git aura
+cd aura
+
+cd backend
+go mod download
+cd ../frontend
+npm ci
+```
+
+Dependency installation may access public Go and npm registries. It does not
+need AURA credentials, a MediUX token, or a media server.
+
+## Build and test without external services
+
+Backend package initialization writes configuration and logs under `/config` by
+default. Set `CONFIG_PATH=<dir>` to a writable local directory for tests and
+local runs. AURA uses SQLite through `mattn/go-sqlite3`, so backend builds and
+tests require cgo and a working C compiler.
+
+```sh
+cd backend
+mkdir -p /tmp/aura-config
+CONFIG_PATH=/tmp/aura-config CGO_ENABLED=1 go test ./...
+CGO_ENABLED=1 go vet ./...
+CGO_ENABLED=1 go build ./...
+```
+
+Frontend has no test runner. Its focused checks are:
+
+```sh
+cd frontend
+npm run lint
+npm run typecheck
+npm run build
+```
+
+After dependencies are installed, these build, unit-test, and static-validation
+commands do not require MediUX or Plex, Emby, or Jellyfin access.
+
+## Run local development servers
+
+Start backend and frontend in separate terminals from repository root:
+
+```sh
+cd backend
+mkdir -p /tmp/aura-config
+CONFIG_PATH=/tmp/aura-config CGO_ENABLED=1 go run .
+```
+
+```sh
+cd frontend
+npm run dev
+```
+
+Frontend runs at `http://localhost:3000`, proxies `/api/*` to backend at
+`http://localhost:8888`, and can show onboarding while configuration is
+incomplete. This is not a full offline application: backend activates full
+routes only after preflight successfully connects to both configured external
+services.
+
+## External services
+
+Full onboarding, library browsing, artwork retrieval/application, and other
+integration flows require:
+
+- A reachable Plex, Emby, or Jellyfin server, its API token, and a real media
+  library.
+- A valid MediUX API token and network access to MediUX. Token access is
+  currently requested through the [AURA Discord](https://discord.gg/YAKzwKPwyw).
+
+No mocks or fixtures currently replace these services.
+
+## Before opening a pull request
+
+Run checks relevant to changed code. Use a
+[Conventional Commit](https://www.conventionalcommits.org/) message; repository
+hooks in `.githooks/` can be enabled with:
+
+```sh
+git config core.hooksPath .githooks
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,7 @@ From a fresh clone:
 
 ```sh
 git clone https://github.com/jabrown93/AURA.git aura
-cd aura
-
-cd backend
+cd aura/backend
 go mod download
 cd ../frontend
 npm ci
@@ -35,37 +33,51 @@ local runs. AURA uses SQLite through `mattn/go-sqlite3`, so backend builds and
 tests require cgo and a working C compiler.
 
 ```sh
-cd backend
-mkdir -p /tmp/aura-config
-CONFIG_PATH=/tmp/aura-config CGO_ENABLED=1 go test ./...
-CGO_ENABLED=1 go vet ./...
-CGO_ENABLED=1 go build ./...
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/backend"
+CONFIG_PATH=$(mktemp -d)
+export CONFIG_PATH CGO_ENABLED=1
+gofmt -l .
+go test ./...
+go vet ./...
+go build ./...
 ```
+
+`gofmt -l .` must print nothing. Format every file it lists before opening a
+pull request.
 
 Frontend has no test runner. Its focused checks are:
 
 ```sh
-cd frontend
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/frontend"
 npm run lint
 npm run typecheck
 npm run build
 ```
 
-After dependencies are installed, these build, unit-test, and static-validation
-commands do not require MediUX or Plex, Emby, or Jellyfin access.
+After dependencies are installed, contributors can validate these capabilities
+without MediUX or Plex, Emby, or Jellyfin access:
+
+- Backend formatting, compilation, vetting, and unit tests.
+- Frontend linting, type checking, and production builds.
+- Frontend onboarding UI through the local development servers below.
 
 ## Run local development servers
 
 Start backend and frontend in separate terminals from repository root:
 
 ```sh
-cd backend
-mkdir -p /tmp/aura-config
-CONFIG_PATH=/tmp/aura-config CGO_ENABLED=1 go run .
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/backend"
+CONFIG_PATH=$(mktemp -d)
+export CONFIG_PATH CGO_ENABLED=1
+go run .
 ```
 
 ```sh
-cd frontend
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/frontend"
 npm run dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ To get started with aura:
 
 > Visit the [Docs](https://mediux-team.github.io/AURA/) for detailed steps.
 
+Developing AURA? See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup,
+offline build/test commands, and external-service requirements.
+
 ---
 
 ## Join the Community

--- a/docs/config.md
+++ b/docs/config.md
@@ -187,7 +187,7 @@ Mediux:
 - **Description**: The API token for MediUX.
 - **Details**: This option specifies the API token required to access MediUX's API. This can be obtained by creating an account on [MediUX](https://mediux.io/) and generating an API token in your account settings.
 - **Note**: This is not yet available to the public, but will be in the future.
-  If you would like to test out aura, please contact us on [Discord](https://discord.gg/YAKzwKPwyw) to get access to the API token.
+  If you would like to test out aura, please contact us on [Discord](https://discord.gg/YAKzwKPwyw) to get access to the API token. Contributors can still use the [offline build and test workflow](../CONTRIBUTING.md#build-and-test-without-external-services) without this token.
 
 ### DownloadQuality
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -187,7 +187,7 @@ Mediux:
 - **Description**: The API token for MediUX.
 - **Details**: This option specifies the API token required to access MediUX's API. This can be obtained by creating an account on [MediUX](https://mediux.io/) and generating an API token in your account settings.
 - **Note**: This is not yet available to the public, but will be in the future.
-  If you would like to test out aura, please contact us on [Discord](https://discord.gg/YAKzwKPwyw) to get access to the API token. Contributors can still use the [offline build and test workflow](../CONTRIBUTING.md#build-and-test-without-external-services) without this token.
+  If you would like to test out aura, please contact us on [Discord](https://discord.gg/YAKzwKPwyw) to get access to the API token. Contributors can still use the [offline build and test workflow](https://github.com/jabrown93/AURA/blob/main/CONTRIBUTING.md#build-and-test-without-external-services) without this token.
 
 ### DownloadQuality
 


### PR DESCRIPTION
## Summary

- add public contributor setup for backend and frontend dependencies
- document external-service-free backend formatting, compilation, vetting, and unit tests
- document external-service-free frontend linting, type checking, production builds, and onboarding UI development
- explain `CONFIG_PATH`, cgo, local dev servers, and truthful full-app requirements for MediUX plus Plex/Emby/Jellyfin
- link contributor guide from README and the gated-token note in `docs/config.md`

## Review repairs

- make command blocks work sequentially by resolving repository root explicitly
- use a fresh `CONFIG_PATH=$(mktemp -d)` instead of a shared fixed `/tmp` path
- include CI-required `gofmt -l .` and explain that any listed files must be formatted

## Verification

- `gofmt -l .` (no output)
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go test ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go vet ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build ./...`
- `git diff --check`
- source checks against `.nvmrc`, `backend/go.mod`, `frontend/package.json`, command paths, and the new documentation link

Frontend dependencies are unavailable in the local worktree. Exact-head CI installs them and validates frontend lint/build without requiring external application services.

Closes #133
