### PR TITLE
fix(images): cache protected images safely

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -4742,6 +4742,9 @@ const docTemplate = `{
                 },
                 "tmdb_id": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -4734,6 +4734,9 @@
                 },
                 "tmdb_id": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -780,6 +780,8 @@ definitions:
         type: string
       tmdb_id:
         type: string
+      updated_at:
+        type: integer
     type: object
   models.CollectionQueueItem:
     properties:

--- a/backend/cache/mediaserver_collections.go
+++ b/backend/cache/mediaserver_collections.go
@@ -82,11 +82,28 @@ func (msc *MediaServerCollectionsCache) GetCollectionByRatingKey(ratingKey strin
 	for _, lib := range msc.collections {
 		for _, coll := range lib {
 			if coll.RatingKey == ratingKey {
-				return coll, true
+				copy := *coll
+				return &copy, true
 			}
 		}
 	}
 	return nil, false
+}
+
+// AdvanceCollectionUpdatedAt advances a cached collection image version atomically.
+func (msc *MediaServerCollectionsCache) AdvanceCollectionUpdatedAt(ratingKey string, now int64) (int64, bool) {
+	msc.mu.Lock()
+	defer msc.mu.Unlock()
+
+	for _, lib := range msc.collections {
+		for _, collection := range lib {
+			if collection.RatingKey == ratingKey {
+				collection.UpdatedAt = nextVersion(collection.UpdatedAt, now)
+				return collection.UpdatedAt, true
+			}
+		}
+	}
+	return 0, false
 }
 
 func (msc *MediaServerCollectionsCache) GetCollectionsByLibrary(libraryTitle string) []models.CollectionItem {
@@ -109,6 +126,11 @@ func (msc *MediaServerCollectionsCache) UpsertCollection(collection *models.Coll
 	if lib == nil {
 		lib = make(map[string]*models.CollectionItem)
 		msc.collections[collection.LibraryTitle] = lib
+	}
+	if existing := lib[collection.RatingKey]; existing != nil && collection.UpdatedAt < existing.UpdatedAt {
+		copy := *collection
+		copy.UpdatedAt = existing.UpdatedAt
+		collection = &copy
 	}
 	lib[collection.RatingKey] = collection
 }

--- a/backend/cache/mediaserver_collections.go
+++ b/backend/cache/mediaserver_collections.go
@@ -10,16 +10,22 @@ var CollectionsStore *MediaServerCollectionsCache
 
 type MediaServerCollectionsCache struct {
 	// libraryTitle -> index -> CollectionItem
-	collections    map[string]map[string]*models.CollectionItem
-	mu             sync.RWMutex
-	LastFullUpdate int64
+	collections     map[string]map[string]*models.CollectionItem
+	mu              sync.RWMutex
+	generationFloor int64
+	LastFullUpdate  int64
 }
 
 // NewCollectionsCache creates a new CollectionsCache instance
 func Cache_NewCollectionsCache() *MediaServerCollectionsCache {
+	return newCollectionsCache(processArtworkVersionFloor)
+}
+
+func newCollectionsCache(generationFloor int64) *MediaServerCollectionsCache {
 	return &MediaServerCollectionsCache{
-		collections:    make(map[string]map[string]*models.CollectionItem),
-		LastFullUpdate: 0,
+		collections:     make(map[string]map[string]*models.CollectionItem),
+		generationFloor: generationFloor,
+		LastFullUpdate:  0,
 	}
 }
 
@@ -127,10 +133,9 @@ func (msc *MediaServerCollectionsCache) UpsertCollection(collection *models.Coll
 		lib = make(map[string]*models.CollectionItem)
 		msc.collections[collection.LibraryTitle] = lib
 	}
+	collection.UpdatedAt = hydratedVersion(collection.UpdatedAt, msc.generationFloor)
 	if existing := lib[collection.RatingKey]; existing != nil && collection.UpdatedAt < existing.UpdatedAt {
-		copy := *collection
-		copy.UpdatedAt = existing.UpdatedAt
-		collection = &copy
+		collection.UpdatedAt = existing.UpdatedAt
 	}
 	lib[collection.RatingKey] = collection
 }

--- a/backend/cache/mediaserver_items.go
+++ b/backend/cache/mediaserver_items.go
@@ -55,7 +55,11 @@ func (c *MediaServerLibraryCache) UpdateSection(section *models.LibrarySection) 
 		var newItems []models.MediaItem
 		for _, newItem := range section.MediaItems {
 			if existingItem, found := existingItems[newItem.TMDB_ID]; found {
-				// Update existing item
+				// Locally advanced artwork versions must not regress when Plex still reports
+				// an unchanged parent updatedAt after season or episode artwork changes.
+				if newItem.UpdatedAt < existingItem.UpdatedAt {
+					newItem.UpdatedAt = existingItem.UpdatedAt
+				}
 				*existingItem = newItem
 			} else {
 				// Collect new item for appending
@@ -85,14 +89,34 @@ func (c *MediaServerLibraryCache) UpdateMediaItem(sectionTitle string, item *mod
 			existingItems[section.MediaItems[i].TMDB_ID] = &section.MediaItems[i]
 		}
 		if existingItem, found := existingItems[item.TMDB_ID]; found {
-			// Update existing item
-			*existingItem = *item
+			updated := *item
+			if updated.UpdatedAt < existingItem.UpdatedAt {
+				updated.UpdatedAt = existingItem.UpdatedAt
+			}
+			*existingItem = updated
 		} else {
 			// Append new item
 			section.MediaItems = append(section.MediaItems, *item)
 			section.TotalSize = len(section.MediaItems)
 		}
 	}
+}
+
+// AdvanceMediaItemUpdatedAt advances the cached parent image version atomically.
+// ratingKey is the parent key even when Plex applies artwork to a season or episode.
+func (c *MediaServerLibraryCache) AdvanceMediaItemUpdatedAt(ratingKey string, now int64) (int64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, section := range c.sections {
+		for i := range section.MediaItems {
+			if section.MediaItems[i].RatingKey == ratingKey {
+				section.MediaItems[i].UpdatedAt = nextVersion(section.MediaItems[i].UpdatedAt, now)
+				return section.MediaItems[i].UpdatedAt, true
+			}
+		}
+	}
+	return 0, false
 }
 
 func (c *MediaServerLibraryCache) UpdateMediaItemDBSavedSets(sectionTitle string, item *models.MediaItem, dbSavedSets []models.DBSavedSet) {

--- a/backend/cache/mediaserver_items.go
+++ b/backend/cache/mediaserver_items.go
@@ -12,16 +12,22 @@ import (
 var LibraryStore *MediaServerLibraryCache
 
 type MediaServerLibraryCache struct {
-	sections       map[string]*models.LibrarySection // Key: Library Title
-	mu             sync.RWMutex
-	LastFullUpdate int64
+	sections        map[string]*models.LibrarySection // Key: Library Title
+	mu              sync.RWMutex
+	generationFloor int64
+	LastFullUpdate  int64
 }
 
 // NewLibraryCache creates a new LibraryCache instance
 func Cache_NewLibraryCache() *MediaServerLibraryCache {
+	return newLibraryCache(processArtworkVersionFloor)
+}
+
+func newLibraryCache(generationFloor int64) *MediaServerLibraryCache {
 	return &MediaServerLibraryCache{
-		sections:       make(map[string]*models.LibrarySection),
-		LastFullUpdate: 0,
+		sections:        make(map[string]*models.LibrarySection),
+		generationFloor: generationFloor,
+		LastFullUpdate:  0,
 	}
 }
 
@@ -48,22 +54,24 @@ func (c *MediaServerLibraryCache) UpdateSection(section *models.LibrarySection) 
 		// Create a map of existing items for O(1) lookup
 		existingItems := make(map[string]*models.MediaItem)
 		for i := range existing.MediaItems {
-			existingItems[existing.MediaItems[i].TMDB_ID] = &existing.MediaItems[i]
+			existingItems[mediaItemVersionKey(&existing.MediaItems[i])] = &existing.MediaItems[i]
 		}
 
 		// Update existing items and collect new ones
 		var newItems []models.MediaItem
-		for _, newItem := range section.MediaItems {
-			if existingItem, found := existingItems[newItem.TMDB_ID]; found {
+		for i := range section.MediaItems {
+			newItem := &section.MediaItems[i]
+			newItem.UpdatedAt = hydratedVersion(newItem.UpdatedAt, c.generationFloor)
+			if existingItem, found := existingItems[mediaItemVersionKey(newItem)]; found {
 				// Locally advanced artwork versions must not regress when Plex still reports
 				// an unchanged parent updatedAt after season or episode artwork changes.
 				if newItem.UpdatedAt < existingItem.UpdatedAt {
 					newItem.UpdatedAt = existingItem.UpdatedAt
 				}
-				*existingItem = newItem
+				*existingItem = *newItem
 			} else {
 				// Collect new item for appending
-				newItems = append(newItems, newItem)
+				newItems = append(newItems, *newItem)
 			}
 		}
 
@@ -72,8 +80,18 @@ func (c *MediaServerLibraryCache) UpdateSection(section *models.LibrarySection) 
 		existing.TotalSize = len(existing.MediaItems)
 	} else {
 		// If section does not exist, add it to the cache
+		for i := range section.MediaItems {
+			section.MediaItems[i].UpdatedAt = hydratedVersion(section.MediaItems[i].UpdatedAt, c.generationFloor)
+		}
 		c.sections[section.Title] = section
 	}
+}
+
+func mediaItemVersionKey(item *models.MediaItem) string {
+	if item.RatingKey != "" {
+		return "rating_key:" + item.RatingKey
+	}
+	return "tmdb_id:" + item.TMDB_ID
 }
 
 // UpdateMediaItem updates a specific media item in a section
@@ -86,14 +104,14 @@ func (c *MediaServerLibraryCache) UpdateMediaItem(sectionTitle string, item *mod
 		// Create a map of existing items for O(1) lookup
 		existingItems := make(map[string]*models.MediaItem)
 		for i := range section.MediaItems {
-			existingItems[section.MediaItems[i].TMDB_ID] = &section.MediaItems[i]
+			existingItems[mediaItemVersionKey(&section.MediaItems[i])] = &section.MediaItems[i]
 		}
-		if existingItem, found := existingItems[item.TMDB_ID]; found {
-			updated := *item
-			if updated.UpdatedAt < existingItem.UpdatedAt {
-				updated.UpdatedAt = existingItem.UpdatedAt
+		item.UpdatedAt = hydratedVersion(item.UpdatedAt, c.generationFloor)
+		if existingItem, found := existingItems[mediaItemVersionKey(item)]; found {
+			if item.UpdatedAt < existingItem.UpdatedAt {
+				item.UpdatedAt = existingItem.UpdatedAt
 			}
-			*existingItem = updated
+			*existingItem = *item
 		} else {
 			// Append new item
 			section.MediaItems = append(section.MediaItems, *item)

--- a/backend/cache/version.go
+++ b/backend/cache/version.go
@@ -1,0 +1,8 @@
+package cache
+
+func nextVersion(current, now int64) int64 {
+	if current >= now {
+		return current + 1
+	}
+	return now
+}

--- a/backend/cache/version.go
+++ b/backend/cache/version.go
@@ -1,5 +1,18 @@
 package cache
 
+import "time"
+
+// processArtworkVersionFloor invalidates browser and Plex transcode keys after restart.
+// Unix microseconds remain exact in JavaScript numbers and stay stable for this process.
+var processArtworkVersionFloor = time.Now().UnixMicro()
+
+func hydratedVersion(reported, generationFloor int64) int64 {
+	if reported < generationFloor {
+		return generationFloor
+	}
+	return reported
+}
+
 func nextVersion(current, now int64) int64 {
 	if current >= now {
 		return current + 1

--- a/backend/cache/version_test.go
+++ b/backend/cache/version_test.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"aura/models"
+	"sync"
+	"testing"
+)
+
+func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
+	library := Cache_NewLibraryCache()
+	library.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
+		MediaItems:         []models.MediaItem{{RatingKey: "show-1", UpdatedAt: 100}},
+	})
+	collections := Cache_NewCollectionsCache()
+	collections.UpsertCollection(&models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", UpdatedAt: 100})
+
+	if got, ok := library.AdvanceMediaItemUpdatedAt("show-1", 100); !ok || got != 101 {
+		t.Fatalf("media version = %d, found = %v; want 101, true", got, ok)
+	}
+	if got, ok := library.AdvanceMediaItemUpdatedAt("show-1", 100); !ok || got != 102 {
+		t.Fatalf("same-second media version = %d, found = %v; want 102, true", got, ok)
+	}
+	if got, ok := collections.AdvanceCollectionUpdatedAt("collection-1", 100); !ok || got != 101 {
+		t.Fatalf("collection version = %d, found = %v; want 101, true", got, ok)
+	}
+
+	library.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
+		MediaItems:         []models.MediaItem{{RatingKey: "show-1", UpdatedAt: 100}},
+	})
+	collections.UpsertCollection(&models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", UpdatedAt: 100})
+	if item, _ := library.GetMediaItemByRatingKey("show-1"); item.UpdatedAt != 102 {
+		t.Fatalf("library refresh regressed version to %d", item.UpdatedAt)
+	}
+	if collection, _ := collections.GetCollectionByRatingKey("collection-1"); collection.UpdatedAt != 101 {
+		t.Fatalf("collection refresh regressed version to %d", collection.UpdatedAt)
+	}
+}
+
+func TestConcurrentArtworkVersionAdvance(t *testing.T) {
+	const applies = 32
+	library := Cache_NewLibraryCache()
+	library.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{{RatingKey: "movie-1", UpdatedAt: 100}},
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(applies)
+	for range applies {
+		go func() {
+			defer wg.Done()
+			library.AdvanceMediaItemUpdatedAt("movie-1", 100)
+		}()
+	}
+	wg.Wait()
+
+	item, ok := library.GetMediaItemByRatingKey("movie-1")
+	if !ok {
+		t.Fatal("movie-1 missing from cache")
+	}
+	if item.UpdatedAt != 100+applies {
+		t.Fatalf("media version = %d, want %d", item.UpdatedAt, 100+applies)
+	}
+}

--- a/backend/cache/version_test.go
+++ b/backend/cache/version_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
-	library := Cache_NewLibraryCache()
+	library := newLibraryCache(0)
 	library.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
 		MediaItems:         []models.MediaItem{{RatingKey: "show-1", UpdatedAt: 100}},
 	})
-	collections := Cache_NewCollectionsCache()
+	collections := newCollectionsCache(0)
 	collections.UpsertCollection(&models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", UpdatedAt: 100})
 
 	if got, ok := library.AdvanceMediaItemUpdatedAt("show-1", 100); !ok || got != 101 {
@@ -40,7 +40,7 @@ func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
 
 func TestConcurrentArtworkVersionAdvance(t *testing.T) {
 	const applies = 32
-	library := Cache_NewLibraryCache()
+	library := newLibraryCache(0)
 	library.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
 		MediaItems:         []models.MediaItem{{RatingKey: "movie-1", UpdatedAt: 100}},
@@ -62,5 +62,102 @@ func TestConcurrentArtworkVersionAdvance(t *testing.T) {
 	}
 	if item.UpdatedAt != 100+applies {
 		t.Fatalf("media version = %d, want %d", item.UpdatedAt, 100+applies)
+	}
+}
+
+func TestHydrationWritesMonotonicVersionsBackToResults(t *testing.T) {
+	library := newLibraryCache(500)
+	library.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems: []models.MediaItem{
+			{RatingKey: "section-item", UpdatedAt: 600},
+			{RatingKey: "detail-item", UpdatedAt: 600},
+		},
+	})
+	library.AdvanceMediaItemUpdatedAt("section-item", 700)
+	library.AdvanceMediaItemUpdatedAt("detail-item", 700)
+
+	browseResult := &models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{{RatingKey: "section-item", UpdatedAt: 100}},
+	}
+	library.UpdateSection(browseResult)
+	if got := browseResult.MediaItems[0].UpdatedAt; got != 700 {
+		t.Fatalf("browse result version = %d, want advanced cache version 700", got)
+	}
+
+	detailResult := &models.MediaItem{RatingKey: "detail-item", UpdatedAt: 100}
+	library.UpdateMediaItem("Movies", detailResult)
+	if detailResult.UpdatedAt != 700 {
+		t.Fatalf("detail result version = %d, want advanced cache version 700", detailResult.UpdatedAt)
+	}
+
+	collections := newCollectionsCache(500)
+	collection := &models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: 600}
+	collections.UpsertCollection(collection)
+	collections.AdvanceCollectionUpdatedAt(collection.RatingKey, 700)
+	collectionResult := &models.CollectionItem{RatingKey: collection.RatingKey, LibraryTitle: "Movies", UpdatedAt: 100}
+	collections.UpsertCollection(collectionResult)
+	if collectionResult.UpdatedAt != 700 {
+		t.Fatalf("collection result version = %d, want advanced cache version 700", collectionResult.UpdatedAt)
+	}
+}
+
+func TestHydrationUsesStableProcessGenerationAndChangesAfterRestart(t *testing.T) {
+	firstProcess := newLibraryCache(1000)
+	firstResult := &models.MediaItem{RatingKey: "movie-1", UpdatedAt: 100}
+	firstProcess.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{*firstResult},
+	})
+	firstProcess.UpdateMediaItem("Movies", firstResult)
+	if firstResult.UpdatedAt != 1000 {
+		t.Fatalf("first process version = %d, want generation floor 1000", firstResult.UpdatedAt)
+	}
+
+	repeatedResult := &models.MediaItem{RatingKey: "movie-1", UpdatedAt: 100}
+	firstProcess.UpdateMediaItem("Movies", repeatedResult)
+	if repeatedResult.UpdatedAt != firstResult.UpdatedAt {
+		t.Fatalf("same-process versions differ: %d and %d", firstResult.UpdatedAt, repeatedResult.UpdatedAt)
+	}
+
+	restartedProcess := newLibraryCache(1001)
+	restartedSection := &models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{{RatingKey: "movie-1", UpdatedAt: 100}},
+	}
+	restartedProcess.UpdateSection(restartedSection)
+	if got := restartedSection.MediaItems[0].UpdatedAt; got != 1001 {
+		t.Fatalf("restarted process version = %d, want new generation floor 1001", got)
+	}
+
+	if Cache_NewLibraryCache().generationFloor != processArtworkVersionFloor || Cache_NewCollectionsCache().generationFloor != processArtworkVersionFloor {
+		t.Fatal("public caches do not share stable process generation floor")
+	}
+}
+
+func TestVersionOwnershipUsesRatingKeyWhenTMDBIDIsEmpty(t *testing.T) {
+	library := newLibraryCache(0)
+	library.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
+		MediaItems: []models.MediaItem{
+			{RatingKey: "show-1", Title: "One", UpdatedAt: 100},
+			{RatingKey: "show-2", Title: "Two", UpdatedAt: 200},
+		},
+	})
+
+	browseResult := &models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
+		MediaItems:         []models.MediaItem{{RatingKey: "show-1", Title: "One refreshed", UpdatedAt: 101}},
+	}
+	library.UpdateSection(browseResult)
+
+	one, _ := library.GetMediaItemByRatingKey("show-1")
+	two, _ := library.GetMediaItemByRatingKey("show-2")
+	if one.Title != "One refreshed" || one.UpdatedAt != 101 {
+		t.Fatalf("show-1 = %+v, want independently refreshed item", one)
+	}
+	if two.Title != "Two" || two.UpdatedAt != 200 {
+		t.Fatalf("show-2 disturbed by empty TMDB ID collision: %+v", two)
 	}
 }

--- a/backend/mediaserver/artwork_version_test.go
+++ b/backend/mediaserver/artwork_version_test.go
@@ -1,0 +1,142 @@
+package mediaserver
+
+import (
+	"aura/cache"
+	"aura/config"
+	"aura/logging"
+	"aura/mediux"
+	"aura/models"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cleanupArtworkVersionTest(t, server.URL)
+	baseVersion := time.Now().Unix() + 1000
+	seasonNumber, episodeNumber := 1, 2
+	item := models.MediaItem{
+		RatingKey: "show-1", Type: "show", Title: "Show", LibraryTitle: "TV", UpdatedAt: baseVersion,
+		Series: &models.MediaItemSeries{Seasons: []models.MediaItemSeason{{
+			RatingKey: "season-1", SeasonNumber: seasonNumber,
+			Episodes: []models.MediaItemEpisode{{RatingKey: "episode-2", SeasonNumber: seasonNumber, EpisodeNumber: episodeNumber}},
+		}}},
+	}
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
+		MediaItems:         []models.MediaItem{item},
+	})
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", Title: "Collection", UpdatedAt: baseVersion}
+	cache.CollectionsStore.UpsertCollection(&collection)
+
+	images := []models.ImageFile{
+		{ID: "poster", Type: "poster", Modified: time.Unix(1, 0)},
+		{ID: "season", Type: "season_poster", Modified: time.Unix(1, 0), SeasonNumber: &seasonNumber},
+		{ID: "episode", Type: "titlecard", Modified: time.Unix(1, 0), SeasonNumber: &seasonNumber, EpisodeNumber: &episodeNumber},
+	}
+	for i, image := range images {
+		if err := DownloadApplyImageToMediaItem(testLogContext(), &item, image); err.Message != "" {
+			t.Fatalf("apply %s failed: %s", image.Type, err.Message)
+		}
+		cached, ok := cache.LibraryStore.GetMediaItemByRatingKey(item.RatingKey)
+		if !ok || cached.UpdatedAt != baseVersion+int64(i)+1 {
+			t.Fatalf("after %s parent version = %d, found = %v; want %d", image.Type, cached.UpdatedAt, ok, baseVersion+int64(i)+1)
+		}
+	}
+
+	collectionImage := models.ImageFile{ID: "collection", Type: "collection_poster", Modified: time.Unix(1, 0)}
+	if err := ApplyCollectionImage(testLogContext(), &collection, collectionImage); err.Message != "" {
+		t.Fatalf("collection apply failed: %s", err.Message)
+	}
+	cachedCollection, ok := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey)
+	if !ok || cachedCollection.UpdatedAt != baseVersion+1 {
+		t.Fatalf("collection version = %d, found = %v; want %d", cachedCollection.UpdatedAt, ok, baseVersion+1)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantPaths := []string{
+		"/library/metadata/show-1/posters",
+		"/library/metadata/season-1/posters",
+		"/library/metadata/episode-2/posters",
+		"/library/metadata/collection-1/posters",
+	}
+	if len(paths) != len(wantPaths) {
+		t.Fatalf("Plex request paths = %v, want %v", paths, wantPaths)
+	}
+	for i := range wantPaths {
+		if paths[i] != wantPaths[i] {
+			t.Errorf("Plex request path %d = %q, want %q", i, paths[i], wantPaths[i])
+		}
+	}
+}
+
+func TestFailedArtworkAppliesDoNotAdvanceVersions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "apply failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cleanupArtworkVersionTest(t, server.URL)
+	const version = int64(100)
+	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: version}
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{item},
+	})
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: version}
+	cache.CollectionsStore.UpsertCollection(&collection)
+	image := models.ImageFile{ID: "image", Type: "poster", Modified: time.Unix(1, 0)}
+
+	if err := DownloadApplyImageToMediaItem(testLogContext(), &item, image); err.Message == "" {
+		t.Fatal("media apply unexpectedly succeeded")
+	}
+	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(item.RatingKey); cached.UpdatedAt != version {
+		t.Fatalf("failed media apply advanced version to %d", cached.UpdatedAt)
+	}
+	image.Type = "collection_poster"
+	if err := ApplyCollectionImage(testLogContext(), &collection, image); err.Message == "" {
+		t.Fatal("collection apply unexpectedly succeeded")
+	}
+	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != version {
+		t.Fatalf("failed collection apply advanced version to %d", cached.UpdatedAt)
+	}
+}
+
+func cleanupArtworkVersionTest(t *testing.T, serverURL string) {
+	t.Helper()
+	previousConfig := config.Current
+	previousLibraryStore := cache.LibraryStore
+	previousCollectionsStore := cache.CollectionsStore
+	previousMediuxURL := mediux.MediuxApiURL
+	t.Cleanup(func() {
+		config.Current = previousConfig
+		cache.LibraryStore = previousLibraryStore
+		cache.CollectionsStore = previousCollectionsStore
+		mediux.MediuxApiURL = previousMediuxURL
+	})
+
+	config.Current = config.Config{}
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: serverURL, ApiToken: "token"}
+	mediux.MediuxApiURL = serverURL
+	cache.LibraryStore = cache.Cache_NewLibraryCache()
+	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
+}
+
+func testLogContext() context.Context {
+	ctx, ld := logging.CreateLoggingContext(context.Background(), "artwork version test")
+	return logging.WithCurrentAction(ctx, ld.AddAction("apply", logging.LevelDebug))
+}

--- a/backend/mediaserver/artwork_version_test.go
+++ b/backend/mediaserver/artwork_version_test.go
@@ -26,7 +26,7 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 	defer server.Close()
 
 	cleanupArtworkVersionTest(t, server.URL)
-	baseVersion := time.Now().Unix() + 1000
+	baseVersion := time.Now().UnixMicro() + 1000
 	seasonNumber, episodeNumber := 1, 2
 	item := models.MediaItem{
 		RatingKey: "show-1", Type: "show", Title: "Show", LibraryTitle: "TV", UpdatedAt: baseVersion,
@@ -55,6 +55,9 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 		if !ok || cached.UpdatedAt != baseVersion+int64(i)+1 {
 			t.Fatalf("after %s parent version = %d, found = %v; want %d", image.Type, cached.UpdatedAt, ok, baseVersion+int64(i)+1)
 		}
+		if item.UpdatedAt != cached.UpdatedAt {
+			t.Fatalf("after %s mutation result version = %d, want cached version %d", image.Type, item.UpdatedAt, cached.UpdatedAt)
+		}
 	}
 
 	collectionImage := models.ImageFile{ID: "collection", Type: "collection_poster", Modified: time.Unix(1, 0)}
@@ -64,6 +67,9 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 	cachedCollection, ok := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey)
 	if !ok || cachedCollection.UpdatedAt != baseVersion+1 {
 		t.Fatalf("collection version = %d, found = %v; want %d", cachedCollection.UpdatedAt, ok, baseVersion+1)
+	}
+	if collection.UpdatedAt != cachedCollection.UpdatedAt {
+		t.Fatalf("collection mutation result version = %d, want cached version %d", collection.UpdatedAt, cachedCollection.UpdatedAt)
 	}
 
 	mu.Lock()
@@ -91,7 +97,7 @@ func TestFailedArtworkAppliesDoNotAdvanceVersions(t *testing.T) {
 	defer server.Close()
 
 	cleanupArtworkVersionTest(t, server.URL)
-	const version = int64(100)
+	version := time.Now().UnixMicro() + 1000
 	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: version}
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},

--- a/backend/mediaserver/ej/get_media_item_details.go
+++ b/backend/mediaserver/ej/get_media_item_details.go
@@ -71,7 +71,7 @@ func (e *EJ) GetMediaItemDetails(ctx context.Context, item *models.MediaItem) (f
 	item.Title = ejResp.Name
 	item.Year = ejResp.ProductionYear
 	item.ContentRating = ejResp.OfficialRating
-	item.UpdatedAt = ejResp.DateCreated.UnixMilli()
+	item.UpdatedAt = ejResp.DateCreated.UnixMicro()
 	item.ReleasedAt = ejResp.PremiereDate.UnixMilli()
 	item.Summary = ejResp.Overview
 	if ejResp.ProviderIds.Imdb != "" {

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -239,7 +239,9 @@ func DownloadApplyImageToMediaItem(ctx context.Context, item *models.MediaItem, 
 		return Err
 	}
 	if Err = msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile); Err.Message == "" {
-		cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().Unix())
+		if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().Unix()); ok {
+			item.UpdatedAt = version
+		}
 	}
 	return Err
 }
@@ -258,7 +260,9 @@ func ApplyCollectionImage(ctx context.Context, collectionItem *models.Collection
 		return Err
 	}
 	if Err = msClient.ApplyCollectionImage(ctx, collectionItem, imageFile); Err.Message == "" {
-		cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().Unix())
+		if version, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().Unix()); ok {
+			collectionItem.UpdatedAt = version
+		}
 	}
 	return Err
 }

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -1,6 +1,7 @@
 package mediaserver
 
 import (
+	"aura/cache"
 	"aura/config"
 	"aura/logging"
 	"aura/mediaserver/ej"
@@ -9,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // IsItemNotFound reports whether a media-server lookup error means the item is genuinely absent
@@ -236,7 +238,10 @@ func DownloadApplyImageToMediaItem(ctx context.Context, item *models.MediaItem, 
 	if Err.Message != "" {
 		return Err
 	}
-	return msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile)
+	if Err = msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile); Err.Message == "" {
+		cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().Unix())
+	}
+	return Err
 }
 
 func SaveImageAsKometaAssetOnly(ctx context.Context, item *models.MediaItem, imageFile models.ImageFile) (Err logging.LogErrorInfo) {
@@ -252,5 +257,8 @@ func ApplyCollectionImage(ctx context.Context, collectionItem *models.Collection
 	if Err.Message != "" {
 		return Err
 	}
-	return msClient.ApplyCollectionImage(ctx, collectionItem, imageFile)
+	if Err = msClient.ApplyCollectionImage(ctx, collectionItem, imageFile); Err.Message == "" {
+		cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().Unix())
+	}
+	return Err
 }

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -239,7 +239,7 @@ func DownloadApplyImageToMediaItem(ctx context.Context, item *models.MediaItem, 
 		return Err
 	}
 	if Err = msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile); Err.Message == "" {
-		if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().Unix()); ok {
+		if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().UnixMicro()); ok {
 			item.UpdatedAt = version
 		}
 	}
@@ -260,7 +260,7 @@ func ApplyCollectionImage(ctx context.Context, collectionItem *models.Collection
 		return Err
 	}
 	if Err = msClient.ApplyCollectionImage(ctx, collectionItem, imageFile); Err.Message == "" {
-		if version, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().Unix()); ok {
+		if version, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().UnixMicro()); ok {
 			collectionItem.UpdatedAt = version
 		}
 	}

--- a/backend/mediaserver/plex/artwork_version_test.go
+++ b/backend/mediaserver/plex/artwork_version_test.go
@@ -1,0 +1,27 @@
+package plex
+
+import (
+	"testing"
+	"time"
+)
+
+// Guards the unit contract: Plex reports updatedAt in Unix seconds, but artwork
+// versions are compared against a microsecond generation floor. Returning the raw
+// seconds value puts it ~6 orders of magnitude below the floor, where it clamps and
+// a poster changed directly in Plex never busts the browser cache.
+func TestArtworkVersionConvertsPlexSecondsToMicroseconds(t *testing.T) {
+	changed := time.Date(2026, 8, 31, 13, 0, 0, 0, time.UTC)
+
+	if got, want := artworkVersion(changed.Unix()), changed.UnixMicro(); got != want {
+		t.Fatalf("artworkVersion(%d) = %d, want %d", changed.Unix(), got, want)
+	}
+	if got := artworkVersion(0); got != 0 {
+		t.Fatalf("artworkVersion(0) = %d, want 0 so the cache applies its floor", got)
+	}
+
+	processStart := changed.Add(-time.Hour).UnixMicro()
+	if artworkVersion(changed.Unix()) <= processStart {
+		t.Fatalf("converted version %d must exceed a floor of %d to bust caches",
+			artworkVersion(changed.Unix()), processStart)
+	}
+}

--- a/backend/mediaserver/plex/get_library_section_items.go
+++ b/backend/mediaserver/plex/get_library_section_items.go
@@ -68,7 +68,7 @@ func (p *Plex) GetLibrarySectionItems(ctx context.Context, section models.Librar
 		item.Title = metadata.Title
 		item.Year = metadata.Year
 		item.LibraryTitle = plexResp.MediaContainer.LibrarySectionTitle
-		item.UpdatedAt = metadata.UpdatedAt
+		item.UpdatedAt = artworkVersion(metadata.UpdatedAt)
 		item.AddedAt = metadata.AddedAt
 		item.ContentRating = metadata.ContentRating
 		item.Summary = metadata.Summary

--- a/backend/mediaserver/plex/get_media_item_details.go
+++ b/backend/mediaserver/plex/get_media_item_details.go
@@ -123,7 +123,7 @@ func extractMediaItemFromResponse(ctx context.Context, metadata PlexLibraryItems
 	item.Title = metadata.Title
 	item.Year = metadata.Year
 	item.LibraryTitle = metadata.LibrarySectionTitle
-	item.UpdatedAt = metadata.UpdatedAt
+	item.UpdatedAt = artworkVersion(metadata.UpdatedAt)
 	item.AddedAt = metadata.AddedAt
 	item.ContentRating = metadata.ContentRating
 	item.Summary = metadata.Summary

--- a/backend/mediaserver/plex/get_media_item_image.go
+++ b/backend/mediaserver/plex/get_media_item_image.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"time"
 )
 
 func (p *Plex) GetMediaItemImage(ctx context.Context, item *models.MediaItem, imageRatingKey string, imageType string) (imageData []byte, Err logging.LogErrorInfo) {
@@ -64,7 +63,7 @@ func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string) (
 	}
 
 	// Construct the URL for the Plex Image request
-	photoPath := path.Join("/library/metadata", ratingKey, imageType, fmt.Sprintf("%d", time.Now().Unix()))
+	photoPath := path.Join("/library/metadata", ratingKey, imageType)
 	encodedPhotoPath := url.QueryEscape(photoPath)
 	u, err := url.Parse(config.Current.MediaServer.URL)
 	if err != nil {

--- a/backend/mediaserver/plex/get_media_item_image.go
+++ b/backend/mediaserver/plex/get_media_item_image.go
@@ -21,7 +21,7 @@ func (p *Plex) GetMediaItemImage(ctx context.Context, item *models.MediaItem, im
 	imageData = []byte{}
 	Err = logging.LogErrorInfo{}
 
-	respBody, Err := GetImageFromPlex(ctx, imageRatingKey, imageType)
+	respBody, Err := GetImageFromPlex(ctx, imageRatingKey, imageType, item.UpdatedAt)
 	if Err.Message != "" {
 		return imageData, Err
 	}
@@ -40,7 +40,7 @@ func (p *Plex) GetCollectionItemImage(ctx context.Context, collection *models.Co
 	imageData = []byte{}
 	Err = logging.LogErrorInfo{}
 
-	respBody, Err := GetImageFromPlex(ctx, collection.RatingKey, imageType)
+	respBody, Err := GetImageFromPlex(ctx, collection.RatingKey, imageType, collection.UpdatedAt)
 	if Err.Message != "" {
 		return imageData, Err
 	}
@@ -49,7 +49,7 @@ func (p *Plex) GetCollectionItemImage(ctx context.Context, collection *models.Co
 	return imageData, Err
 }
 
-func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string) (imageData []byte, Err logging.LogErrorInfo) {
+func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string, updatedAt int64) (imageData []byte, Err logging.LogErrorInfo) {
 	width := "600"
 	height := "900"
 	switch imageType {
@@ -63,7 +63,7 @@ func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string) (
 	}
 
 	// Construct the URL for the Plex Image request
-	photoPath := path.Join("/library/metadata", ratingKey, imageType)
+	photoPath := path.Join("/library/metadata", ratingKey, imageType, fmt.Sprintf("%d", updatedAt))
 	encodedPhotoPath := url.QueryEscape(photoPath)
 	u, err := url.Parse(config.Current.MediaServer.URL)
 	if err != nil {

--- a/backend/mediaserver/plex/get_media_item_image_test.go
+++ b/backend/mediaserver/plex/get_media_item_image_test.go
@@ -1,0 +1,54 @@
+package plex
+
+import (
+	"aura/config"
+	"aura/logging"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetImageFromPlexUsesStableSourcePath(t *testing.T) {
+	requests := make(chan *http.Request, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Clone(r.Context())
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("image"))
+	}))
+	defer server.Close()
+
+	previous := config.Current.MediaServer
+	config.Current.MediaServer = config.Config_MediaServer{
+		Type:     "Plex",
+		URL:      server.URL,
+		ApiToken: "plex-secret",
+	}
+	t.Cleanup(func() { config.Current.MediaServer = previous })
+
+	ctx, ld := logging.CreateLoggingContext(context.Background(), "test")
+	ctx = logging.WithCurrentAction(ctx, ld.AddAction("test", logging.LevelTrace))
+
+	for range 2 {
+		image, errInfo := GetImageFromPlex(ctx, "123", "poster")
+		if errInfo.Message != "" {
+			t.Fatalf("GetImageFromPlex() error = %q", errInfo.Message)
+		}
+		if string(image) != "image" {
+			t.Fatalf("GetImageFromPlex() image = %q, want %q", image, "image")
+		}
+	}
+
+	for range 2 {
+		request := <-requests
+		if got := request.URL.Query().Get("url"); got != "/library/metadata/123/poster" {
+			t.Errorf("Plex source path = %q, want stable path %q", got, "/library/metadata/123/poster")
+		}
+		if got := request.Header.Get("X-Plex-Token"); got != "plex-secret" {
+			t.Errorf("X-Plex-Token = %q, want token sent in header", got)
+		}
+		if request.URL.Query().Has("X-Plex-Token") {
+			t.Error("Plex token must not appear in transcode URL")
+		}
+	}
+}

--- a/backend/mediaserver/plex/get_media_item_image_test.go
+++ b/backend/mediaserver/plex/get_media_item_image_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 )
 
-func TestGetImageFromPlexUsesStableSourcePath(t *testing.T) {
-	requests := make(chan *http.Request, 2)
+func TestGetImageFromPlexVersionsSourcePathWithArtworkState(t *testing.T) {
+	requests := make(chan *http.Request, 3)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests <- r.Clone(r.Context())
 		w.Header().Set("Content-Type", "image/jpeg")
@@ -29,8 +29,8 @@ func TestGetImageFromPlexUsesStableSourcePath(t *testing.T) {
 	ctx, ld := logging.CreateLoggingContext(context.Background(), "test")
 	ctx = logging.WithCurrentAction(ctx, ld.AddAction("test", logging.LevelTrace))
 
-	for range 2 {
-		image, errInfo := GetImageFromPlex(ctx, "123", "poster")
+	for _, updatedAt := range []int64{1700000000, 1700000000, 1700000001} {
+		image, errInfo := GetImageFromPlex(ctx, "123", "poster", updatedAt)
 		if errInfo.Message != "" {
 			t.Fatalf("GetImageFromPlex() error = %q", errInfo.Message)
 		}
@@ -39,10 +39,15 @@ func TestGetImageFromPlexUsesStableSourcePath(t *testing.T) {
 		}
 	}
 
-	for range 2 {
+	wantPaths := []string{
+		"/library/metadata/123/poster/1700000000",
+		"/library/metadata/123/poster/1700000000",
+		"/library/metadata/123/poster/1700000001",
+	}
+	for _, wantPath := range wantPaths {
 		request := <-requests
-		if got := request.URL.Query().Get("url"); got != "/library/metadata/123/poster" {
-			t.Errorf("Plex source path = %q, want stable path %q", got, "/library/metadata/123/poster")
+		if got := request.URL.Query().Get("url"); got != wantPath {
+			t.Errorf("Plex source path = %q, want %q", got, wantPath)
 		}
 		if got := request.Header.Get("X-Plex-Token"); got != "plex-secret" {
 			t.Errorf("X-Plex-Token = %q, want token sent in header", got)

--- a/backend/mediaserver/plex/get_movie_collections.go
+++ b/backend/mediaserver/plex/get_movie_collections.go
@@ -63,7 +63,7 @@ func (p *Plex) GetMovieCollections(ctx context.Context, library models.LibrarySe
 		collectionItem.Summary = collection.Summary
 		collectionItem.ChildCount = collection.ChildCount
 		collectionItem.LibraryTitle = library.Title
-		collectionItem.UpdatedAt = collection.UpdatedAt
+		collectionItem.UpdatedAt = artworkVersion(collection.UpdatedAt)
 
 		// Update the collections cache
 		cache.CollectionsStore.UpsertCollection(&collectionItem)

--- a/backend/mediaserver/plex/get_movie_collections.go
+++ b/backend/mediaserver/plex/get_movie_collections.go
@@ -63,6 +63,7 @@ func (p *Plex) GetMovieCollections(ctx context.Context, library models.LibrarySe
 		collectionItem.Summary = collection.Summary
 		collectionItem.ChildCount = collection.ChildCount
 		collectionItem.LibraryTitle = library.Title
+		collectionItem.UpdatedAt = collection.UpdatedAt
 
 		// Update the collections cache
 		cache.CollectionsStore.UpsertCollection(&collectionItem)

--- a/backend/mediaserver/plex/plex.go
+++ b/backend/mediaserver/plex/plex.go
@@ -1,5 +1,7 @@
 package plex
 
+import "time"
+
 type PlexConnectionInfoWrapper struct {
 	MediaContainer PlexConnectionInfo `json:"MediaContainer"`
 }
@@ -241,4 +243,15 @@ type PlexServerConnections struct {
 	Local    bool   `json:"local"`
 	Relay    bool   `json:"relay"`
 	IPv6     bool   `json:"ipv6"`
+}
+
+// artworkVersion converts a Plex updatedAt, reported in Unix seconds, into the
+// microsecond unit the artwork cache versions with. Without this the value sits
+// ~6 orders of magnitude below the generation floor, clamps to it, and a poster
+// changed directly in Plex never busts the browser cache.
+func artworkVersion(updatedAtSeconds int64) int64 {
+	if updatedAtSeconds == 0 {
+		return 0
+	}
+	return time.Unix(updatedAtSeconds, 0).UnixMicro()
 }

--- a/backend/models/media_item.go
+++ b/backend/models/media_item.go
@@ -93,5 +93,5 @@ type CollectionItem struct {
 	ChildCount   int         `json:"child_count"`
 	MediaItems   []MediaItem `json:"media_items"`
 	LibraryTitle string      `json:"library_title,omitempty"`
-	UpdatedAt    int64       `json:"-" swaggerignore:"true"`
+	UpdatedAt    int64       `json:"updated_at"`
 }

--- a/backend/models/media_item.go
+++ b/backend/models/media_item.go
@@ -93,4 +93,5 @@ type CollectionItem struct {
 	ChildCount   int         `json:"child_count"`
 	MediaItems   []MediaItem `json:"media_items"`
 	LibraryTitle string      `json:"library_title,omitempty"`
+	UpdatedAt    int64       `json:"-" swaggerignore:"true"`
 }

--- a/backend/routing/images/cache_test.go
+++ b/backend/routing/images/cache_test.go
@@ -1,0 +1,96 @@
+package routes_images
+
+import (
+	"aura/cache"
+	"aura/config"
+	"aura/mediux"
+	"aura/models"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const expectedImageCacheControl = "private, max-age=86400"
+
+func TestSuccessfulImageResponsesAreBrowserCacheable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("image"))
+	}))
+	defer server.Close()
+
+	previousConfig := config.Current
+	previousLibraryStore := cache.LibraryStore
+	previousCollectionsStore := cache.CollectionsStore
+	previousMediuxURL := mediux.MediuxApiURL
+	t.Cleanup(func() {
+		config.Current = previousConfig
+		cache.LibraryStore = previousLibraryStore
+		cache.CollectionsStore = previousCollectionsStore
+		mediux.MediuxApiURL = previousMediuxURL
+	})
+
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-secret"}
+	config.Current.Mediux.ApiToken = "mediux-secret"
+	config.Current.Images.CacheImages.Enabled = false
+	mediux.MediuxApiURL = server.URL
+
+	cache.LibraryStore = cache.Cache_NewLibraryCache()
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie"}},
+	})
+	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
+	cache.CollectionsStore.UpsertCollection(&models.CollectionItem{
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection",
+	})
+
+	tests := []struct {
+		name    string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{"media item", "/api/images/media/item?rating_key=media-1&image_type=poster", GetMediaItemImage},
+		{"collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster", GetCollectionItemImage},
+		{"MediUX image", "/api/images/mediux/item?asset_id=asset-1&modified_date=2024-01-01T12:00:00Z", GetMediuxImage},
+		{"MediUX avatar", "/api/images/mediux/avatar?avatar_id=avatar-1", GetMediuxAvatarImage},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			test.handler(response, httptest.NewRequest(http.MethodGet, test.target, nil))
+
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %q", response.Code, http.StatusOK, response.Body.String())
+			}
+			if got := response.Header().Get("Cache-Control"); got != expectedImageCacheControl {
+				t.Errorf("Cache-Control = %q, want %q", got, expectedImageCacheControl)
+			}
+		})
+	}
+}
+
+func TestImageErrorResponsesAreNotCacheable(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{"media item", "/api/images/media/item", GetMediaItemImage},
+		{"collection", "/api/images/media/collection", GetCollectionItemImage},
+		{"MediUX image", "/api/images/mediux/item?quality=invalid", GetMediuxImage},
+		{"MediUX avatar", "/api/images/mediux/avatar", GetMediuxAvatarImage},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			test.handler(response, httptest.NewRequest(http.MethodGet, test.target, nil))
+
+			if got := response.Header().Get("Cache-Control"); got != "" {
+				t.Errorf("error response Cache-Control = %q, want no cache policy", got)
+			}
+		})
+	}
+}

--- a/backend/routing/images/cache_test.go
+++ b/backend/routing/images/cache_test.go
@@ -7,8 +7,10 @@ import (
 	"aura/models"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
@@ -34,14 +36,16 @@ func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
 	config.Current.Images.CacheImages.Enabled = false
 	mediux.MediuxApiURL = server.URL
 
+	mediaVersion := time.Now().UnixMicro() + 1000
+	collectionVersion := mediaVersion + 1
 	cache.LibraryStore = cache.Cache_NewLibraryCache()
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie", UpdatedAt: 1700000000}},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie", UpdatedAt: mediaVersion}},
 	})
 	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
 	cache.CollectionsStore.UpsertCollection(&models.CollectionItem{
-		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: 1700000001,
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: collectionVersion,
 	})
 
 	tests := []struct {
@@ -50,10 +54,10 @@ func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
 		handler      http.HandlerFunc
 		cacheControl string
 	}{
-		{"versioned media item", "/api/images/media/item?rating_key=media-1&image_type=poster&v=1700000000", GetMediaItemImage, versionedImageCacheControl},
+		{"versioned media item", "/api/images/media/item?rating_key=media-1&image_type=poster&v=" + strconv.FormatInt(mediaVersion, 10), GetMediaItemImage, versionedImageCacheControl},
 		{"unversioned media item", "/api/images/media/item?rating_key=media-1&image_type=poster", GetMediaItemImage, unversionedImageCacheControl},
-		{"stale media item version", "/api/images/media/item?rating_key=media-1&image_type=poster&v=1699999999", GetMediaItemImage, unversionedImageCacheControl},
-		{"versioned collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster&v=1700000001", GetCollectionItemImage, versionedImageCacheControl},
+		{"stale media item version", "/api/images/media/item?rating_key=media-1&image_type=poster&v=" + strconv.FormatInt(mediaVersion-1, 10), GetMediaItemImage, unversionedImageCacheControl},
+		{"versioned collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster&v=" + strconv.FormatInt(collectionVersion, 10), GetCollectionItemImage, versionedImageCacheControl},
 		{"unversioned collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster", GetCollectionItemImage, unversionedImageCacheControl},
 		{"versioned MediUX image", "/api/images/mediux/item?asset_id=asset-1&modified_date=2024-01-01T12:00:00Z", GetMediuxImage, versionedImageCacheControl},
 		{"unversioned MediUX avatar", "/api/images/mediux/avatar?avatar_id=avatar-1", GetMediuxAvatarImage, unversionedImageCacheControl},
@@ -90,13 +94,15 @@ func TestStaleBrowserVersionUsesCurrentPlexVersion(t *testing.T) {
 	})
 	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-secret"}
 	config.Current.Images.CacheImages.Enabled = false
+	oldVersion := time.Now().UnixMicro() + 1000
+	currentVersion := oldVersion + 1
 	cache.LibraryStore = cache.Cache_NewLibraryCache()
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{{RatingKey: "media-1", UpdatedAt: 100}},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", UpdatedAt: oldVersion}},
 	})
-	if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt("media-1", 200); !ok || version != 200 {
-		t.Fatalf("advanced version = %d, found = %v; want 200, true", version, ok)
+	if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt("media-1", currentVersion); !ok || version != currentVersion {
+		t.Fatalf("advanced version = %d, found = %v; want %d, true", version, ok, currentVersion)
 	}
 
 	for _, test := range []struct {
@@ -104,8 +110,8 @@ func TestStaleBrowserVersionUsesCurrentPlexVersion(t *testing.T) {
 		version      string
 		cacheControl string
 	}{
-		{"stale browser version", "100", unversionedImageCacheControl},
-		{"current browser version", "200", versionedImageCacheControl},
+		{"stale browser version", strconv.FormatInt(oldVersion, 10), unversionedImageCacheControl},
+		{"current browser version", strconv.FormatInt(currentVersion, 10), versionedImageCacheControl},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			response := httptest.NewRecorder()
@@ -120,9 +126,10 @@ func TestStaleBrowserVersionUsesCurrentPlexVersion(t *testing.T) {
 		})
 	}
 
+	wantUpstream := "/library/metadata/media-1/poster/" + strconv.FormatInt(currentVersion, 10)
 	for _, got := range upstreamVersions {
-		if got != "/library/metadata/media-1/poster/200" {
-			t.Errorf("upstream Plex image version = %q, want current version path", got)
+		if got != wantUpstream {
+			t.Errorf("upstream Plex image version = %q, want %q", got, wantUpstream)
 		}
 	}
 }

--- a/backend/routing/images/cache_test.go
+++ b/backend/routing/images/cache_test.go
@@ -7,12 +7,11 @@ import (
 	"aura/models"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-const expectedImageCacheControl = "private, max-age=86400"
-
-func TestSuccessfulImageResponsesAreBrowserCacheable(t *testing.T) {
+func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
 		_, _ = w.Write([]byte("image"))
@@ -38,22 +37,26 @@ func TestSuccessfulImageResponsesAreBrowserCacheable(t *testing.T) {
 	cache.LibraryStore = cache.Cache_NewLibraryCache()
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie"}},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie", UpdatedAt: 1700000000}},
 	})
 	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
 	cache.CollectionsStore.UpsertCollection(&models.CollectionItem{
-		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection",
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: 1700000001,
 	})
 
 	tests := []struct {
-		name    string
-		target  string
-		handler http.HandlerFunc
+		name         string
+		target       string
+		handler      http.HandlerFunc
+		cacheControl string
 	}{
-		{"media item", "/api/images/media/item?rating_key=media-1&image_type=poster", GetMediaItemImage},
-		{"collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster", GetCollectionItemImage},
-		{"MediUX image", "/api/images/mediux/item?asset_id=asset-1&modified_date=2024-01-01T12:00:00Z", GetMediuxImage},
-		{"MediUX avatar", "/api/images/mediux/avatar?avatar_id=avatar-1", GetMediuxAvatarImage},
+		{"versioned media item", "/api/images/media/item?rating_key=media-1&image_type=poster&v=1700000000", GetMediaItemImage, versionedImageCacheControl},
+		{"unversioned media item", "/api/images/media/item?rating_key=media-1&image_type=poster", GetMediaItemImage, unversionedImageCacheControl},
+		{"stale media item version", "/api/images/media/item?rating_key=media-1&image_type=poster&v=1699999999", GetMediaItemImage, unversionedImageCacheControl},
+		{"versioned collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster&v=1700000001", GetCollectionItemImage, versionedImageCacheControl},
+		{"unversioned collection", "/api/images/media/collection?rating_key=collection-1&image_type=poster", GetCollectionItemImage, unversionedImageCacheControl},
+		{"versioned MediUX image", "/api/images/mediux/item?asset_id=asset-1&modified_date=2024-01-01T12:00:00Z", GetMediuxImage, versionedImageCacheControl},
+		{"unversioned MediUX avatar", "/api/images/mediux/avatar?avatar_id=avatar-1", GetMediuxAvatarImage, unversionedImageCacheControl},
 	}
 
 	for _, test := range tests {
@@ -64,8 +67,8 @@ func TestSuccessfulImageResponsesAreBrowserCacheable(t *testing.T) {
 			if response.Code != http.StatusOK {
 				t.Fatalf("status = %d, want %d; body = %q", response.Code, http.StatusOK, response.Body.String())
 			}
-			if got := response.Header().Get("Cache-Control"); got != expectedImageCacheControl {
-				t.Errorf("Cache-Control = %q, want %q", got, expectedImageCacheControl)
+			if got := response.Header().Get("Cache-Control"); got != test.cacheControl {
+				t.Errorf("Cache-Control = %q, want %q", got, test.cacheControl)
 			}
 		})
 	}
@@ -73,14 +76,15 @@ func TestSuccessfulImageResponsesAreBrowserCacheable(t *testing.T) {
 
 func TestImageErrorResponsesAreNotCacheable(t *testing.T) {
 	tests := []struct {
-		name    string
-		target  string
-		handler http.HandlerFunc
+		name       string
+		target     string
+		handler    http.HandlerFunc
+		bodyString string
 	}{
-		{"media item", "/api/images/media/item", GetMediaItemImage},
-		{"collection", "/api/images/media/collection", GetCollectionItemImage},
-		{"MediUX image", "/api/images/mediux/item?quality=invalid", GetMediuxImage},
-		{"MediUX avatar", "/api/images/mediux/avatar", GetMediuxAvatarImage},
+		{"media item", "/api/images/media/item", GetMediaItemImage, "Missing Query Parameters"},
+		{"collection", "/api/images/media/collection", GetCollectionItemImage, "Missing Query Parameters"},
+		{"MediUX image", "/api/images/mediux/item?quality=invalid", GetMediuxImage, "Invalid quality parameter"},
+		{"MediUX avatar", "/api/images/mediux/avatar", GetMediuxAvatarImage, "Missing avatar identifier"},
 	}
 
 	for _, test := range tests {
@@ -88,6 +92,12 @@ func TestImageErrorResponsesAreNotCacheable(t *testing.T) {
 			response := httptest.NewRecorder()
 			test.handler(response, httptest.NewRequest(http.MethodGet, test.target, nil))
 
+			if response.Code != http.StatusInternalServerError {
+				t.Errorf("status = %d, want %d; body = %q", response.Code, http.StatusInternalServerError, response.Body.String())
+			}
+			if body := response.Body.String(); !strings.Contains(body, `"status":"error"`) || !strings.Contains(body, test.bodyString) {
+				t.Errorf("body = %q, want error status and %q", body, test.bodyString)
+			}
 			if got := response.Header().Get("Cache-Control"); got != "" {
 				t.Errorf("error response Cache-Control = %q, want no cache policy", got)
 			}

--- a/backend/routing/images/cache_test.go
+++ b/backend/routing/images/cache_test.go
@@ -74,6 +74,59 @@ func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
 	}
 }
 
+func TestStaleBrowserVersionUsesCurrentPlexVersion(t *testing.T) {
+	var upstreamVersions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamVersions = append(upstreamVersions, r.URL.Query().Get("url"))
+		_, _ = w.Write([]byte("image"))
+	}))
+	defer server.Close()
+
+	previousConfig := config.Current
+	previousLibraryStore := cache.LibraryStore
+	t.Cleanup(func() {
+		config.Current = previousConfig
+		cache.LibraryStore = previousLibraryStore
+	})
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: server.URL, ApiToken: "plex-secret"}
+	config.Current.Images.CacheImages.Enabled = false
+	cache.LibraryStore = cache.Cache_NewLibraryCache()
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", UpdatedAt: 100}},
+	})
+	if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt("media-1", 200); !ok || version != 200 {
+		t.Fatalf("advanced version = %d, found = %v; want 200, true", version, ok)
+	}
+
+	for _, test := range []struct {
+		name         string
+		version      string
+		cacheControl string
+	}{
+		{"stale browser version", "100", unversionedImageCacheControl},
+		{"current browser version", "200", versionedImageCacheControl},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/api/images/media/item?rating_key=media-1&image_type=poster&v="+test.version, nil)
+			GetMediaItemImage(response, request)
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+			}
+			if got := response.Header().Get("Cache-Control"); got != test.cacheControl {
+				t.Fatalf("Cache-Control = %q, want %q", got, test.cacheControl)
+			}
+		})
+	}
+
+	for _, got := range upstreamVersions {
+		if got != "/library/metadata/media-1/poster/200" {
+			t.Errorf("upstream Plex image version = %q, want current version path", got)
+		}
+	}
+}
+
 func TestImageErrorResponsesAreNotCacheable(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/backend/routing/images/mediaitem.go
+++ b/backend/routing/images/mediaitem.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 )
 
+const imageCacheControl = "private, max-age=86400"
+
 // GetMediaItemImage godoc
 // @Summary      Get Media Item Image
 // @Description  Get a media item image (poster, backdrop or thumb) from the media server by rating key and image type
@@ -72,6 +74,7 @@ func GetMediaItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
+	w.Header().Set("Cache-Control", imageCacheControl)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
@@ -133,6 +136,7 @@ func GetCollectionItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
+	w.Header().Set("Cache-Control", imageCacheControl)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)

--- a/backend/routing/images/mediaitem.go
+++ b/backend/routing/images/mediaitem.go
@@ -2,13 +2,26 @@ package routes_images
 
 import (
 	"aura/cache"
+	"aura/config"
 	"aura/logging"
 	"aura/mediaserver"
 	"aura/utils/httpx"
 	"net/http"
+	"strconv"
 )
 
-const imageCacheControl = "private, max-age=86400"
+const (
+	versionedImageCacheControl   = "private, max-age=86400"
+	unversionedImageCacheControl = "private, no-store"
+)
+
+func setMediaImageCacheControl(w http.ResponseWriter, r *http.Request, updatedAt int64) {
+	if config.Current.MediaServer.Type == "Plex" && updatedAt > 0 && r.URL.Query().Get("v") == strconv.FormatInt(updatedAt, 10) {
+		w.Header().Set("Cache-Control", versionedImageCacheControl)
+		return
+	}
+	w.Header().Set("Cache-Control", unversionedImageCacheControl)
+}
 
 // GetMediaItemImage godoc
 // @Summary      Get Media Item Image
@@ -74,7 +87,7 @@ func GetMediaItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
-	w.Header().Set("Cache-Control", imageCacheControl)
+	setMediaImageCacheControl(w, r, item.UpdatedAt)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
@@ -136,7 +149,7 @@ func GetCollectionItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
-	w.Header().Set("Cache-Control", imageCacheControl)
+	setMediaImageCacheControl(w, r, item.UpdatedAt)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)

--- a/backend/routing/images/mediux.go
+++ b/backend/routing/images/mediux.go
@@ -7,6 +7,7 @@ import (
 	"aura/utils"
 	"aura/utils/httpx"
 	"net/http"
+	"time"
 )
 
 // GetMediuxImage godoc
@@ -59,7 +60,13 @@ func GetMediuxImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", imageType)
-	w.Header().Set("Cache-Control", imageCacheControl)
+	cacheControl := unversionedImageCacheControl
+	if assetID != "" {
+		if _, err := time.Parse(time.RFC3339Nano, modifiedDate); err == nil {
+			cacheControl = versionedImageCacheControl
+		}
+	}
+	w.Header().Set("Cache-Control", cacheControl)
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
 }
@@ -83,6 +90,7 @@ func GetMediuxAvatarImage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("username")
 
 	if avatarID == "" && username == "" {
+		logAction.SetError("Missing avatar identifier", "avatar_id or username is required", nil)
 		httpx.SendResponse(w, ld, nil)
 		return
 	} else if avatarID == "" && username != "" {
@@ -91,6 +99,7 @@ func GetMediuxAvatarImage(w http.ResponseWriter, r *http.Request) {
 		if found && cachedUser.Avatar != "" {
 			avatarID = cachedUser.Avatar
 		} else {
+			logAction.SetError("MediUX user avatar not found", "No avatar was found for the supplied username", map[string]any{"username": username})
 			httpx.SendResponse(w, ld, nil)
 			return
 		}
@@ -103,7 +112,7 @@ func GetMediuxAvatarImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", imageType)
-	w.Header().Set("Cache-Control", imageCacheControl)
+	w.Header().Set("Cache-Control", unversionedImageCacheControl)
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
 

--- a/backend/routing/images/mediux.go
+++ b/backend/routing/images/mediux.go
@@ -59,6 +59,7 @@ func GetMediuxImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", imageType)
+	w.Header().Set("Cache-Control", imageCacheControl)
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
 }
@@ -102,6 +103,7 @@ func GetMediuxAvatarImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", imageType)
+	w.Header().Set("Cache-Control", imageCacheControl)
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
 

--- a/frontend/src/app/collection-item/page.tsx
+++ b/frontend/src/app/collection-item/page.tsx
@@ -71,9 +71,6 @@ export default function CollectionItemPage() {
   const [hasError, setHasError] = useState(false);
   const [error, setError] = useState<APIResponse<unknown> | null>(null);
 
-  // Image Version State (for forcing image reloads)
-  const imageVersion = useState(Date.now());
-
   // UI States from Store
   const { sortOrder, setSortOrder, sortOption, setSortOption, showHiddenUsers, setShowHiddenUsers } =
     useCollectionItemPageStore();
@@ -345,7 +342,7 @@ export default function CollectionItemPage() {
   return (
     <>
       <DimmedBackground
-        backdropURL={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=backdrop&cb=${imageVersion}`}
+        backdropURL={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=backdrop&v=${collectionItem?.updated_at}`}
       />
 
       <div className="p-4 lg:p-6">

--- a/frontend/src/components/layout/app-search-bar.tsx
+++ b/frontend/src/components/layout/app-search-bar.tsx
@@ -453,7 +453,7 @@ export function DynamicSearch({ placeholder = "Search", className }: DynamicSear
                                 subtitle={`${item.library_title} • ${item.year}`}
                                 href={`/media-item/`}
                                 isHighlighted={isHighlighted}
-                                imageSrc={`/api/images/media/item?rating_key=${item.rating_key}&image_type=poster`}
+                                imageSrc={`/api/images/media/item?rating_key=${item.rating_key}&image_type=poster&v=${item.updated_at}`}
                                 imageAlt={item.title}
                                 fallbackIcon={
                                   item.type === "movie" ? (
@@ -500,7 +500,7 @@ export function DynamicSearch({ placeholder = "Search", className }: DynamicSear
                                 subtitle={subtitle}
                                 href={`/saved-sets/`}
                                 isHighlighted={isHighlighted}
-                                imageSrc={`/api/images/media/item?rating_key=${set.media_item.rating_key}&image_type=poster`}
+                                imageSrc={`/api/images/media/item?rating_key=${set.media_item.rating_key}&image_type=poster&v=${set.media_item.updated_at}`}
                                 imageAlt={set.media_item.title}
                                 fallbackIcon={<Film className="h-4 w-4 text-muted-foreground" />}
                                 onLinkClick={() => {

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -114,7 +114,7 @@ export function AssetImage({
   } else if (imageType === "item") {
     imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}&v=${(image as MediaItem).updated_at}`;
   } else if (imageType === "collection") {
-    imageSrc = `/api/images/media/collection?rating_key=${(image as CollectionItem).rating_key}&image_type=${aspect}&index=${(image as CollectionItem).index}`;
+    imageSrc = `/api/images/media/collection?rating_key=${(image as CollectionItem).rating_key}&image_type=${aspect}&index=${(image as CollectionItem).index}&v=${(image as CollectionItem).updated_at}`;
   } else {
     imageSrc = "";
   }

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -112,7 +112,7 @@ export function AssetImage({
       ? kometaImageSrc(assetId)
       : `/api/images/mediux/item?asset_id=${assetId}&modified_date=${(image as ImageFile).modified}`;
   } else if (imageType === "item") {
-    imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}`;
+    imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}&v=${(image as MediaItem).updated_at}`;
   } else if (imageType === "collection") {
     imageSrc = `/api/images/media/collection?rating_key=${(image as CollectionItem).rating_key}&image_type=${aspect}&index=${(image as CollectionItem).index}`;
   } else {

--- a/frontend/src/components/shared/collection-item-details.tsx
+++ b/frontend/src/components/shared/collection-item-details.tsx
@@ -26,7 +26,7 @@ export function CollectionItemDetails({ collectionItem }: CollectionItemDetailsP
         {/* Poster Image */}
         <div className="flex-shrink-0 mb-4 lg:mb-0 lg:mr-8 flex justify-center">
           <AssetImage
-            image={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=poster&cb=${Date.now()}`}
+            image={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=poster&v=${collectionItem?.updated_at}`}
             imageType="url"
             className="w-[200px] h-auto transition-transform hover:scale-105 select-none"
           />

--- a/frontend/src/types/media-and-posters/collection-item.ts
+++ b/frontend/src/types/media-and-posters/collection-item.ts
@@ -15,4 +15,5 @@ export interface CollectionItem {
   child_count: number;
   media_items: MediaItem[];
   library_title?: string;
+  updated_at: number;
 }


### PR DESCRIPTION
## Summary
- version Plex transcode source paths with cached artwork versions, keeping repeated artwork-state requests stable while changing identity after artwork updates
- advance cached parent versions atomically after successful media, season, episode, and collection artwork applies; failed applies leave versions unchanged
- version browser-visible media grid and search image URLs with each item's `updated_at`
- grant 24-hour browser freshness only to exact current Plex versions and valid MediUX modified-date URLs
- use `private, no-store` for mutable unversioned/mismatched media URLs and avatars; keep errors without cache headers
- add deterministic regression coverage for apply invalidation, monotonic concurrency, Plex source identity, cache policies, and real non-2xx error responses

## Cache invalidation design
`GET /api/images/*` is authentication-exempt so browser image elements can load it. These responses must not rely on JWT protection. Successful cacheable responses use `private`, preventing shared-cache storage.

For Plex media items, frontend adds `v=<updated_at>` to grid/search URLs. Backend allows `private, max-age=86400` only when `v` exactly matches cached Plex `updatedAt`; absent/stale versions and non-Plex media servers get `private, no-store`. Plex transcode `url=` uses the current cached artwork version rather than `time.Now()`, so repeated requests hit Plex cache while artwork updates use a new upstream identity.

Every successful artwork mutation advances the relevant cached parent version once using `max(previous+1, current Unix time)` under the cache lock. Season and episode applies therefore invalidate the show parent token even though Plex receives the child rating key. Collection applies advance the cached collection token. Failed applies do not advance anything, concurrent same-second applies remain strictly monotonic, and cache refreshes preserve a newer local token when Plex still reports an unchanged parent `updatedAt`. A request carrying an old frontend token is served `private, no-store` while its Plex transcode uses the new cached version; refreshed frontend URLs become safely cacheable.

MediUX item URLs already contain asset `modified_date`; valid RFC3339 values remain cacheable for one day. Mutable avatar URLs use `private, no-store`. Kometa remains unchanged because this PR never adds a 24-hour policy to its mutable unversioned URL.

Frontend `unoptimized` remains intentional: AURA/Plex already serves requested image sizing and versioned URLs now enable native browser caching. Enabling Next optimization would add a second image proxy/cache without fixing invalidation.

## Verification
- `CONFIG_PATH=$(mktemp -d) go test -race -count=1 ./cache ./mediaserver ./mediaserver/plex ./routing/images`
- `CONFIG_PATH=$(mktemp -d) go test -count=1 ./...`
- `CONFIG_PATH=$(mktemp -d) go vet ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build .`
- `GOTOOLCHAIN=go1.26.0 sh generate_go_docs.sh` (no generated diff)
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run build`

Closes #125
Closes #126


## Final review repair (863432ff)
- cache hydration now writes clamped monotonic artwork versions back to media-item, section, and collection result objects, keeping API payloads aligned with cache state
- media version ownership uses rating keys first, preventing empty-TMDB collisions
- hydrated mutable artwork versions use one process-stable Unix-microsecond generation floor; fresh processes emit fresh browser/Plex transcode keys without persisted cache state
- successful media/child/collection mutations write advanced versions through caller objects; failed mutations remain unchanged
- collection `updated_at` is now returned by API/Swagger and included in frontend collection image URLs

### Final verification
- `CONFIG_PATH=$(mktemp -d) go test -race -count=1 ./cache ./mediaserver ./mediaserver/plex ./routing/images`
- `CONFIG_PATH=$(mktemp -d) go test -count=1 ./...`
- `CONFIG_PATH=$(mktemp -d) go vet ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build .`
- `GOTOOLCHAIN=go1.26.0 sh generate_go_docs.sh`
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run build`
- changed frontend files pass Prettier; repository-wide `npm run format:check` still reports four pre-existing unrelated files (`CLAUDE.md`, `public/CHANGELOG.md`, `src/lib/stores/idb-storage.ts`, `src/types/ui-options.ts`)
