### PR TITLE
perf(library): page home media requests

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -2594,7 +2594,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieve items from a specific library section in the media server. This endpoint accepts query parameters to identify the library section and pagination options, and returns the items contained within that library section, allowing clients to display the media items available in the selected library section.",
+                "description": "Retrieve one filtered, sorted page from the warmed media-server library cache.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2604,35 +2604,85 @@ const docTemplate = `{
                 "tags": [
                     "MediaServer"
                 ],
-                "summary": "Get Library Section Items",
+                "summary": "Get Library Items",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Library Section ID",
-                        "name": "section_id",
-                        "in": "query",
-                        "required": true
+                        "description": "Library Title (repeat for multiple)",
+                        "name": "library_titles",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Library Section Title",
-                        "name": "section_title",
-                        "in": "query",
-                        "required": true
+                        "description": "Title search",
+                        "name": "search_title",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Library Section Type",
-                        "name": "section_type",
-                        "in": "query",
-                        "required": true
+                        "description": "Library search",
+                        "name": "search_library",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Start Index for Pagination",
-                        "name": "section_start_index",
-                        "in": "query",
-                        "required": true
+                        "description": "Exact TMDB ID search",
+                        "name": "search_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Release year",
+                        "name": "search_year",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Database filter (inDB or notInDB)",
+                        "name": "filter_in_db",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ignore status or mode",
+                        "name": "filter_ignored",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "MediUX set availability",
+                        "name": "filter_has_sets",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort option",
+                        "name": "sort_option",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page_number",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (maximum 1000)",
+                        "name": "items_per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Refresh server cache before reading",
+                        "name": "refresh",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6041,8 +6091,20 @@ const docTemplate = `{
         "routes_ms.GetLibrarySectionItems_Response": {
             "type": "object",
             "properties": {
-                "library_section": {
-                    "$ref": "#/definitions/models.LibrarySection"
+                "has_episode_added_at": {
+                    "type": "boolean"
+                },
+                "has_updated_at": {
+                    "type": "boolean"
+                },
+                "media_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.MediaItem"
+                    }
+                },
+                "total_items": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -2586,7 +2586,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieve items from a specific library section in the media server. This endpoint accepts query parameters to identify the library section and pagination options, and returns the items contained within that library section, allowing clients to display the media items available in the selected library section.",
+                "description": "Retrieve one filtered, sorted page from the warmed media-server library cache.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2596,35 +2596,85 @@
                 "tags": [
                     "MediaServer"
                 ],
-                "summary": "Get Library Section Items",
+                "summary": "Get Library Items",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Library Section ID",
-                        "name": "section_id",
-                        "in": "query",
-                        "required": true
+                        "description": "Library Title (repeat for multiple)",
+                        "name": "library_titles",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Library Section Title",
-                        "name": "section_title",
-                        "in": "query",
-                        "required": true
+                        "description": "Title search",
+                        "name": "search_title",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Library Section Type",
-                        "name": "section_type",
-                        "in": "query",
-                        "required": true
+                        "description": "Library search",
+                        "name": "search_library",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Start Index for Pagination",
-                        "name": "section_start_index",
-                        "in": "query",
-                        "required": true
+                        "description": "Exact TMDB ID search",
+                        "name": "search_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Release year",
+                        "name": "search_year",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Database filter (inDB or notInDB)",
+                        "name": "filter_in_db",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ignore status or mode",
+                        "name": "filter_ignored",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "MediUX set availability",
+                        "name": "filter_has_sets",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort option",
+                        "name": "sort_option",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page_number",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (maximum 1000)",
+                        "name": "items_per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Refresh server cache before reading",
+                        "name": "refresh",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6033,8 +6083,20 @@
         "routes_ms.GetLibrarySectionItems_Response": {
             "type": "object",
             "properties": {
-                "library_section": {
-                    "$ref": "#/definitions/models.LibrarySection"
+                "has_episode_added_at": {
+                    "type": "boolean"
+                },
+                "has_updated_at": {
+                    "type": "boolean"
+                },
+                "media_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.MediaItem"
+                    }
+                },
+                "total_items": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -1,4 +1,6 @@
 basePath: /
+# yamllint disable rule:indentation
+# yamllint disable rule:line-length
 definitions:
   autodownload.AutoDownloadResult:
     properties:
@@ -1658,8 +1660,16 @@ definitions:
     type: object
   routes_ms.GetLibrarySectionItems_Response:
     properties:
-      library_section:
-        $ref: '#/definitions/models.LibrarySection'
+      has_episode_added_at:
+        type: boolean
+      has_updated_at:
+        type: boolean
+      media_items:
+        items:
+          $ref: '#/definitions/models.MediaItem'
+        type: array
+      total_items:
+        type: integer
     type: object
   routes_ms.GetLibrarySections_Response:
     properties:
@@ -3434,32 +3444,61 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve items from a specific library section in the media server.
-        This endpoint accepts query parameters to identify the library section and
-        pagination options, and returns the items contained within that library section,
-        allowing clients to display the media items available in the selected library
-        section.
+      description: Retrieve one filtered, sorted page from the warmed media-server
+        library cache.
       parameters:
-      - description: Library Section ID
+      - description: Library Title (repeat for multiple)
         in: query
-        name: section_id
-        required: true
+        name: library_titles
         type: string
-      - description: Library Section Title
+      - description: Title search
         in: query
-        name: section_title
-        required: true
+        name: search_title
         type: string
-      - description: Library Section Type
+      - description: Library search
         in: query
-        name: section_type
-        required: true
+        name: search_library
         type: string
-      - description: Start Index for Pagination
+      - description: Exact TMDB ID search
         in: query
-        name: section_start_index
-        required: true
+        name: search_id
         type: string
+      - description: Release year
+        in: query
+        name: search_year
+        type: integer
+      - description: Database filter (inDB or notInDB)
+        in: query
+        name: filter_in_db
+        type: string
+      - description: Ignore status or mode
+        in: query
+        name: filter_ignored
+        type: string
+      - description: MediUX set availability
+        in: query
+        name: filter_has_sets
+        type: string
+      - description: Sort option
+        in: query
+        name: sort_option
+        type: string
+      - description: Sort order (asc or desc)
+        in: query
+        name: sort_order
+        type: string
+      - description: Page number
+        in: query
+        name: page_number
+        type: integer
+      - description: Items per page (maximum 1000)
+        in: query
+        name: items_per_page
+        type: integer
+      - description: Refresh server cache before reading
+        in: query
+        name: refresh
+        type: boolean
       produces:
       - application/json
       responses:
@@ -3482,7 +3521,7 @@ paths:
             $ref: '#/definitions/httpx.JSONResponse'
       security:
       - BearerAuth: []
-      summary: Get Library Section Items
+      summary: Get Library Items
       tags:
       - MediaServer
   /api/mediaserver/rate:

--- a/backend/cache/mediaserver_items.go
+++ b/backend/cache/mediaserver_items.go
@@ -249,9 +249,16 @@ func (c *MediaServerLibraryCache) GetItemsCount() int {
 func (c *MediaServerLibraryCache) GetAllMediaItems() []models.MediaItem {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
+	titles := make([]string, 0, len(c.sections))
+	for title := range c.sections {
+		titles = append(titles, title)
+	}
+	sort.Strings(titles)
+
 	var allItems []models.MediaItem
-	for _, section := range c.sections {
-		allItems = append(allItems, section.MediaItems...)
+	for _, title := range titles {
+		allItems = append(allItems, c.sections[title].MediaItems...)
 	}
 	return allItems
 }

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -64,6 +64,9 @@ type DB interface {
 	// Get All Media Items with info on whether they have saved sets or are ignored
 	GetAllMediaItemsWithFlags(ctx context.Context) (items []MediaItemWithFlags, logErr logging.LogErrorInfo)
 
+	// Get saved-set and ignore state for all media items in one query
+	GetAllMediaItemStates(ctx context.Context) (states map[MediaItemKey]MediaItemState, logErr logging.LogErrorInfo)
+
 	// Update Media Item
 	UpdateMediaItem(ctx context.Context, updatedItem models.MediaItem) (Err logging.LogErrorInfo)
 
@@ -96,6 +99,9 @@ type DB interface {
 
 	// Update Media Item on_server flag
 	UpdateMediaItemOnServer(ctx context.Context, tmdbID string, libraryTitle string, onServer bool) (logErr logging.LogErrorInfo)
+
+	// Update on_server for one page of media items in one statement
+	UpdateMediaItemsOnServer(ctx context.Context, libraryTitle string, tmdbIDs []string, onServer bool) (logErr logging.LogErrorInfo)
 }
 
 func NewDatabaseClient() (DB, logging.LogErrorInfo) {
@@ -235,6 +241,13 @@ func GetAllMediaItemsWithFlags(ctx context.Context) (items []MediaItemWithFlags,
 	return Client.GetAllMediaItemsWithFlags(ctx)
 }
 
+func GetAllMediaItemStates(ctx context.Context) (states map[MediaItemKey]MediaItemState, logErr logging.LogErrorInfo) {
+	if Client == nil {
+		return map[MediaItemKey]MediaItemState{}, logging.Error_DBClientNotInitialized()
+	}
+	return Client.GetAllMediaItemStates(ctx)
+}
+
 func UpdateMediaItem(ctx context.Context, updatedItem models.MediaItem) (Err logging.LogErrorInfo) {
 	if Client == nil {
 		return logging.Error_DBClientNotInitialized()
@@ -310,4 +323,11 @@ func UpdateMediaItemOnServer(ctx context.Context, tmdbID string, libraryTitle st
 		return logging.Error_DBClientNotInitialized()
 	}
 	return Client.UpdateMediaItemOnServer(ctx, tmdbID, libraryTitle, onServer)
+}
+
+func UpdateMediaItemsOnServer(ctx context.Context, libraryTitle string, tmdbIDs []string, onServer bool) (logErr logging.LogErrorInfo) {
+	if Client == nil {
+		return logging.Error_DBClientNotInitialized()
+	}
+	return Client.UpdateMediaItemsOnServer(ctx, libraryTitle, tmdbIDs, onServer)
 }

--- a/backend/database/sqlite_get_media_item_states.go
+++ b/backend/database/sqlite_get_media_item_states.go
@@ -1,0 +1,88 @@
+package database
+
+import (
+	"aura/logging"
+	"aura/models"
+	"context"
+	"database/sql"
+	"strings"
+)
+
+type MediaItemKey struct {
+	TMDBID       string
+	LibraryTitle string
+}
+
+type MediaItemState struct {
+	Ignored    bool
+	IgnoreMode string
+	SavedSets  []models.DBSavedSet
+}
+
+func (s *SQliteDB) GetAllMediaItemStates(ctx context.Context) (map[MediaItemKey]MediaItemState, logging.LogErrorInfo) {
+	ctx, logAction := logging.AddSubActionToContext(ctx, "Retrieving media item database states", logging.LevelDebug)
+	defer logAction.Complete()
+
+	states := make(map[MediaItemKey]MediaItemState)
+	rows, err := s.conn.QueryContext(ctx, `
+		SELECT DISTINCT
+		       COALESCE(m.tmdb_id, i.tmdb_id, si.tmdb_id) AS tmdb_id,
+		       COALESCE(m.library_title, i.library_title, si.library_title) AS library_title,
+		       i.mode, ps.set_id, ps.user,
+		       si.poster_selected, si.backdrop_selected, si.season_poster_selected,
+		       si.special_season_poster_selected, si.titlecard_selected
+		FROM MediaItems m
+		FULL OUTER JOIN IgnoredItems i
+		  ON i.tmdb_id = m.tmdb_id AND i.library_title = m.library_title
+		FULL OUTER JOIN SavedItems si
+		  ON si.tmdb_id = COALESCE(m.tmdb_id, i.tmdb_id)
+		 AND si.library_title = COALESCE(m.library_title, i.library_title)
+		LEFT JOIN PosterSets ps ON ps.id = si.poster_set_id
+		ORDER BY library_title, tmdb_id, ps.set_id
+	`)
+	if err != nil {
+		logAction.SetError("Failed to query media item database states", "", map[string]any{"error": err.Error()})
+		return states, *logAction.Error
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tmdbID, libraryTitle string
+		var ignoreMode, setID, user sql.NullString
+		var poster, backdrop, seasonPoster, specialSeasonPoster, titlecard sql.NullInt64
+		if err := rows.Scan(
+			&tmdbID, &libraryTitle, &ignoreMode, &setID, &user,
+			&poster, &backdrop, &seasonPoster, &specialSeasonPoster, &titlecard,
+		); err != nil {
+			logAction.SetError("Failed to scan media item database state", "", map[string]any{"error": err.Error()})
+			return states, *logAction.Error
+		}
+
+		key := MediaItemKey{TMDBID: tmdbID, LibraryTitle: libraryTitle}
+		state := states[key]
+		trimmedIgnoreMode := strings.TrimSpace(ignoreMode.String)
+		if ignoreMode.Valid && trimmedIgnoreMode != "" {
+			state.Ignored = true
+			state.IgnoreMode = trimmedIgnoreMode
+			state.SavedSets = nil
+		} else if setID.Valid {
+			state.SavedSets = append(state.SavedSets, models.DBSavedSet{
+				ID:          setID.String,
+				UserCreated: user.String,
+				SelectedTypes: models.SelectedTypes{
+					Poster:              poster.Int64 == 1,
+					Backdrop:            backdrop.Int64 == 1,
+					SeasonPoster:        seasonPoster.Int64 == 1,
+					SpecialSeasonPoster: specialSeasonPoster.Int64 == 1,
+					Titlecard:           titlecard.Int64 == 1,
+				},
+			})
+		}
+		states[key] = state
+	}
+	if err := rows.Err(); err != nil {
+		logAction.SetError("Failed while reading media item database states", "", map[string]any{"error": err.Error()})
+		return states, *logAction.Error
+	}
+	return states, logging.LogErrorInfo{}
+}

--- a/backend/database/sqlite_get_media_item_states_test.go
+++ b/backend/database/sqlite_get_media_item_states_test.go
@@ -1,0 +1,108 @@
+package database
+
+import (
+	"aura/logging"
+	"context"
+	"database/sql"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+func TestGetAllMediaItemStatesReturnsSavedSetsAndIgnoreModesInOneBulkRead(t *testing.T) {
+	var selectStatements, updateStatements atomic.Int32
+	sql.Register("sqlite3_media_state_counts", &sqlite3.SQLiteDriver{ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+		conn.RegisterAuthorizer(func(operation int, _, _, _ string) int {
+			switch operation {
+			case sqlite3.SQLITE_SELECT:
+				selectStatements.Add(1)
+			case sqlite3.SQLITE_UPDATE:
+				updateStatements.Add(1)
+			}
+			return sqlite3.SQLITE_OK
+		})
+		return nil
+	}})
+	conn, err := sql.Open("sqlite3_media_state_counts", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	statements := []string{
+		`CREATE TABLE MediaItems (tmdb_id TEXT, library_title TEXT, on_server INTEGER DEFAULT 0)`,
+		`CREATE TABLE IgnoredItems (tmdb_id TEXT, library_title TEXT, mode TEXT)`,
+		`CREATE TABLE PosterSets (id INTEGER PRIMARY KEY, set_id TEXT, user TEXT)`,
+		`CREATE TABLE SavedItems (
+			tmdb_id TEXT, library_title TEXT, poster_set_id INTEGER,
+			poster_selected INTEGER, backdrop_selected INTEGER,
+			season_poster_selected INTEGER, special_season_poster_selected INTEGER,
+			titlecard_selected INTEGER
+		)`,
+		`INSERT INTO MediaItems(tmdb_id, library_title) VALUES ('1', 'Movies'), ('2', 'Movies'), ('3', 'Movies')`,
+		`INSERT INTO IgnoredItems VALUES
+			('2', 'Movies', ' until-set-available '),
+			('4', 'Movies', 'always')`,
+		`INSERT INTO PosterSets VALUES (7, 'set-7', 'creator')`,
+		`INSERT INTO SavedItems VALUES
+			('1', 'Movies', 7, 1, 0, 1, 0, 1),
+			('1', 'Movies', 7, 1, 0, 1, 0, 1),
+			('3', 'Movies', 99, 1, 0, 0, 0, 0)`,
+	}
+	for _, statement := range statements {
+		if _, err := conn.Exec(statement); err != nil {
+			t.Fatalf("exec %q: %v", statement, err)
+		}
+	}
+
+	db := &SQliteDB{conn: conn}
+	ctx, logData := logging.CreateLoggingContext(context.Background(), "test")
+	ctx = logging.WithCurrentAction(ctx, logData.AddAction("bulk states", logging.LevelDebug))
+	selectStatements.Store(0)
+	states, logErr := db.GetAllMediaItemStates(ctx)
+	if logErr.Message != "" {
+		t.Fatalf("GetAllMediaItemStates() error = %s", logErr.Message)
+	}
+	if got := selectStatements.Load(); got != 1 {
+		t.Fatalf("GetAllMediaItemStates() prepared %d SELECT statements, want 1", got)
+	}
+
+	saved := states[MediaItemKey{TMDBID: "1", LibraryTitle: "Movies"}]
+	if saved.Ignored || len(saved.SavedSets) != 1 || saved.SavedSets[0].ID != "set-7" {
+		t.Fatalf("saved state = %+v", saved)
+	}
+	if !saved.SavedSets[0].SelectedTypes.Poster || !saved.SavedSets[0].SelectedTypes.SeasonPoster || !saved.SavedSets[0].SelectedTypes.Titlecard {
+		t.Fatalf("saved selected types = %+v", saved.SavedSets[0].SelectedTypes)
+	}
+
+	ignored := states[MediaItemKey{TMDBID: "2", LibraryTitle: "Movies"}]
+	if !ignored.Ignored || ignored.IgnoreMode != "until-set-available" || len(ignored.SavedSets) != 0 {
+		t.Fatalf("ignored state = %+v", ignored)
+	}
+
+	unresolved := states[MediaItemKey{TMDBID: "3", LibraryTitle: "Movies"}]
+	if unresolved.Ignored || len(unresolved.SavedSets) != 0 {
+		t.Fatalf("unresolved poster-set state = %+v, want no saved sets", unresolved)
+	}
+
+	ignoredWithoutMediaItem := states[MediaItemKey{TMDBID: "4", LibraryTitle: "Movies"}]
+	if !ignoredWithoutMediaItem.Ignored || ignoredWithoutMediaItem.IgnoreMode != "always" {
+		t.Fatalf("ignored-only state = %+v, want always ignored", ignoredWithoutMediaItem)
+	}
+
+	updateStatements.Store(0)
+	if logErr := db.UpdateMediaItemsOnServer(ctx, "Movies", []string{"1", "2"}, true); logErr.Message != "" {
+		t.Fatalf("UpdateMediaItemsOnServer() error = %s", logErr.Message)
+	}
+	var updated int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM MediaItems WHERE on_server = 1`).Scan(&updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated != 2 {
+		t.Fatalf("bulk-updated rows = %d, want 2", updated)
+	}
+	if got := updateStatements.Load(); got != 1 {
+		t.Fatalf("UpdateMediaItemsOnServer() prepared %d UPDATE statements, want 1", got)
+	}
+}

--- a/backend/database/sqlite_update_on_server.go
+++ b/backend/database/sqlite_update_on_server.go
@@ -3,6 +3,7 @@ package database
 import (
 	"aura/logging"
 	"context"
+	"encoding/json"
 )
 
 func (s *SQliteDB) UpdateMediaItemOnServer(ctx context.Context, tmdbID string, libraryTitle string, onServer bool) (logErr logging.LogErrorInfo) {
@@ -41,4 +42,23 @@ func (s *SQliteDB) UpdateMediaItemOnServer(ctx context.Context, tmdbID string, l
 	}
 
 	return logErr
+}
+
+func (s *SQliteDB) UpdateMediaItemsOnServer(ctx context.Context, libraryTitle string, tmdbIDs []string, onServer bool) logging.LogErrorInfo {
+	if len(tmdbIDs) == 0 {
+		return logging.LogErrorInfo{}
+	}
+	encodedIDs, err := json.Marshal(tmdbIDs)
+	if err != nil {
+		return logging.LogErrorInfo{Message: "Failed to encode media item IDs", Detail: map[string]any{"error": err.Error()}}
+	}
+	if _, err := s.conn.ExecContext(ctx, `
+		UPDATE MediaItems
+		SET on_server = ?
+		WHERE library_title = ?
+		  AND tmdb_id IN (SELECT value FROM json_each(?))
+	`, onServer, libraryTitle, string(encodedIDs)); err != nil {
+		return logging.LogErrorInfo{Message: "Failed to bulk-update MediaItem on_server flags", Detail: map[string]any{"error": err.Error()}}
+	}
+	return logging.LogErrorInfo{}
 }

--- a/backend/generate_go_docs.sh
+++ b/backend/generate_go_docs.sh
@@ -1,1 +1,1 @@
-swag init -g main.go -o api-docs --parseDependency --parseInternal --parseDepth 3
+swag init -g main.go -o api-docs --parseInternal --parseDepth 3

--- a/backend/mediaserver/ej/get_library_section_items.go
+++ b/backend/mediaserver/ej/get_library_section_items.go
@@ -3,7 +3,6 @@ package ej
 import (
 	"aura/cache"
 	"aura/config"
-	"aura/database"
 	"aura/logging"
 	"aura/mediux"
 	"aura/models"
@@ -136,25 +135,6 @@ func (e *EJ) GetLibrarySectionItems(ctx context.Context, section models.LibraryS
 			logging.LOGGER.Warn().Timestamp().Str("item_title", item.Title).Str("library_section", section.Title).Msgf("Skipping item in '%s' as no TMDB ID could be found", section.Title)
 			totalSize-- // Decrement total size as this item will be skipped
 			continue    // Skip items without TMDB ID
-		}
-
-		// Check if Media Item exists in DB
-		ignored, ignoredMode, sets, logErr := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
-		if logErr.Message != "" {
-			logAction.AppendWarning("message", "Failed to check if media item exists in database")
-			logAction.AppendWarning("error", Err)
-		}
-		if !ignored {
-			item.DBSavedSets = sets
-		} else {
-			item.IgnoredInDB = true
-			item.IgnoredMode = ignoredMode
-		}
-
-		// Update the Media Item on Server in the DB
-		updateErr := database.UpdateMediaItemOnServer(ctx, item.TMDB_ID, item.LibraryTitle, true)
-		if updateErr.Message != "" {
-			logAction.AppendWarning("update_on_server_error", updateErr.Message)
 		}
 
 		// Check if Media Item exists in MediUX with a set
@@ -292,19 +272,6 @@ func splitCollectionIntoIndividualItems(ctx context.Context, collectionName, par
 		if itemInfo.TMDB_ID == "" {
 			logging.LOGGER.Warn().Timestamp().Str("item_title", itemInfo.Title).Str("library_section", sectionTitle).Msg("Skipping item in BoxSet collection because it does not have a TMDB ID")
 			continue // Skip items without TMDB ID
-		}
-
-		// Check if Media Item exists in DB
-		ignored, ignoredMode, sets, logErr := database.CheckIfMediaItemExists(ctx, itemInfo.TMDB_ID, itemInfo.LibraryTitle)
-		if logErr.Message != "" {
-			logAction.AppendWarning("message", "Failed to check if media item exists in database")
-			logAction.AppendWarning("error", logErr)
-		}
-		if !ignored {
-			itemInfo.DBSavedSets = sets
-		} else {
-			itemInfo.IgnoredInDB = true
-			itemInfo.IgnoredMode = ignoredMode
 		}
 
 		// Check if Media Item exists in MediUX with a set

--- a/backend/mediaserver/get_all_library_sections_and_items.go
+++ b/backend/mediaserver/get_all_library_sections_and_items.go
@@ -3,7 +3,9 @@ package mediaserver
 import (
 	"aura/cache"
 	"aura/config"
+	"aura/database"
 	"aura/logging"
+	"aura/mediaserver/plex"
 	"aura/models"
 	"context"
 	"fmt"
@@ -100,14 +102,43 @@ func RefreshSectionItems(ctx context.Context, sectionTitle string) (success bool
 // fetchAndCacheSectionItems pages through a library section's items and upserts them into
 // the library cache. Returns false if a page fetch fails.
 func fetchAndCacheSectionItems(ctx context.Context, section models.LibrarySection) bool {
+	msClient, Err := NewMediaServerClient(&config.Current.MediaServer)
+	if Err.Message != "" {
+		return false
+	}
+
+	states, stateErr := database.GetAllMediaItemStates(ctx)
+	if stateErr.Message != "" {
+		logging.LOGGER.Warn().Timestamp().Str("section_title", section.Title).Str("error", stateErr.Message).Msg("Failed to bulk-fetch media item database state")
+		states = map[database.MediaItemKey]database.MediaItemState{}
+	}
+	if plexClient, ok := msClient.(*plex.Plex); ok {
+		if prepareErr := plexClient.PrepareLatestEpisodeAddedAt(ctx, section); prepareErr.Message != "" {
+			logging.LOGGER.Warn().Timestamp().Str("section_title", section.Title).Str("error", prepareErr.Message).Msg("Failed to fetch latest episode dates")
+		}
+	}
+
 	pageSize := 1000
 	start := 0
 	expectedTotal := 0
-
 	for {
-		items, totalSize, Err := GetLibrarySectionItems(ctx, section, strconv.Itoa(start), strconv.Itoa(pageSize))
+		items, totalSize, Err := msClient.GetLibrarySectionItems(ctx, section, strconv.Itoa(start), strconv.Itoa(pageSize))
 		if Err.Message != "" {
 			return false
+		}
+		tmdbIDs := make([]string, 0, len(items))
+		for i := range items {
+			state := states[database.MediaItemKey{TMDBID: items[i].TMDB_ID, LibraryTitle: items[i].LibraryTitle}]
+			items[i].DBSavedSets = []models.DBSavedSet{}
+			items[i].IgnoredInDB = state.Ignored
+			items[i].IgnoredMode = state.IgnoreMode
+			if !state.Ignored && len(state.SavedSets) > 0 {
+				items[i].DBSavedSets = state.SavedSets
+			}
+			tmdbIDs = append(tmdbIDs, items[i].TMDB_ID)
+		}
+		if updateErr := database.UpdateMediaItemsOnServer(ctx, section.Title, tmdbIDs, true); updateErr.Message != "" {
+			logging.LOGGER.Warn().Timestamp().Str("section_title", section.Title).Str("error", updateErr.Message).Msg("Failed to bulk-update media item server flags")
 		}
 		logging.LOGGER.Info().Timestamp().
 			Str("section_title", section.Title).

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -143,14 +143,6 @@ func GetLibrarySectionDetails(ctx context.Context, library *models.LibrarySectio
 	return msClient.GetLibrarySectionDetails(ctx, library)
 }
 
-func GetLibrarySectionItems(ctx context.Context, section models.LibrarySection, sectionStartIndex string, limit string) ([]models.MediaItem, int, logging.LogErrorInfo) {
-	msClient, Err := NewMediaServerClient(&config.Current.MediaServer)
-	if Err.Message != "" {
-		return nil, 0, Err
-	}
-	return msClient.GetLibrarySectionItems(ctx, section, sectionStartIndex, limit)
-}
-
 func GetMovieCollections(ctx context.Context, section models.LibrarySection) (collections []models.CollectionItem, Err logging.LogErrorInfo) {
 	msClient, Err := NewMediaServerClient(&config.Current.MediaServer)
 	if Err.Message != "" {

--- a/backend/mediaserver/plex/get_library_section_items.go
+++ b/backend/mediaserver/plex/get_library_section_items.go
@@ -3,7 +3,6 @@ package plex
 import (
 	"aura/cache"
 	"aura/config"
-	"aura/database"
 	"aura/logging"
 	"aura/models"
 	"aura/utils/httpx"
@@ -11,9 +10,22 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
+
+func (p *Plex) PrepareLatestEpisodeAddedAt(ctx context.Context, section models.LibrarySection) logging.LogErrorInfo {
+	p.latestEpisodeAddedAtByShow = nil
+	if section.Type != "show" || !config.Current.MediaServer.EnableSortByEpisodeAddedDate {
+		return logging.LogErrorInfo{}
+	}
+	latest, Err := fetchLatestEpisodeAddedAtByShow(ctx, section.ID)
+	if Err.Message == "" {
+		p.latestEpisodeAddedAtByShow = latest
+	}
+	return Err
+}
 
 func (p *Plex) GetLibrarySectionItems(ctx context.Context, section models.LibrarySection, sectionStartIndex string, limit string) (items []models.MediaItem, totalSize int, Err logging.LogErrorInfo) {
 	ctx, logAction := logging.AddSubActionToContext(ctx, fmt.Sprintf(
@@ -127,25 +139,6 @@ func (p *Plex) GetLibrarySectionItems(ctx context.Context, section models.Librar
 			continue    // Skip items without TMDB ID
 		}
 
-		// Check if Media Item exists in DB
-		ignored, ignoredMode, sets, logErr := database.CheckIfMediaItemExists(ctx, item.TMDB_ID, item.LibraryTitle)
-		if logErr.Message != "" {
-			logAction.AppendWarning("message", "Failed to check if media item exists in database")
-			logAction.AppendWarning("error", Err)
-		}
-		if !ignored {
-			item.DBSavedSets = sets
-		} else {
-			item.IgnoredInDB = true
-			item.IgnoredMode = ignoredMode
-		}
-
-		// Update the Media Item on Server in the DB
-		updateErr := database.UpdateMediaItemOnServer(ctx, item.TMDB_ID, item.LibraryTitle, true)
-		if updateErr.Message != "" {
-			logAction.AppendWarning("update_on_server_error", updateErr.Message)
-		}
-
 		// Check if Media Item exists in MediUX with a set
 		if cache.MediuxItems.CheckItemExists(item.Type, item.TMDB_ID) {
 			item.HasMediuxSets = true
@@ -160,20 +153,11 @@ func (p *Plex) GetLibrarySectionItems(ctx context.Context, section models.Librar
 			}
 		}
 
-		cache.LibraryStore.UpdateMediaItem(section.Title, &item)
 		items = append(items, item)
 	}
 
-	// For show sections, bulk-fetch all episodes to compute LatestEpisodeAddedAt per show.
-	if section.Type == "show" && config.Current.MediaServer.EnableSortByEpisodeAddedDate {
-		latestEpAdded, fetchErr := fetchLatestEpisodeAddedAtByShow(ctx, section.ID)
-		if fetchErr.Message != "" {
-			logAction.AppendWarning("latest_episode_added_at", "Failed to bulk-fetch latest episode addedAt for shows")
-		} else {
-			for i := range items {
-				items[i].LatestEpisodeAddedAt = latestEpAdded[items[i].RatingKey]
-			}
-		}
+	for i := range items {
+		items[i].LatestEpisodeAddedAt = p.latestEpisodeAddedAtByShow[items[i].RatingKey]
 	}
 
 	return items, totalSize, logging.LogErrorInfo{}
@@ -220,30 +204,35 @@ func fetchLatestEpisodeAddedAtByShow(ctx context.Context, sectionID string) (map
 		return map[string]int64{}, logging.LogErrorInfo{}
 	}
 
-	// Second pass: fetch all episodes in one shot
-	query.Set("X-Plex-Container-Size", fmt.Sprintf("%d", totalEpisodes))
-	u.RawQuery = query.Encode()
-
-	resp, respBody, Err = makeRequest(ctx, config.Current.MediaServer, u.String(), "GET", nil)
-	if Err.Message != "" {
-		logAction.SetErrorFromInfo(Err)
-		return nil, *logAction.Error
-	}
-	resp.Body.Close()
-
-	var episodesResp PlexLibraryItemsWrapper
-	Err = httpx.DecodeResponseToJSON(ctx, respBody, &episodesResp, "Plex All Episodes Response")
-	if Err.Message != "" {
-		return nil, *logAction.Error
-	}
-
+	const pageSize = 1000
 	latest := make(map[string]int64)
-	for _, ep := range episodesResp.MediaContainer.Metadata {
-		showKey := ep.GrandParentRatingKey
-		if ep.AddedAt > latest[showKey] {
-			latest[showKey] = ep.AddedAt
-		}
-	}
+	for start := 0; start < totalEpisodes; {
+		query.Set("X-Plex-Container-Start", strconv.Itoa(start))
+		query.Set("X-Plex-Container-Size", strconv.Itoa(min(pageSize, totalEpisodes-start)))
+		u.RawQuery = query.Encode()
 
+		resp, respBody, Err = makeRequest(ctx, config.Current.MediaServer, u.String(), "GET", nil)
+		if Err.Message != "" {
+			logAction.SetErrorFromInfo(Err)
+			return nil, *logAction.Error
+		}
+		resp.Body.Close()
+
+		var episodesResp PlexLibraryItemsWrapper
+		Err = httpx.DecodeResponseToJSON(ctx, respBody, &episodesResp, "Plex Episodes Page Response")
+		if Err.Message != "" {
+			return nil, *logAction.Error
+		}
+		if len(episodesResp.MediaContainer.Metadata) == 0 {
+			break
+		}
+		for _, ep := range episodesResp.MediaContainer.Metadata {
+			showKey := ep.GrandParentRatingKey
+			if ep.AddedAt > latest[showKey] {
+				latest[showKey] = ep.AddedAt
+			}
+		}
+		start += len(episodesResp.MediaContainer.Metadata)
+	}
 	return latest, logging.LogErrorInfo{}
 }

--- a/backend/mediaserver/plex/get_library_section_items_test.go
+++ b/backend/mediaserver/plex/get_library_section_items_test.go
@@ -1,0 +1,69 @@
+package plex
+
+import (
+	"aura/config"
+	"aura/logging"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestFetchLatestEpisodeAddedAtByShowUsesBoundedPages(t *testing.T) {
+	const totalEpisodes = 2001
+	var mu sync.Mutex
+	requestedSizes := []int{}
+	requestedStarts := []int{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		size, _ := strconv.Atoi(r.URL.Query().Get("X-Plex-Container-Size"))
+		start, _ := strconv.Atoi(r.URL.Query().Get("X-Plex-Container-Start"))
+		mu.Lock()
+		requestedSizes = append(requestedSizes, size)
+		requestedStarts = append(requestedStarts, start)
+		mu.Unlock()
+
+		metadata := make([]PlexLibraryItemsMetadata, 0, size)
+		if size > 0 {
+			end := min(start+size, totalEpisodes)
+			for i := start; i < end; i++ {
+				metadata = append(metadata, PlexLibraryItemsMetadata{
+					GrandParentRatingKey: fmt.Sprintf("show-%d", i%2),
+					AddedAt:              int64(i + 1),
+				})
+			}
+		}
+		_ = json.NewEncoder(w).Encode(PlexLibraryItemsWrapper{MediaContainer: PlexLibraryItems{
+			TotalSize: totalEpisodes,
+			Metadata:  metadata,
+		}})
+	}))
+	defer server.Close()
+
+	previous := config.Current.MediaServer
+	config.Current.MediaServer.URL = server.URL
+	t.Cleanup(func() { config.Current.MediaServer = previous })
+
+	ctx, logData := logging.CreateLoggingContext(context.Background(), "test")
+	ctx = logging.WithCurrentAction(ctx, logData.AddAction("episode pages", logging.LevelDebug))
+	latest, logErr := fetchLatestEpisodeAddedAtByShow(ctx, "1")
+	if logErr.Message != "" {
+		t.Fatalf("fetchLatestEpisodeAddedAtByShow() error = %s", logErr.Message)
+	}
+	if latest["show-0"] != 2001 || latest["show-1"] != 2000 {
+		t.Fatalf("latest = %+v, want show-0=2001 and show-1=2000", latest)
+	}
+	for _, size := range requestedSizes {
+		if size > 1000 {
+			t.Fatalf("requested container sizes = %v; size %d is unbounded", requestedSizes, size)
+		}
+	}
+	wantStarts := []int{0, 0, 1000, 2000}
+	if fmt.Sprint(requestedStarts) != fmt.Sprint(wantStarts) {
+		t.Fatalf("requested starts = %v, want %v", requestedStarts, wantStarts)
+	}
+}

--- a/backend/mediaserver/plex/init.go
+++ b/backend/mediaserver/plex/init.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Plex struct {
-	Config config.Config_MediaServer
+	Config                     config.Config_MediaServer
+	latestEpisodeAddedAtByShow map[string]int64
 }
 
 func (p *Plex) GetAdminUser(ctx context.Context, msConfig config.Config_MediaServer) (userID string, Err logging.LogErrorInfo) {

--- a/backend/routing/mediaserver/get_library_section_items.go
+++ b/backend/routing/mediaserver/get_library_section_items.go
@@ -7,79 +7,255 @@ import (
 	"aura/models"
 	"aura/utils/httpx"
 	"net/http"
-	"time"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
 )
 
 type GetLibrarySectionItems_Response struct {
-	LibrarySection models.LibrarySection `json:"library_section"`
+	MediaItems        []models.MediaItem `json:"media_items"`
+	TotalItems        int                `json:"total_items"`
+	HasUpdatedAt      bool               `json:"has_updated_at"`
+	HasEpisodeAddedAt bool               `json:"has_episode_added_at"`
 }
 
+type libraryItemsQuery struct {
+	LibraryTitles []string
+	SearchTitle   string
+	SearchLibrary string
+	SearchID      string
+	SearchYear    int
+	FilterInDB    string
+	FilterIgnored string
+	FilterHasSets string
+	SortOption    string
+	SortOrder     string
+	PageNumber    int
+	ItemsPerPage  int
+}
+
+type libraryItemsPage struct {
+	Items             []models.MediaItem
+	TotalItems        int
+	HasUpdatedAt      bool
+	HasEpisodeAddedAt bool
+}
+
+var refreshLibraryCache = mediaserver.GetAllLibrarySectionsAndItems
+
 // GetLibrarySectionItems godoc
-// @Summary      Get Library Section Items
-// @Description  Retrieve items from a specific library section in the media server. This endpoint accepts query parameters to identify the library section and pagination options, and returns the items contained within that library section, allowing clients to display the media items available in the selected library section.
+// @Summary      Get Library Items
+// @Description  Retrieve one filtered, sorted page from the warmed media-server library cache.
 // @Tags         MediaServer
 // @Accept       json
 // @Produce      json
-// @Param        section_id query string true "Library Section ID"
-// @Param        section_title query string true "Library Section Title"
-// @Param        section_type query string true "Library Section Type"
-// @Param        section_start_index query string true "Start Index for Pagination"
-// @Security 	 BearerAuth
+// @Param        library_titles query string false "Library Title (repeat for multiple)"
+// @Param        search_title query string false "Title search"
+// @Param        search_library query string false "Library search"
+// @Param        search_id query string false "Exact TMDB ID search"
+// @Param        search_year query int false "Release year"
+// @Param        filter_in_db query string false "Database filter (inDB or notInDB)"
+// @Param        filter_ignored query string false "Ignore status or mode"
+// @Param        filter_has_sets query string false "MediUX set availability"
+// @Param        sort_option query string false "Sort option"
+// @Param        sort_order query string false "Sort order (asc or desc)"
+// @Param        page_number query int false "Page number"
+// @Param        items_per_page query int false "Items per page (maximum 1000)"
+// @Param        refresh query bool false "Refresh server cache before reading"
+// @Security     BearerAuth
 // @Failure      401  {object}  httpx.UnauthorizedResponse "Unauthorized (only when Auth.Enabled=true)"
 // @Success      200  {object}  httpx.JSONResponse{data=GetLibrarySectionItems_Response}
-// @Failure	  500  {object}  httpx.JSONResponse "Internal Server Error"
+// @Failure      500  {object}  httpx.JSONResponse "Internal Server Error"
 // @Router       /api/mediaserver/library/items [get]
 func GetLibrarySectionItems(w http.ResponseWriter, r *http.Request) {
 	ctx, ld := logging.CreateLoggingContext(r.Context(), r.URL.Path)
-	logAction := ld.AddAction("Get Library Section Items", logging.LevelInfo)
+	logAction := ld.AddAction("Get Library Items", logging.LevelInfo)
 	ctx = logging.WithCurrentAction(ctx, logAction)
-	var response GetLibrarySectionItems_Response
 
-	actionGetQueryParams := logAction.AddSubAction("Get all query params", logging.LevelTrace)
-	// Get the following information from the URL
-	// Section ID
-	// Section Title
-	// Section Type
-	// Item Start Index
-	sectionID := r.URL.Query().Get("section_id")
-	sectionTitle := r.URL.Query().Get("section_title")
-	sectionType := r.URL.Query().Get("section_type")
-	sectionStartIndex := r.URL.Query().Get("section_start_index")
-	sectionLimit := r.URL.Query().Get("limit")
-	if sectionLimit == "" {
-		sectionLimit = "500"
-	}
-
-	// Validate the section ID, title, type, and start index
-	if sectionID == "" || sectionTitle == "" || sectionType == "" || sectionStartIndex == "" {
-		actionGetQueryParams.SetError("Missing Query Parameters", "One or more required query parameters are missing",
-			map[string]any{
-				"section_id":          sectionID,
-				"section_title":       sectionTitle,
-				"section_type":        sectionType,
-				"section_start_index": sectionStartIndex,
-			})
-		httpx.SendResponse(w, ld, response)
-		return
-	}
-	actionGetQueryParams.Complete()
-
-	// Fetch the section items from the media server
-	response.LibrarySection = models.LibrarySection{
-		LibrarySectionBase: models.LibrarySectionBase{
-			ID:    sectionID,
-			Title: sectionTitle,
-			Type:  sectionType,
-		},
-	}
-	mediaItems, totalSize, Err := mediaserver.GetLibrarySectionItems(ctx, response.LibrarySection, sectionStartIndex, sectionLimit)
-	if Err.Message != "" {
-		httpx.SendResponse(w, ld, response)
+	forceRefresh := strings.EqualFold(r.URL.Query().Get("refresh"), "true")
+	if (forceRefresh || cache.LibraryStore.LastFullUpdate == 0) && !refreshLibraryCache(ctx, forceRefresh) {
+		logAction.SetError("Failed to refresh library items", "Retry after the media server is available", nil)
+		httpx.SendResponse(w, ld, GetLibrarySectionItems_Response{})
 		return
 	}
 
-	response.LibrarySection.MediaItems = mediaItems
-	response.LibrarySection.TotalSize = totalSize
-	cache.LibraryStore.LastFullUpdate = time.Now().Unix()
+	query := libraryItemsQuery{
+		SearchTitle:   r.URL.Query().Get("search_title"),
+		SearchLibrary: r.URL.Query().Get("search_library"),
+		SearchID:      r.URL.Query().Get("search_id"),
+		FilterInDB:    r.URL.Query().Get("filter_in_db"),
+		FilterIgnored: r.URL.Query().Get("filter_ignored"),
+		FilterHasSets: r.URL.Query().Get("filter_has_sets"),
+		SortOption:    r.URL.Query().Get("sort_option"),
+		SortOrder:     r.URL.Query().Get("sort_order"),
+		SearchYear:    positiveInt(r.URL.Query().Get("search_year"), 0),
+		PageNumber:    positiveInt(r.URL.Query().Get("page_number"), 1),
+		ItemsPerPage:  positiveInt(r.URL.Query().Get("items_per_page"), 20),
+	}
+	query.LibraryTitles = r.URL.Query()["library_titles[]"]
+	if len(query.LibraryTitles) == 0 {
+		query.LibraryTitles = r.URL.Query()["library_titles"]
+	}
+	if query.ItemsPerPage > 1000 {
+		query.ItemsPerPage = 1000
+	}
+
+	page := filterSortAndPaginateLibraryItems(cache.LibraryStore.GetAllMediaItems(), query)
+	response := GetLibrarySectionItems_Response{
+		MediaItems:        page.Items,
+		TotalItems:        page.TotalItems,
+		HasUpdatedAt:      page.HasUpdatedAt,
+		HasEpisodeAddedAt: page.HasEpisodeAddedAt,
+	}
 	httpx.SendResponse(w, ld, response)
+}
+
+func positiveInt(value string, fallback int) int {
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func filterSortAndPaginateLibraryItems(items []models.MediaItem, query libraryItemsQuery) libraryItemsPage {
+	selectedLibraries := make(map[string]struct{}, len(query.LibraryTitles))
+	for _, title := range query.LibraryTitles {
+		selectedLibraries[title] = struct{}{}
+	}
+
+	filtered := make([]models.MediaItem, 0, len(items))
+	for _, item := range items {
+		if len(selectedLibraries) > 0 {
+			if _, selected := selectedLibraries[item.LibraryTitle]; !selected {
+				continue
+			}
+		}
+		if query.SearchYear > 0 && item.Year != query.SearchYear {
+			continue
+		}
+		if query.SearchLibrary != "" && !strings.Contains(normalizeLibrarySearch(item.LibraryTitle), normalizeLibrarySearch(query.SearchLibrary)) {
+			continue
+		}
+		if query.SearchID != "" && item.TMDB_ID != query.SearchID {
+			continue
+		}
+		if !titleMatches(item.Title, query.SearchTitle) {
+			continue
+		}
+		if query.FilterInDB == "notInDB" && len(item.DBSavedSets) > 0 {
+			continue
+		}
+		if query.FilterInDB == "inDB" && len(item.DBSavedSets) == 0 {
+			continue
+		}
+		if !ignoredMatches(item, query.FilterIgnored) {
+			continue
+		}
+		if query.FilterHasSets == "hasSetsAvailable" && !item.HasMediuxSets {
+			continue
+		}
+		if query.FilterHasSets == "noSetsAvailable" && item.HasMediuxSets {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		cmp := compareLibraryItems(filtered[i], filtered[j], query.SortOption)
+		if strings.EqualFold(query.SortOrder, "desc") {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+
+	page := libraryItemsPage{TotalItems: len(filtered), Items: []models.MediaItem{}}
+	for _, item := range filtered {
+		page.HasUpdatedAt = page.HasUpdatedAt || item.UpdatedAt > 0
+		page.HasEpisodeAddedAt = page.HasEpisodeAddedAt || item.LatestEpisodeAddedAt > 0
+	}
+	start := (query.PageNumber - 1) * query.ItemsPerPage
+	if start >= len(filtered) {
+		return page
+	}
+	end := min(start+query.ItemsPerPage, len(filtered))
+	page.Items = filtered[start:end]
+	return page
+}
+
+func compareLibraryItems(a, b models.MediaItem, option string) int {
+	switch option {
+	case "title":
+		return strings.Compare(strings.ToLower(a.Title), strings.ToLower(b.Title))
+	case "dateUpdated":
+		return intCompare(a.UpdatedAt, b.UpdatedAt)
+	case "dateReleased":
+		return intCompare(a.ReleasedAt, b.ReleasedAt)
+	case "newEpisodeAdded":
+		aDate, bDate := a.LatestEpisodeAddedAt, b.LatestEpisodeAddedAt
+		if aDate == 0 {
+			aDate = a.AddedAt
+		}
+		if bDate == 0 {
+			bDate = b.AddedAt
+		}
+		return intCompare(aDate, bDate)
+	default:
+		return intCompare(a.AddedAt, b.AddedAt)
+	}
+}
+
+func intCompare(a, b int64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func ignoredMatches(item models.MediaItem, filter string) bool {
+	switch filter {
+	case "ignored":
+		return item.IgnoredInDB
+	case "not_ignored":
+		return !item.IgnoredInDB
+	case "always", "until-set-available", "until-new-set-available":
+		return item.IgnoredInDB && item.IgnoredMode == filter
+	default:
+		return true
+	}
+}
+
+func titleMatches(title, query string) bool {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return true
+	}
+	normalizedTitle := normalizeLibrarySearch(title)
+	quotePairs := [][2]string{{`"`, `"`}, {`'`, `'`}, {`‘`, `’`}, {`“`, `”`}}
+	for _, pair := range quotePairs {
+		if strings.HasPrefix(query, pair[0]) && strings.HasSuffix(query, pair[1]) {
+			unquoted := strings.TrimSuffix(strings.TrimPrefix(query, pair[0]), pair[1])
+			return normalizedTitle == normalizeLibrarySearch(unquoted)
+		}
+	}
+	for _, word := range strings.Fields(normalizeLibrarySearch(query)) {
+		if !strings.Contains(normalizedTitle, word) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeLibrarySearch(value string) string {
+	var normalized strings.Builder
+	for _, r := range strings.ToLower(value) {
+		if r == '_' || r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || unicode.IsSpace(r) {
+			normalized.WriteRune(r)
+		}
+	}
+	return normalized.String()
 }

--- a/backend/routing/mediaserver/get_library_section_items_test.go
+++ b/backend/routing/mediaserver/get_library_section_items_test.go
@@ -1,0 +1,134 @@
+package routes_ms
+
+import (
+	"aura/cache"
+	"aura/models"
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFilterSortAndPaginateLibraryItems(t *testing.T) {
+	items := []models.MediaItem{
+		{TMDB_ID: "1", LibraryTitle: "Shows", Type: "show", Title: "Alpha Show", Year: 2020, AddedAt: 20, LatestEpisodeAddedAt: 25, HasMediuxSets: true},
+		{TMDB_ID: "2", LibraryTitle: "Movies", Type: "movie", Title: "Beta Movie", Year: 2021, AddedAt: 30, DBSavedSets: []models.DBSavedSet{{ID: "set-1"}}},
+		{TMDB_ID: "3", LibraryTitle: "Movies", Type: "movie", Title: "Gamma Movie", Year: 2021, AddedAt: 10, IgnoredInDB: true, IgnoredMode: "always"},
+	}
+
+	page := filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		LibraryTitles: []string{"Movies"},
+		SearchTitle:   "movie",
+		SearchYear:    2021,
+		FilterInDB:    "notInDB",
+		FilterIgnored: "not_ignored",
+		SortOption:    "dateAdded",
+		SortOrder:     "desc",
+		PageNumber:    1,
+		ItemsPerPage:  1,
+	})
+
+	if page.TotalItems != 0 {
+		t.Fatalf("TotalItems = %d, want 0 after combined filters", page.TotalItems)
+	}
+
+	page = filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		LibraryTitles: []string{"Movies"},
+		SearchTitle:   "movie",
+		SearchYear:    2021,
+		SortOption:    "dateAdded",
+		SortOrder:     "desc",
+		PageNumber:    1,
+		ItemsPerPage:  1,
+	})
+	if page.TotalItems != 2 || len(page.Items) != 1 || page.Items[0].TMDB_ID != "2" {
+		t.Fatalf("page = %+v, want first of 2 filtered items to be TMDB 2", page)
+	}
+	if page.HasUpdatedAt || page.HasEpisodeAddedAt {
+		t.Fatalf("capability flags = (%v, %v), want no dates in filtered movie results", page.HasUpdatedAt, page.HasEpisodeAddedAt)
+	}
+
+	page = filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		LibraryTitles: []string{"Shows"}, PageNumber: 1, ItemsPerPage: 20,
+	})
+	if page.HasUpdatedAt || !page.HasEpisodeAddedAt {
+		t.Fatalf("show capability flags = (%v, %v), want episode dates only", page.HasUpdatedAt, page.HasEpisodeAddedAt)
+	}
+}
+
+func TestFilterSortAndPaginateLibraryItemsPreservesTitleOrderAndPageBounds(t *testing.T) {
+	items := []models.MediaItem{
+		{TMDB_ID: "1", Title: "beta"},
+		{TMDB_ID: "2", Title: "Alpha"},
+		{TMDB_ID: "3", Title: "charlie"},
+	}
+
+	page := filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		SortOption: "title", SortOrder: "asc", PageNumber: 2, ItemsPerPage: 1,
+	})
+	if page.TotalItems != 3 || len(page.Items) != 1 || page.Items[0].Title != "beta" {
+		t.Fatalf("second title page = %+v, want beta from 3 case-insensitively sorted items", page)
+	}
+
+	page = filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		SortOption: "title", SortOrder: "asc", PageNumber: 4, ItemsPerPage: 1,
+	})
+	if page.TotalItems != 3 || len(page.Items) != 0 {
+		t.Fatalf("page beyond filtered items = %+v, want empty page with total 3", page)
+	}
+}
+
+func TestGetLibrarySectionItemsRefreshesColdCacheAndReportsFailure(t *testing.T) {
+	previousCache := cache.LibraryStore
+	previousRefresh := refreshLibraryCache
+	t.Cleanup(func() {
+		cache.LibraryStore = previousCache
+		refreshLibraryCache = previousRefresh
+	})
+	cache.LibraryStore = cache.Cache_NewLibraryCache()
+
+	refreshCalls := 0
+	refreshLibraryCache = func(_ context.Context, force bool) bool {
+		refreshCalls++
+		if force {
+			t.Fatal("cold-cache retry must not force a second full refresh")
+		}
+		return false
+	}
+
+	response := httptest.NewRecorder()
+	GetLibrarySectionItems(response, httptest.NewRequest("GET", "/api/mediaserver/library/items", nil))
+	if refreshCalls != 1 {
+		t.Fatalf("cold-cache refresh calls = %d, want 1", refreshCalls)
+	}
+	if !strings.Contains(response.Body.String(), "Failed to refresh library items") {
+		t.Fatalf("cold-cache response = %s, want explicit refresh error", response.Body.String())
+	}
+}
+
+func TestFilterSortAndPaginateLibraryItemsPreservesSearchSemantics(t *testing.T) {
+	items := []models.MediaItem{
+		{TMDB_ID: "10", LibraryTitle: "4K Movies", Title: "Spider-Man: Homecoming", Year: 2017},
+		{TMDB_ID: "11", LibraryTitle: "Movies", Title: "Spider Man No Way Home", Year: 2021},
+	}
+
+	page := filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		SearchTitle:   "spider home",
+		SearchLibrary: "4k",
+		SearchID:      "10",
+		PageNumber:    1,
+		ItemsPerPage:  20,
+	})
+	if page.TotalItems != 1 || page.Items[0].TMDB_ID != "10" {
+		t.Fatalf("search page = %+v, want TMDB 10", page)
+	}
+
+	page = filterSortAndPaginateLibraryItems(items, libraryItemsQuery{
+		SearchTitle:  `“Spider-Man: Homecoming”`,
+		PageNumber:   1,
+		ItemsPerPage: 20,
+	})
+	if page.TotalItems != 1 || page.Items[0].TMDB_ID != "10" {
+		t.Fatalf("exact normalized-title search page = %+v, want TMDB 10", page)
+	}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "format": "prettier -l --write \"**/*.{ts,tsx,md,json,js,jsx}\"",
     "format:check": "prettier -l \"**/*.{ts,tsx,md,json,js,jsx}\"",
     "typecheck": "tsc --noEmit",
+    "test": "node --no-warnings --test --experimental-strip-types src/services/mediaserver/collect-library-pages.test.ts",
     "audit": "npm audit",
     "audit:fix": "npm audit fix"
   },

--- a/frontend/src/app/media-item/page.tsx
+++ b/frontend/src/app/media-item/page.tsx
@@ -2,6 +2,7 @@
 
 import { makePlural } from "@/helper/make_plural";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import { GetCompleteLibrarySection } from "@/services/mediaserver/get-library-section-items";
 import { GetMediaItemDetails } from "@/services/mediaserver/get-media-item-details";
 import {
   ArrowDown01,
@@ -45,12 +46,14 @@ import { TYPE_MEDIA_ITEM_TYPE_OPTIONS } from "@/types/ui-options";
 const MediaItemPage = () => {
   const router = useRouter();
   const isMounted = useRef(false);
+  const membershipFetchRatingKey = useRef("");
 
   // Partial Media Item States
   const partialMediaItem = useMediaStore((state) => state.mediaItem);
 
   // Library Sections States (From Library Section Store)
   const librarySectionsMap = useLibrarySectionsStore((state) => state.sections);
+  const setLibrarySection = useLibrarySectionsStore((state) => state.setSection);
   const librarySectionsHasHydrated = useLibrarySectionsStore((state) => state.hasHydrated);
 
   // Response Loading State
@@ -164,12 +167,38 @@ const MediaItemPage = () => {
     if (mediaItem && mediaItem.rating_key === partialMediaItem.rating_key) return;
     if (hasError) return;
     if (responseLoading === true && mediaItem !== null) return;
+    if (membershipFetchRatingKey.current === partialMediaItem.rating_key) return;
+    membershipFetchRatingKey.current = partialMediaItem.rating_key;
 
     setError(null);
 
     const fetchMediaItem = async () => {
       try {
         setResponseLoading(true);
+        setLoadingMessage(`Loading ${partialMediaItem.library_title} membership...`);
+
+        const loadedSectionsMap = { ...librarySectionsMap };
+        const sectionsMissingMembership = Object.values(librarySectionsMap).filter(
+          (section) =>
+            (section.title === partialMediaItem.library_title || section.type === partialMediaItem.type) &&
+            section.media_items.length === 0
+        );
+        for (const section of sectionsMissingMembership) {
+          const membershipResponse = await GetCompleteLibrarySection(section.title);
+          if (membershipResponse.status === "error" || !membershipResponse.data) {
+            setError(membershipResponse);
+            setHasError(true);
+            return;
+          }
+          const loadedSection = {
+            ...section,
+            total_size: membershipResponse.data.total_items,
+            media_items: membershipResponse.data.media_items,
+          };
+          loadedSectionsMap[section.title] = loadedSection;
+          setLibrarySection(section.title, loadedSection);
+        }
+
         setLoadingMessage(`Loading Details for ${partialMediaItem.title}...`);
         log(
           "INFO",
@@ -234,7 +263,7 @@ const MediaItemPage = () => {
         }
 
         // Find if this item exists in other sections
-        const otherSections = Object.values(librarySectionsMap).filter(
+        const otherSections = Object.values(loadedSectionsMap).filter(
           (s) => s.type === mediaItemResponse.type && s.title !== mediaItemResponse.library_title
         );
 
@@ -309,7 +338,15 @@ const MediaItemPage = () => {
     };
 
     fetchMediaItem();
-  }, [librarySectionsHasHydrated, hasError, responseLoading, partialMediaItem, librarySectionsMap, mediaItem]);
+  }, [
+    librarySectionsHasHydrated,
+    hasError,
+    responseLoading,
+    partialMediaItem,
+    librarySectionsMap,
+    mediaItem,
+    setLibrarySection,
+  ]);
 
   // 3. Filtering logic for poster sets
   useEffect(() => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { ReturnErrorMessage } from "@/services/api-error-return";
 import { GetLibrarySectionItems } from "@/services/mediaserver/get-library-section-items";
 import { GetLibrarySections } from "@/services/mediaserver/get-library-sections";
-import { Loader } from "lucide-react";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -14,41 +13,30 @@ import HomeMediaItemCard from "@/components/shared/media-item-card";
 import { HomeMediaItemCardSkeletonGrid } from "@/components/shared/media-item-card-skeleton";
 import { RefreshButton } from "@/components/shared/refresh-button";
 import { ResponsiveGrid } from "@/components/shared/responsive-grid";
-import { Label } from "@/components/ui/label";
-import { Progress } from "@/components/ui/progress";
 
-import { cn } from "@/lib/cn";
 import { log } from "@/lib/logger";
 import { MAX_CACHE_DURATION, useLibrarySectionsStore } from "@/lib/stores/global-store-library-sections";
 import { useSearchQueryStore } from "@/lib/stores/global-store-search-query";
 import { useHomePageStore } from "@/lib/stores/page-store-home";
 
-import { searchItems } from "@/hooks/search-query";
+import { extractInfoFromSearchQuery } from "@/hooks/search-query";
 
 import type { APIResponse } from "@/types/api/api-response";
 import type { LibrarySection } from "@/types/media-and-posters/media-item-and-library";
 
 export default function Home() {
-  const isMounted = useRef(false);
-
-  // -------------------------------
-  // States
-  // -------------------------------
-  // Search
+  const requestID = useRef(0);
   const { searchQuery } = useSearchQueryStore();
   const prevSearchQuery = useRef(searchQuery);
 
-  // Loading & Error
   const [error, setError] = useState<APIResponse<unknown> | null>(null);
-  const [fullyLoaded, setFullyLoaded] = useState<boolean>(false);
-
-  // Library sections & progress
+  const [loading, setLoading] = useState(true);
+  const [sectionsLoaded, setSectionsLoaded] = useState(false);
   const [librarySections, setLibrarySections] = useState<LibrarySection[]>([]);
-  const [sectionProgress, setSectionProgress] = useState<{
-    [key: string]: { loaded: number; total: number };
-  }>({});
+  const [totalItems, setTotalItems] = useState(0);
+  const [hasUpdatedAt, setHasUpdatedAt] = useState(false);
+  const [hasEpisodeAddedAt, setHasEpisodeAddedAt] = useState(false);
 
-  // State to track the HomePageStore values
   const {
     filteredLibraries,
     setFilteredLibraries,
@@ -72,34 +60,8 @@ export default function Home() {
 
   const { sections, setSections, timestamp } = useLibrarySectionsStore();
   const hasHydrated = useLibrarySectionsStore((state) => state.hasHydrated);
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  // -------------------------------
-  // Derived values
-  // -------------------------------
-  const paginatedItems = filteredAndSortedMediaItems.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
-  const totalPages = Math.ceil(filteredAndSortedMediaItems.length / itemsPerPage);
-
-  const dedupeMediaItemsByTmdbId = useCallback((items: LibrarySection["media_items"]) => {
-    const seenTmdbIds = new Set<string>();
-    return items.filter((item) => {
-      if (item.tmdb_id === null || item.tmdb_id === undefined || item.tmdb_id === "") {
-        return true;
-      }
-
-      const tmdbId = String(item.tmdb_id);
-      if (seenTmdbIds.has(tmdbId)) {
-        return false;
-      }
-
-      seenTmdbIds.add(tmdbId);
-      return true;
-    });
-  }, []);
-
-  // Set sortOption to "dateAdded" if its not title or dateUpdated or dateAdded or dateReleased or newEpisodeAdded
   useEffect(() => {
     if (
       sortOption !== "title" &&
@@ -113,127 +75,111 @@ export default function Home() {
     }
   }, [sortOption, setSortOption, setSortOrder]);
 
-  // Fetch data from cache or API
-  const getMediaItems = useCallback(
-    async (useCache: boolean) => {
-      if (isMounted.current && useCache) return;
-      setSectionProgress({});
-      setLibrarySections([]);
-      setError(null);
-      setFullyLoaded(false);
-      try {
-        // Check if we want to use cache
-        if (useCache) {
-          const isCacheAgeValid = timestamp ? Date.now() - timestamp < MAX_CACHE_DURATION : false;
-          const cacheContainsSectionsAndTimestamp = sections && timestamp && Object.keys(sections).length > 0;
-          log("INFO", "Home Page", "Library Cache", "Attempting to load sections from cache", {
-            "Current Time": Date.now(),
-            "Cache Timestamp": timestamp,
-            "Cache Age Max (ms)": MAX_CACHE_DURATION,
-            "Cache Age (ms)": timestamp ? Date.now() - timestamp : "N/A",
-            "Is Cache Age Valid": isCacheAgeValid,
-            "Cache Contains Sections & Timestamp": cacheContainsSectionsAndTimestamp,
-          });
-          if (cacheContainsSectionsAndTimestamp) {
-            if (isCacheAgeValid) {
-              setLibrarySections(Object.values(sections));
-              setFullyLoaded(true);
-              log("INFO", "Home Page", "Library Cache", "Using cached sections", sections);
-              return;
-            } else {
-              log("WARN", "Home Page", "Library Cache", "Cache expired, fetching fresh data");
-            }
-          } else {
-            log("WARN", "Home Page", "Library Cache", "No valid cache found, fetching fresh data");
-          }
-        }
+  useEffect(() => {
+    if (!hasHydrated || sectionsLoaded) return;
 
-        // Fetch fresh data
-        const response = await GetLibrarySections();
-        if (response.status === "error") {
-          setError(response);
-          setFullyLoaded(true);
-          return;
-        }
-
-        const fetchedSections = response.data?.sections || [];
-        if (!fetchedSections || fetchedSections.length === 0) {
-          setError(ReturnErrorMessage<unknown>(new Error("No sections found, please check the logs.")));
-          return;
-        }
-
-        // Initialize each section's MediaItems to an empty array
-        fetchedSections.forEach((section) => (section.media_items = []));
-        setLibrarySections(fetchedSections.slice().sort((a, b) => a.title.localeCompare(b.title)));
-
-        // Process each section concurrently
-        await Promise.all(
-          fetchedSections.map(async (section) => {
-            let itemsFetched = 0;
-            let totalSize = Infinity;
-            let allItems: LibrarySection["media_items"] = [];
-
-            while (itemsFetched < totalSize) {
-              const itemsResponse = await GetLibrarySectionItems(section, itemsFetched);
-              if (itemsResponse.status === "error") {
-                setError(itemsResponse);
-                return;
-              }
-
-              const data = itemsResponse.data?.library_section;
-              const items = data?.media_items || [];
-
-              allItems = allItems.concat(items);
-              if (totalSize === Infinity) {
-                totalSize = data?.total_size ?? 0;
-              }
-              itemsFetched += items.length;
-              setSectionProgress((prev) => ({
-                ...prev,
-                [section.id]: {
-                  loaded: itemsFetched,
-                  total: totalSize,
-                },
-              }));
-              if (items.length === 0) {
-                break;
-              }
-            }
-            const deduplicatedItems = dedupeMediaItemsByTmdbId(allItems);
-
-            section.media_items = deduplicatedItems;
-            section.total_size = deduplicatedItems.length;
-          })
-        );
-
-        // Build the sections object for the store
-        const sectionsObj = fetchedSections.reduce<Record<string, LibrarySection>>((acc, section) => {
-          acc[section.title] = section;
-          return acc;
-        }, {});
-        const librarySections = fetchedSections.slice().sort((a, b) => a.title.localeCompare(b.title));
-        // Store in zustand and update timestamp
-        setSections(sectionsObj, Date.now());
-        setFullyLoaded(true);
-        log("INFO", "Home Page", "", "Sections fetched successfully from server", {
-          "Library Sections": librarySections,
-          Sections: sectionsObj,
-        });
-        setLibrarySections(librarySections);
-      } catch (error) {
-        setError(ReturnErrorMessage<unknown>(error));
-      } finally {
-        isMounted.current = false;
+    const loadSections = async () => {
+      const cachedSections = Object.values(sections);
+      const cacheValid = Boolean(timestamp && Date.now() - timestamp < MAX_CACHE_DURATION && cachedSections.length > 0);
+      if (cacheValid) {
+        const summaries = cachedSections.map((section) => ({ ...section, media_items: [] }));
+        setLibrarySections(summaries.sort((a, b) => a.title.localeCompare(b.title)));
+        setSectionsLoaded(true);
+        return;
       }
+
+      const response = await GetLibrarySections();
+      if (response.status === "error") {
+        setError(response);
+        setLoading(false);
+        return;
+      }
+      const fetchedSections = (response.data?.sections ?? [])
+        .map((section) => ({ ...section, media_items: [] }))
+        .sort((a, b) => a.title.localeCompare(b.title));
+      if (fetchedSections.length === 0) {
+        setError(ReturnErrorMessage<unknown>(new Error("No sections found, please check the logs.")));
+        setLoading(false);
+        return;
+      }
+      setLibrarySections(fetchedSections);
+      setSections(
+        Object.fromEntries(
+          fetchedSections.map((section) => [
+            section.title,
+            { ...section, media_items: sections[section.title]?.media_items ?? [] },
+          ])
+        ),
+        Date.now()
+      );
+      setSectionsLoaded(true);
+    };
+
+    void loadSections();
+  }, [hasHydrated, sections, sectionsLoaded, setSections, timestamp]);
+
+  const fetchPage = useCallback(
+    async (refresh = false) => {
+      if (!sectionsLoaded) return;
+      const thisRequest = ++requestID.current;
+      setLoading(true);
+      setError(null);
+      const { searchTMDBID, searchLibrary, searchYear, searchTitle } = extractInfoFromSearchQuery(searchQuery);
+      const response = await GetLibrarySectionItems({
+        libraryTitles: filteredLibraries,
+        searchTitle,
+        searchLibrary,
+        searchID: searchTMDBID,
+        searchYear,
+        filterInDB,
+        filterIgnored,
+        filterHasSets: hasSetsAvailableFilter,
+        sortOption,
+        sortOrder,
+        pageNumber: currentPage,
+        itemsPerPage,
+        refresh,
+      });
+      if (thisRequest !== requestID.current) return;
+      if (response.status === "error") {
+        setError(response);
+        setLoading(false);
+        return;
+      }
+
+      const data = response.data;
+      const nextTotal = data?.total_items ?? 0;
+      const nextTotalPages = Math.ceil(nextTotal / itemsPerPage);
+      if (nextTotalPages > 0 && currentPage > nextTotalPages) {
+        setCurrentPage(nextTotalPages);
+        return;
+      }
+      setFilteredAndSortedMediaItems(data?.media_items ?? []);
+      setTotalItems(nextTotal);
+      setHasUpdatedAt(data?.has_updated_at ?? false);
+      setHasEpisodeAddedAt(data?.has_episode_added_at ?? false);
+      setLoading(false);
+      log("INFO", "Home Page", "Library Page", `Loaded ${data?.media_items.length ?? 0} of ${nextTotal} items`);
     },
-    [dedupeMediaItemsByTmdbId, sections, setSections, timestamp]
+    [
+      currentPage,
+      filterIgnored,
+      filterInDB,
+      filteredLibraries,
+      hasSetsAvailableFilter,
+      itemsPerPage,
+      searchQuery,
+      sectionsLoaded,
+      setCurrentPage,
+      setFilteredAndSortedMediaItems,
+      sortOption,
+      sortOrder,
+    ]
   );
 
   useEffect(() => {
-    if (!hasHydrated) return;
-    getMediaItems(true);
-    isMounted.current = true;
-  }, [getMediaItems, hasHydrated]);
+    void fetchPage();
+  }, [fetchPage]);
 
   useEffect(() => {
     if (searchQuery !== prevSearchQuery.current) {
@@ -242,199 +188,41 @@ export default function Home() {
     }
   }, [searchQuery, setCurrentPage]);
 
-  // Filter items based on the search query
-  useEffect(() => {
-    const filterAndSortItems = async () => {
-      let items = librarySections.flatMap((section) => section.media_items || []);
-
-      // Sort items by Title
-      if (sortOption === "title") {
-        if (sortOrder === "asc") {
-          items.sort((a, b) => a.title.localeCompare(b.title));
-        } else if (sortOrder === "desc") {
-          items.sort((a, b) => b.title.localeCompare(a.title));
-        }
-      } else if (sortOption === "dateUpdated") {
-        if (sortOrder === "asc") {
-          items.sort((a, b) => (a.updated_at ?? 0) - (b.updated_at ?? 0));
-        } else if (sortOrder === "desc") {
-          items.sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0));
-        }
-      } else if (sortOption === "dateAdded") {
-        if (sortOrder === "asc") {
-          items.sort((a, b) => (a.added_at ?? 0) - (b.added_at ?? 0));
-        } else if (sortOrder === "desc") {
-          items.sort((a, b) => (b.added_at ?? 0) - (a.added_at ?? 0));
-        }
-      } else if (sortOption === "dateReleased") {
-        if (sortOrder === "asc") {
-          items.sort((a, b) => (a.released_at ?? 0) - (b.released_at ?? 0));
-        } else if (sortOrder === "desc") {
-          items.sort((a, b) => (b.released_at ?? 0) - (a.released_at ?? 0));
-        }
-      } else if (sortOption === "newEpisodeAdded") {
-        // Sort shows by the most recently added episode; movies fall back to their own added_at.
-        const getLatestEpisodeAdded = (item: (typeof items)[number]) =>
-          item.latest_episode_added_at ?? item.added_at ?? 0;
-        if (sortOrder === "asc") {
-          items.sort((a, b) => getLatestEpisodeAdded(a) - getLatestEpisodeAdded(b));
-        } else {
-          items.sort((a, b) => getLatestEpisodeAdded(b) - getLatestEpisodeAdded(a));
-        }
-      }
-
-      // Filter by selected libraries
-      if (filteredLibraries.length > 0) {
-        items = items.filter((item) => filteredLibraries.includes(item.library_title));
-      }
-
-      // Filter out items already in the DB
-      if (filterInDB === "notInDB") {
-        items = items.filter((item) => !item.db_saved_sets || item.db_saved_sets.length === 0);
-      } else if (filterInDB === "inDB") {
-        items = items.filter((item) => item.db_saved_sets && item.db_saved_sets.length > 0);
-      }
-
-      // Filter out items that are ignored
-      if (filterIgnored === "always") {
-        items = items.filter((item) => item.ignored_in_db && item.ignored_mode === "always");
-      } else if (filterIgnored === "until-set-available") {
-        items = items.filter((item) => item.ignored_in_db && item.ignored_mode === "until-set-available");
-      } else if (filterIgnored === "until-new-set-available") {
-        items = items.filter((item) => item.ignored_in_db && item.ignored_mode === "until-new-set-available");
-      } else if (filterIgnored === "ignored") {
-        items = items.filter((item) => item.ignored_in_db);
-      } else if (filterIgnored === "not_ignored") {
-        items = items.filter((item) => !item.ignored_in_db);
-      }
-
-      // Filter by sets availability
-      if (hasSetsAvailableFilter === "hasSetsAvailable") {
-        items = items.filter((item) => item.has_mediux_sets);
-      } else if (hasSetsAvailableFilter === "noSetsAvailable") {
-        items = items.filter((item) => !item.has_mediux_sets);
-      }
-
-      // Filter out items by search
-      const filteredItems = searchItems(items, searchQuery, {
-        getTitle: (item) => item.title,
-        getYear: (item) => item.year,
-        getLibraryTitle: (item) => item.library_title,
-        getID: (item) => item.tmdb_id || item.rating_key,
-      });
-
-      // Store the filtered items in local storage
-      setFilteredAndSortedMediaItems(filteredItems);
-    };
-    filterAndSortItems();
-  }, [
-    librarySections,
-    filteredLibraries,
-    setFilteredAndSortedMediaItems,
-    searchQuery,
-    filterInDB,
-    filterIgnored,
-    sortOption,
-    sortOrder,
-    hasSetsAvailableFilter,
-  ]);
-
   if (error) {
     return <ErrorMessage error={error} />;
   }
 
-  const hasUpdatedAt = paginatedItems.some(
-    (item) => item.updated_at !== undefined && item.updated_at !== null && item.updated_at > 0
-  );
-  const hasEpisodeAddedAt = paginatedItems.some(
-    (item) =>
-      item.latest_episode_added_at !== undefined &&
-      item.latest_episode_added_at !== null &&
-      item.latest_episode_added_at > 0
-  );
-
   return (
     <div className="flex items-center justify-center">
-      {!fullyLoaded && librarySections.length > 0 ? (
-        <div className="min-h-screen pb-4 px-4 sm:px-10 w-full">
-          {/* Progress bars */}
-          <div className="flex flex-col items-center w-full px-4">
-            {[...librarySections]
-              .sort((a, b) => {
-                const progressA = sectionProgress[a.id];
-                const percentA =
-                  progressA && progressA.total > 0 ? Math.min((progressA.loaded / progressA.total) * 100, 100) : 0;
-                const progressB = sectionProgress[b.id];
-                const percentB =
-                  progressB && progressB.total > 0 ? Math.min((progressB.loaded / progressB.total) * 100, 100) : 0;
-                return percentB - percentA; // Sort descending
-              })
-              .map((section) => {
-                const progressInfo = sectionProgress[section.id];
-                const percentage =
-                  progressInfo && progressInfo.total > 0
-                    ? Math.min((progressInfo.loaded / progressInfo.total) * 100, 100)
-                    : 0;
-
-                return (
-                  <div key={section.id} className="mb-6 w-full max-w-xl flex flex-col items-center px-2">
-                    <Label className="text-lg font-semibold text-center mb-2">Loading {section.title}</Label>
-                    <Progress
-                      value={percentage}
-                      className={cn(
-                        "w-full max-w-lg h-2 rounded-md overflow-hidden",
-                        percentage < 100 && "animate-pulse",
-                        percentage >= 0 && percentage < 20 && "[&>div]:bg-yellow-100",
-                        percentage >= 20 && percentage < 40 && "[&>div]:bg-yellow-300",
-                        percentage >= 40 && percentage < 60 && "[&>div]:bg-green-200",
-                        percentage >= 60 && percentage < 80 && "[&>div]:bg-green-300",
-                        percentage >= 80 && percentage < 100 && "[&>div]:bg-green-400",
-                        percentage === 100 && "[&>div]:bg-green-500"
-                      )}
-                    />
-
-                    {percentage < 100 && <Loader className="animate-spin mt-2" />}
-                    <span className="mt-2 text-base text-muted-foreground font-medium">
-                      {Math.round(percentage)}%
-                      {typeof progressInfo?.total === "number" && progressInfo.total > 0
-                        ? ` - ${progressInfo.loaded} / ${progressInfo.total} items`
-                        : ""}
-                    </span>
-                  </div>
-                );
-              })}
-          </div>
-          <HomeMediaItemCardSkeletonGrid />
+      <div className="min-h-screen pb-4 px-4 sm:px-10 w-full">
+        <div className="w-full flex items-center justify-center mb-4 mt-4">
+          <FilterHome
+            librarySections={librarySections}
+            filteredLibraries={filteredLibraries}
+            setFilteredLibraries={setFilteredLibraries}
+            filterInDB={filterInDB}
+            setFilterInDB={setFilterInDB}
+            filterIgnored={filterIgnored}
+            setFilterIgnored={setFilterIgnored}
+            hasSetsAvailableFilter={hasSetsAvailableFilter}
+            setHasSetsAvailableFilter={setHasSetsAvailableFilter}
+            hasUpdatedAt={hasUpdatedAt}
+            hasEpisodeAddedAt={hasEpisodeAddedAt}
+            sortOption={sortOption}
+            setSortOption={setSortOption}
+            sortOrder={sortOrder}
+            setSortOrder={setSortOrder}
+            setCurrentPage={setCurrentPage}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={setItemsPerPage}
+          />
         </div>
-      ) : (
-        <div className="min-h-screen pb-4 px-4 sm:px-10 w-full">
-          {/* Filter & Sort Controls */}
-          <div className="w-full flex items-center justify-center mb-4 mt-4">
-            <FilterHome
-              librarySections={librarySections}
-              filteredLibraries={filteredLibraries}
-              setFilteredLibraries={setFilteredLibraries}
-              filterInDB={filterInDB}
-              setFilterInDB={setFilterInDB}
-              filterIgnored={filterIgnored}
-              setFilterIgnored={setFilterIgnored}
-              hasSetsAvailableFilter={hasSetsAvailableFilter}
-              setHasSetsAvailableFilter={setHasSetsAvailableFilter}
-              hasUpdatedAt={hasUpdatedAt}
-              hasEpisodeAddedAt={hasEpisodeAddedAt}
-              sortOption={sortOption}
-              setSortOption={setSortOption}
-              sortOrder={sortOrder}
-              setSortOrder={setSortOrder}
-              setCurrentPage={setCurrentPage}
-              itemsPerPage={itemsPerPage}
-              setItemsPerPage={setItemsPerPage}
-            />
-          </div>
 
-          {/* Grid of Cards */}
+        {loading ? (
+          <HomeMediaItemCardSkeletonGrid />
+        ) : (
           <ResponsiveGrid size="regular">
-            {paginatedItems.length === 0 && fullyLoaded && (searchQuery || filteredLibraries.length > 0) ? (
+            {filteredAndSortedMediaItems.length === 0 && (searchQuery || filteredLibraries.length > 0) ? (
               <div className="col-span-full text-center text-red-500">
                 <ErrorMessage
                   error={ReturnErrorMessage<string>(
@@ -451,23 +239,21 @@ export default function Home() {
                 />
               </div>
             ) : (
-              paginatedItems.map((item) => <HomeMediaItemCard key={item.rating_key} item={item} />)
+              filteredAndSortedMediaItems.map((item) => <HomeMediaItemCard key={item.rating_key} item={item} />)
             )}
           </ResponsiveGrid>
+        )}
 
-          {/* Pagination */}
-          <CustomPagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            setCurrentPage={setCurrentPage}
-            scrollToTop={true}
-            filterItemsLength={filteredAndSortedMediaItems.length}
-            itemsPerPage={itemsPerPage}
-          />
-          {/* Refresh Button */}
-          <RefreshButton onClick={() => getMediaItems(false)} />
-        </div>
-      )}
+        <CustomPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          setCurrentPage={setCurrentPage}
+          scrollToTop={true}
+          filterItemsLength={totalItems}
+          itemsPerPage={itemsPerPage}
+        />
+        <RefreshButton onClick={() => void fetchPage(true)} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/user/[username]/page.tsx
+++ b/frontend/src/app/user/[username]/page.tsx
@@ -4,6 +4,8 @@ import { setRefsToFormItems } from "@/helper/download-modal/set-to-form-item";
 import { formatLastUpdatedDate } from "@/helper/format-date-last-updates";
 import { type TMDBLookupMap, createTMDBLookupMap, searchWithLookupMap } from "@/helper/search-idb-for-tmdb-id";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import { beginLibraryMembershipFetch } from "@/services/mediaserver/collect-library-pages";
+import { GetCompleteLibrarySection } from "@/services/mediaserver/get-library-section-items";
 import { GetAllUserSets } from "@/services/mediux/get-user-sets";
 import { ArrowDownAZ, ArrowDownZA, ClockArrowDown, ClockArrowUp, User } from "lucide-react";
 
@@ -135,6 +137,7 @@ const UserSetPage = () => {
   // Get the username from the URL
   const { username } = useParams();
   const hasFetchedInfo = useRef(false);
+  const attemptedMembershipFetches = useRef(new Set<string>());
   // Error Handling
   const [error, setError] = useState<APIResponse<unknown> | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -158,7 +161,7 @@ const UserSetPage = () => {
   // State to track the selected sorting option
   const { sortOption, setSortOption, sortOrder, setSortOrder } = useUserPageStore();
 
-  const { sections, getSectionSummaries, hasHydrated } = useLibrarySectionsStore();
+  const { sections, setSection, getSectionSummaries, hasHydrated } = useLibrarySectionsStore();
 
   // User Response From Server
   const [creatorSetsResponse, setCreatorSetsResponse] = useState<CreatorSetsResponse>({
@@ -267,14 +270,35 @@ const UserSetPage = () => {
       setIsLoading(true);
 
       const librarySection = sections[selectedLibrarySection.title];
-      if (!librarySection || !librarySection.media_items || librarySection.media_items.length === 0) {
-        log(
-          "ERROR",
-          "User Page",
-          "Fetch User Sets",
-          `No data found for library section: ${selectedLibrarySection.title}`
-        );
-        setIsLoading(false);
+      if (!librarySection?.media_items?.length) {
+        if (
+          !beginLibraryMembershipFetch(
+            attemptedMembershipFetches.current,
+            selectedLibrarySection.title,
+            librarySection?.media_items?.length ?? 0
+          )
+        ) {
+          setIsLoading(false);
+          return;
+        }
+
+        setLoadMessage(`Loading ${selectedLibrarySection.title} membership...`);
+        const response = await GetCompleteLibrarySection(selectedLibrarySection.title);
+        if (response.status === "error" || !response.data) {
+          attemptedMembershipFetches.current.delete(selectedLibrarySection.title);
+          setError(response);
+          setIsLoading(false);
+          return;
+        }
+        setSection(selectedLibrarySection.title, {
+          ...librarySection,
+          id: librarySection?.id ?? "",
+          title: selectedLibrarySection.title,
+          type: selectedLibrarySection.type,
+          total_size: response.data.total_items,
+          media_items: response.data.media_items,
+        });
+        if (response.data.media_items.length === 0) setIsLoading(false);
         return;
       }
 
@@ -380,7 +404,7 @@ const UserSetPage = () => {
     };
 
     filterOutItems();
-  }, [sections, selectedLibrarySection, creatorSetsResponse]);
+  }, [sections, setSection, selectedLibrarySection, creatorSetsResponse]);
 
   useEffect(() => {
     if (!creatorSetsResponse) return;

--- a/frontend/src/services/mediaserver/collect-library-pages.test.ts
+++ b/frontend/src/services/mediaserver/collect-library-pages.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  beginLibraryMembershipFetch,
+  buildLibraryItemsParams,
+  collectLibraryPages,
+} from "./collect-library-pages.ts";
+
+test("collectLibraryPages fetches complete on-demand membership for SetFileCounts", async () => {
+  const requestedPages: number[] = [];
+  const allItems = Array.from({ length: 2001 }, (_, index) => index);
+
+  const items = await collectLibraryPages(async (pageNumber) => {
+    requestedPages.push(pageNumber);
+    const start = (pageNumber - 1) * 1000;
+    return { items: allItems.slice(start, start + 1000), totalItems: allItems.length };
+  });
+
+  assert.deepEqual(requestedPages, [1, 2, 3]);
+  assert.deepEqual(items, allItems);
+});
+
+test("home page query remains page-scoped on page 2", () => {
+  const params = buildLibraryItemsParams({
+    libraryTitles: ["Movies"],
+    searchTitle: "",
+    searchLibrary: "",
+    searchID: "",
+    searchYear: 0,
+    filterInDB: "",
+    filterIgnored: "",
+    filterHasSets: "",
+    sortOption: "title",
+    sortOrder: "asc",
+    pageNumber: 2,
+    itemsPerPage: 20,
+  });
+
+  assert.equal(params.page_number, 2);
+  assert.equal(params.items_per_page, 20);
+  assert.deepEqual(params.library_titles, ["Movies"]);
+});
+
+test("empty creator membership is fetched once and terminates", () => {
+  const attemptedLibraryTitles = new Set<string>();
+
+  assert.equal(beginLibraryMembershipFetch(attemptedLibraryTitles, "Empty", 0), true);
+  assert.equal(beginLibraryMembershipFetch(attemptedLibraryTitles, "Empty", 0), false);
+  assert.equal(beginLibraryMembershipFetch(attemptedLibraryTitles, "Loaded", 2), false);
+  assert.deepEqual([...attemptedLibraryTitles], ["Empty"]);
+});

--- a/frontend/src/services/mediaserver/collect-library-pages.ts
+++ b/frontend/src/services/mediaserver/collect-library-pages.ts
@@ -1,0 +1,54 @@
+export interface LibraryItemsQuery {
+  libraryTitles: string[];
+  searchTitle: string;
+  searchLibrary: string;
+  searchID: string;
+  searchYear: number;
+  filterInDB: string;
+  filterIgnored: string;
+  filterHasSets: string;
+  sortOption: string;
+  sortOrder: "asc" | "desc";
+  pageNumber: number;
+  itemsPerPage: number;
+  refresh?: boolean;
+}
+
+export function buildLibraryItemsParams(query: LibraryItemsQuery) {
+  return {
+    library_titles: query.libraryTitles,
+    search_title: query.searchTitle,
+    search_library: query.searchLibrary,
+    search_id: query.searchID,
+    search_year: query.searchYear,
+    filter_in_db: query.filterInDB,
+    filter_ignored: query.filterIgnored,
+    filter_has_sets: query.filterHasSets,
+    sort_option: query.sortOption,
+    sort_order: query.sortOrder,
+    page_number: query.pageNumber,
+    items_per_page: query.itemsPerPage,
+    refresh: query.refresh,
+  };
+}
+
+export function beginLibraryMembershipFetch(
+  attemptedLibraryTitles: Set<string>,
+  libraryTitle: string,
+  itemCount: number
+): boolean {
+  if (itemCount > 0 || attemptedLibraryTitles.has(libraryTitle)) return false;
+  attemptedLibraryTitles.add(libraryTitle);
+  return true;
+}
+
+export async function collectLibraryPages<T>(
+  fetchPage: (pageNumber: number) => Promise<{ items: T[]; totalItems: number }>
+): Promise<T[]> {
+  const items: T[] = [];
+  for (let pageNumber = 1; ; pageNumber += 1) {
+    const page = await fetchPage(pageNumber);
+    items.push(...page.items);
+    if (page.items.length === 0 || items.length >= page.totalItems) return items;
+  }
+}

--- a/frontend/src/services/mediaserver/get-library-section-items.ts
+++ b/frontend/src/services/mediaserver/get-library-section-items.ts
@@ -1,53 +1,93 @@
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import {
+  buildLibraryItemsParams,
+  collectLibraryPages,
+  type LibraryItemsQuery,
+} from "@/services/mediaserver/collect-library-pages";
 
 import { log } from "@/lib/logger";
 
 import type { APIResponse } from "@/types/api/api-response";
-import type { LibrarySection } from "@/types/media-and-posters/media-item-and-library";
+import type { MediaItem } from "@/types/media-and-posters/media-item-and-library";
 
 export interface GetLibrarySectionItems_Response {
-  library_section: LibrarySection;
+  media_items: MediaItem[];
+  total_items: number;
+  has_updated_at: boolean;
+  has_episode_added_at: boolean;
 }
 
 export const GetLibrarySectionItems = async (
-  librarySection: LibrarySection,
-  sectionStartIndex: number
+  query: LibraryItemsQuery
 ): Promise<APIResponse<GetLibrarySectionItems_Response>> => {
-  const logMessage =
-    sectionStartIndex === 0
-      ? `Fetching items for '${librarySection.title}'...`
-      : `Fetching items for '${librarySection.title}' (index: ${sectionStartIndex})`;
-  log("INFO", "API - Media Server", "Fetch Section Items", logMessage);
+  log("INFO", "API - Media Server", "Fetch Library Items", `Fetching library page ${query.pageNumber}`);
   try {
-    const params = {
-      section_id: librarySection.id,
-      section_title: librarySection.title,
-      section_type: librarySection.type,
-      section_start_index: sectionStartIndex,
-    };
+    const params = buildLibraryItemsParams(query);
     const response = await apiClient.get<APIResponse<GetLibrarySectionItems_Response>>(`/mediaserver/library/items`, {
       params,
     });
-    const resp = response.data;
-    if (resp.status === "error") {
-      throw new Error(resp.error?.message || `Unknown error fetching items for section '${librarySection.title}'`);
-    } else {
-      log(
-        "INFO",
-        "API - Media Server",
-        "Fetch Section Items",
-        `Fetched ${resp.data?.library_section.media_items.length ?? 0} items for '${librarySection.title}'`
-      );
+    if (response.data.status === "error") {
+      throw new Error(response.data.error?.message || "Unknown error fetching library items");
     }
+    log(
+      "INFO",
+      "API - Media Server",
+      "Fetch Library Items",
+      `Fetched ${response.data.data?.media_items.length ?? 0} library items`
+    );
     return response.data;
   } catch (error) {
     log(
       "ERROR",
       "API - Media Server",
-      "Fetch Section Items",
-      `Failed to fetch items for '${librarySection.title}': ${error instanceof Error ? error.message : "Unknown error"}`
+      "Fetch Library Items",
+      `Failed to fetch library items: ${error instanceof Error ? error.message : "Unknown error"}`
     );
+    return ReturnErrorMessage<GetLibrarySectionItems_Response>(error);
+  }
+};
+
+export const GetCompleteLibrarySection = async (
+  libraryTitle: string
+): Promise<APIResponse<GetLibrarySectionItems_Response>> => {
+  let hasUpdatedAt = false;
+  let hasEpisodeAddedAt = false;
+  let totalItems = 0;
+  try {
+    const mediaItems = await collectLibraryPages(async (pageNumber) => {
+      const response = await GetLibrarySectionItems({
+        libraryTitles: [libraryTitle],
+        searchTitle: "",
+        searchLibrary: "",
+        searchID: "",
+        searchYear: 0,
+        filterInDB: "",
+        filterIgnored: "",
+        filterHasSets: "",
+        sortOption: "title",
+        sortOrder: "asc",
+        pageNumber,
+        itemsPerPage: 1000,
+      });
+      if (response.status === "error" || !response.data) {
+        throw new Error(response.error?.message || `Failed to fetch complete library '${libraryTitle}'`);
+      }
+      totalItems = response.data.total_items;
+      hasUpdatedAt ||= response.data.has_updated_at;
+      hasEpisodeAddedAt ||= response.data.has_episode_added_at;
+      return { items: response.data.media_items, totalItems };
+    });
+    return {
+      status: "success",
+      data: {
+        media_items: mediaItems,
+        total_items: totalItems,
+        has_updated_at: hasUpdatedAt,
+        has_episode_added_at: hasEpisodeAddedAt,
+      },
+    };
+  } catch (error) {
     return ReturnErrorMessage<GetLibrarySectionItems_Response>(error);
   }
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- hydrate database flags once per section and bulk-update page presence instead of querying each item
- compute Plex latest-episode dates once per section walk using bounded 1,000-episode requests
- serve filtered/sorted home pages from warmed backend cache while lazily loading complete membership for creator/detail flows
- preserve loading, error, empty, filter, sort, count, and cached-membership behavior

## Call counts
- SQLite: ~4N item statements per library walk -> one state SELECT per section plus one bulk UPDATE per server page
- Plex episodes: count + one unbounded all-episode fetch per show page -> one count plus ceil(episodes/1000) bounded fetches per section
- Browser home: all pages for all sections -> one section-summary request plus one current-page item request

## Validation
- `cd backend && CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go test ./...`
- `cd backend && CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build -o /tmp/aura .`
- `cd backend && sh generate_go_docs.sh`
- `cd frontend && npm test`
- `cd frontend && npm run lint -- --max-warnings=0`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`

Closes #127
Closes #128
Closes #129