### PR TITLE
fix: return applied artwork versions

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -5772,6 +5772,9 @@ const docTemplate = `{
             "properties": {
                 "result": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },
@@ -5791,6 +5794,9 @@ const docTemplate = `{
             "properties": {
                 "result": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -5764,6 +5764,9 @@
             "properties": {
                 "result": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },
@@ -5783,6 +5786,9 @@
             "properties": {
                 "result": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -1458,6 +1458,8 @@ definitions:
     properties:
       result:
         type: string
+      updated_at:
+        type: integer
     type: object
   routes_download.DownloadImageFileForMediaItem_Request:
     properties:
@@ -1470,6 +1472,8 @@ definitions:
     properties:
       result:
         type: string
+      updated_at:
+        type: integer
     type: object
   routes_download.GetAllCollectionDownloadQueueItems_Response:
     properties:

--- a/backend/mediaserver/artwork_version_test.go
+++ b/backend/mediaserver/artwork_version_test.go
@@ -26,7 +26,7 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 	defer server.Close()
 
 	cleanupArtworkVersionTest(t, server.URL)
-	baseVersion := time.Now().UnixMicro() + 1000
+	baseVersion := time.Now().Add(time.Second).UnixMicro()
 	seasonNumber, episodeNumber := 1, 2
 	item := models.MediaItem{
 		RatingKey: "show-1", Type: "show", Title: "Show", LibraryTitle: "TV", UpdatedAt: baseVersion,
@@ -90,6 +90,34 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 	}
 }
 
+func TestSuccessfulArtworkAppliesAdvanceUncachedParentVersions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cleanupArtworkVersionTest(t, server.URL)
+	baseVersion := time.Now().Add(time.Second).UnixMicro()
+	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion}
+	image := models.ImageFile{ID: "poster", Type: "poster", Modified: time.Unix(1, 0)}
+
+	if err := DownloadApplyImageToMediaItem(testLogContext(), &item, image); err.Message != "" {
+		t.Fatalf("media apply failed: %s", err.Message)
+	}
+	if item.UpdatedAt != baseVersion+1 {
+		t.Fatalf("uncached media version = %d, want %d", item.UpdatedAt, baseVersion+1)
+	}
+
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: baseVersion}
+	image.Type = "collection_poster"
+	if err := ApplyCollectionImage(testLogContext(), &collection, image); err.Message != "" {
+		t.Fatalf("collection apply failed: %s", err.Message)
+	}
+	if collection.UpdatedAt != baseVersion+1 {
+		t.Fatalf("uncached collection version = %d, want %d", collection.UpdatedAt, baseVersion+1)
+	}
+}
+
 func TestFailedArtworkAppliesDoNotAdvanceVersions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "apply failed", http.StatusInternalServerError)
@@ -97,7 +125,7 @@ func TestFailedArtworkAppliesDoNotAdvanceVersions(t *testing.T) {
 	defer server.Close()
 
 	cleanupArtworkVersionTest(t, server.URL)
-	version := time.Now().UnixMicro() + 1000
+	version := time.Now().Add(time.Second).UnixMicro()
 	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: version}
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -231,9 +231,12 @@ func DownloadApplyImageToMediaItem(ctx context.Context, item *models.MediaItem, 
 		return Err
 	}
 	if Err = msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile); Err.Message == "" {
-		if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, time.Now().UnixMicro()); ok {
-			item.UpdatedAt = version
+		now := time.Now().UnixMicro()
+		version := max(item.UpdatedAt+1, now)
+		if cachedVersion, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, now); ok {
+			version = cachedVersion
 		}
+		item.UpdatedAt = version
 	}
 	return Err
 }
@@ -252,9 +255,12 @@ func ApplyCollectionImage(ctx context.Context, collectionItem *models.Collection
 		return Err
 	}
 	if Err = msClient.ApplyCollectionImage(ctx, collectionItem, imageFile); Err.Message == "" {
-		if version, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, time.Now().UnixMicro()); ok {
-			collectionItem.UpdatedAt = version
+		now := time.Now().UnixMicro()
+		version := max(collectionItem.UpdatedAt+1, now)
+		if cachedVersion, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, now); ok {
+			version = cachedVersion
 		}
+		collectionItem.UpdatedAt = version
 	}
 	return Err
 }

--- a/backend/routing/download/artwork_version_response_test.go
+++ b/backend/routing/download/artwork_version_response_test.go
@@ -1,0 +1,146 @@
+package routes_download
+
+import (
+	"aura/cache"
+	"aura/config"
+	"aura/mediux"
+	"aura/models"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestArtworkApplyResponsesReturnAdvancedVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cleanupArtworkApplyResponseTest(t, server.URL)
+	baseVersion := time.Now().Add(time.Second).UnixMicro()
+
+	mediaItem := models.MediaItem{
+		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion,
+	}
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{mediaItem},
+	})
+	mediaResponse := postArtworkApply[DownloadImageFileForMediaItem_Response](t, "/api/download/image/item", map[string]any{
+		"media_item": mediaItem,
+		"image_file": models.ImageFile{ID: "poster", Type: "poster"},
+	}, DownloadImageFileForMediaItem)
+	if mediaResponse.Status != "success" {
+		t.Fatalf("media response status = %q, want success", mediaResponse.Status)
+	}
+	if mediaResponse.Data.UpdatedAt != baseVersion+1 {
+		t.Fatalf("media response updated_at = %d, want %d", mediaResponse.Data.UpdatedAt, baseVersion+1)
+	}
+
+	collection := models.CollectionItem{
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: baseVersion,
+	}
+	cache.CollectionsStore.UpsertCollection(&collection)
+	collectionResponse := postArtworkApply[DownloadCollectionImage_Response](t, "/api/download/image/collection", map[string]any{
+		"collection_item": collection,
+		"image_file":      models.ImageFile{ID: "collection-poster", Type: "collection_poster"},
+	}, DownloadImageFileForCollectionItem)
+	if collectionResponse.Status != "success" {
+		t.Fatalf("collection response status = %q, want success", collectionResponse.Status)
+	}
+	if collectionResponse.Data.UpdatedAt != baseVersion+1 {
+		t.Fatalf("collection response updated_at = %d, want %d", collectionResponse.Data.UpdatedAt, baseVersion+1)
+	}
+}
+
+func TestFailedArtworkApplyResponsesDoNotReturnVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "apply failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cleanupArtworkApplyResponseTest(t, server.URL)
+	baseVersion := time.Now().Add(time.Second).UnixMicro()
+	mediaItem := models.MediaItem{
+		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion,
+	}
+	cache.LibraryStore.UpdateSection(&models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems:         []models.MediaItem{mediaItem},
+	})
+
+	response := postArtworkApply[map[string]any](t, "/api/download/image/item", map[string]any{
+		"media_item": mediaItem,
+		"image_file": models.ImageFile{ID: "poster", Type: "poster"},
+	}, DownloadImageFileForMediaItem)
+	if _, ok := response.Data["updated_at"]; ok {
+		t.Fatal("failed apply response returned updated_at")
+	}
+	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(mediaItem.RatingKey); cached.UpdatedAt != baseVersion {
+		t.Fatalf("failed apply advanced version to %d", cached.UpdatedAt)
+	}
+
+	collection := models.CollectionItem{
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: baseVersion,
+	}
+	cache.CollectionsStore.UpsertCollection(&collection)
+	collectionResponse := postArtworkApply[map[string]any](t, "/api/download/image/collection", map[string]any{
+		"collection_item": collection,
+		"image_file":      models.ImageFile{ID: "collection-poster", Type: "collection_poster"},
+	}, DownloadImageFileForCollectionItem)
+	if _, ok := collectionResponse.Data["updated_at"]; ok {
+		t.Fatal("failed collection apply response returned updated_at")
+	}
+	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != baseVersion {
+		t.Fatalf("failed collection apply advanced version to %d", cached.UpdatedAt)
+	}
+}
+
+func postArtworkApply[T any](t *testing.T, path string, body any, handler http.HandlerFunc) struct {
+	Status string `json:"status"`
+	Data   T      `json:"data"`
+} {
+	t.Helper()
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(encoded))
+	recorder := httptest.NewRecorder()
+	handler(recorder, request)
+
+	if recorder.Code != http.StatusOK && recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("response status code = %d", recorder.Code)
+	}
+	var response struct {
+		Status string `json:"status"`
+		Data   T      `json:"data"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func cleanupArtworkApplyResponseTest(t *testing.T, serverURL string) {
+	t.Helper()
+	previousConfig := config.Current
+	previousLibraryStore := cache.LibraryStore
+	previousCollectionsStore := cache.CollectionsStore
+	previousMediuxURL := mediux.MediuxApiURL
+	t.Cleanup(func() {
+		config.Current = previousConfig
+		cache.LibraryStore = previousLibraryStore
+		cache.CollectionsStore = previousCollectionsStore
+		mediux.MediuxApiURL = previousMediuxURL
+	})
+
+	config.Current = config.Config{}
+	config.Current.MediaServer = config.Config_MediaServer{Type: "Plex", URL: serverURL, ApiToken: "token"}
+	mediux.MediuxApiURL = serverURL
+	cache.LibraryStore = cache.Cache_NewLibraryCache()
+	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
+}

--- a/backend/routing/download/artwork_version_response_test.go
+++ b/backend/routing/download/artwork_version_response_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func TestArtworkApplyResponsesReturnAdvancedVersion(t *testing.T) {
+func TestArtworkApplyResponsesReturnAdvancedVersionOnCacheMiss(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -25,10 +25,6 @@ func TestArtworkApplyResponsesReturnAdvancedVersion(t *testing.T) {
 	mediaItem := models.MediaItem{
 		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion,
 	}
-	cache.LibraryStore.UpdateSection(&models.LibrarySection{
-		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{mediaItem},
-	})
 	mediaResponse := postArtworkApply[DownloadImageFileForMediaItem_Response](t, "/api/download/image/item", map[string]any{
 		"media_item": mediaItem,
 		"image_file": models.ImageFile{ID: "poster", Type: "poster"},
@@ -43,7 +39,6 @@ func TestArtworkApplyResponsesReturnAdvancedVersion(t *testing.T) {
 	collection := models.CollectionItem{
 		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: baseVersion,
 	}
-	cache.CollectionsStore.UpsertCollection(&collection)
 	collectionResponse := postArtworkApply[DownloadCollectionImage_Response](t, "/api/download/image/collection", map[string]any{
 		"collection_item": collection,
 		"image_file":      models.ImageFile{ID: "collection-poster", Type: "collection_poster"},

--- a/backend/routing/download/download_collection_image.go
+++ b/backend/routing/download/download_collection_image.go
@@ -14,7 +14,8 @@ type DownloadCollectionImage_Request struct {
 }
 
 type DownloadCollectionImage_Response struct {
-	Result string `json:"result"`
+	Result    string `json:"result"`
+	UpdatedAt int64  `json:"updated_at,omitempty"`
 }
 
 // DownloadImageFileForCollectionItem godoc
@@ -79,5 +80,6 @@ func DownloadImageFileForCollectionItem(w http.ResponseWriter, r *http.Request) 
 	}
 
 	response.Result = "ok"
+	response.UpdatedAt = req.CollectionItem.UpdatedAt
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/routing/download/download_image.go
+++ b/backend/routing/download/download_image.go
@@ -16,7 +16,8 @@ type DownloadImageFileForMediaItem_Request struct {
 }
 
 type DownloadImageFileForMediaItem_Response struct {
-	Result string `json:"result"`
+	Result    string `json:"result"`
+	UpdatedAt int64  `json:"updated_at,omitempty"`
 }
 
 // DownloadImageFileForMediaItem godoc
@@ -81,5 +82,6 @@ func DownloadImageFileForMediaItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.Result = fmt.Sprintf("Sucessfully downloaded %s", utils.GetFileDownloadName(req.MediaItem.Title, req.ImageFile))
+	response.UpdatedAt = req.MediaItem.UpdatedAt
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/routing/download/download_image.go
+++ b/backend/routing/download/download_image.go
@@ -81,7 +81,7 @@ func DownloadImageFileForMediaItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response.Result = fmt.Sprintf("Sucessfully downloaded %s", utils.GetFileDownloadName(req.MediaItem.Title, req.ImageFile))
+	response.Result = fmt.Sprintf("Successfully downloaded %s", utils.GetFileDownloadName(req.MediaItem.Title, req.ImageFile))
 	response.UpdatedAt = req.MediaItem.UpdatedAt
 	httpx.SendResponse(w, ld, response)
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "format": "prettier -l --write \"**/*.{ts,tsx,md,json,js,jsx}\"",
     "format:check": "prettier -l \"**/*.{ts,tsx,md,json,js,jsx}\"",
     "typecheck": "tsc --noEmit",
-    "test": "node --no-warnings --test --experimental-strip-types src/services/mediaserver/collect-library-pages.test.ts",
+    "test": "node --no-warnings --test --experimental-strip-types src/services/mediaserver/collect-library-pages.test.ts src/services/downloads/artwork-version.test.ts",
     "audit": "npm audit",
     "audit:fix": "npm audit fix"
   },

--- a/frontend/src/app/collection-item/collection-download-modal.tsx
+++ b/frontend/src/app/collection-item/collection-download-modal.tsx
@@ -47,6 +47,7 @@ import {
 export interface CollectionsDownloadModalProps {
   item: CollectionItem;
   set: CollectionItemSetRef;
+  onArtworkApplied?: (item: CollectionItem) => void;
 }
 
 const downloadSchema = z.object({
@@ -54,7 +55,7 @@ const downloadSchema = z.object({
   backdrop: z.boolean(),
 });
 
-const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ item, set }) => {
+const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ item, set, onArtworkApplied }) => {
   const [isMounted, setIsMounted] = useState(false);
 
   // Cancel Button Text
@@ -194,6 +195,7 @@ const CollectionsDownloadModal: React.FC<CollectionsDownloadModalProps> = ({ ite
       if (response.status === "error") {
         throw new Error(response.error?.message || `Unknown error downloading ${imageLabel}`);
       }
+      onArtworkApplied?.({ ...collectionItem });
 
       // Mark as done and set progress to target
       isDone = true;

--- a/frontend/src/app/collection-item/page.tsx
+++ b/frontend/src/app/collection-item/page.tsx
@@ -471,7 +471,11 @@ export default function CollectionItemPage() {
                     <div className="relative w-full mb-1">
                       {/* Download Button - absolute top right */}
                       <div className="absolute top-0 right-0 z-10">
-                        <CollectionsDownloadModal item={collectionItem} set={set} />
+                        <CollectionsDownloadModal
+                          item={collectionItem}
+                          set={set}
+                          onArtworkApplied={setCollectionItem}
+                        />
                       </div>
                       {/* Set Name */}
                       <P className="text-primary-dynamic text-sm font-semibold w-full mb-1 truncate pr-10">

--- a/frontend/src/app/media-item/page.tsx
+++ b/frontend/src/app/media-item/page.tsx
@@ -695,6 +695,7 @@ const MediaItemPage = () => {
             ignoredInDB={ignoredInDB}
             ignoredMode={ignoredMode}
             currentSetsAvailable={posterSets?.map((set) => set.id) || []}
+            onArtworkApplied={handleMediaItemChange}
           />
 
           {/* Loading and Error States */}

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -31,7 +31,8 @@ interface AssetImageProps {
   imageClassName?: string;
   priority?: boolean;
   matchedToItem?: boolean;
-  includedItems?: { [key: string]: IncludedItem };
+  includedItems?: Record<string, IncludedItem>;
+  onArtworkApplied?: (item: MediaItem) => void;
 }
 
 /**
@@ -88,6 +89,7 @@ export function AssetImage({
   priority = false,
   matchedToItem = false,
   includedItems,
+  onArtworkApplied,
 }: AssetImageProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
@@ -149,7 +151,8 @@ export function AssetImage({
       const resp = await downloadImageFileForMediaItem(
         image,
         includedItems[image.item_tmdb_id].media_item,
-        downloadName
+        downloadName,
+        onArtworkApplied
       );
       if (resp.status === "error") {
         throw new Error(resp.error?.message || "Unknown error");

--- a/frontend/src/components/shared/carousel-display.tsx
+++ b/frontend/src/components/shared/carousel-display.tsx
@@ -15,10 +15,12 @@ export function CarouselDisplay({
   sets,
   includedItems = {},
   dimNotFound = false,
+  onArtworkApplied,
 }: {
   sets: SetRef[];
   includedItems?: { [tmdb_id: string]: IncludedItem };
   dimNotFound?: boolean;
+  onArtworkApplied?: (item: MediaItem) => void;
 }) {
   const downloadDefaultTypes = useUserPreferencesStore((state) => state.downloadDefaults);
   const showOnlyDownloadDefaults = useUserPreferencesStore((state) => state.showOnlyDownloadDefaults);
@@ -86,6 +88,7 @@ export function CarouselDisplay({
                             className={`w-full ${!isAvailable && dimNotFound ? "opacity-35" : ""}`}
                             includedItems={includedItems}
                             matchedToItem={isAvailable}
+                            onArtworkApplied={onArtworkApplied}
                           />
                         ))}
                       {shouldShow("backdrop") &&
@@ -98,6 +101,7 @@ export function CarouselDisplay({
                             className={`w-full ${!isAvailable && dimNotFound ? "opacity-35" : ""}`}
                             includedItems={includedItems}
                             matchedToItem={isAvailable}
+                            onArtworkApplied={onArtworkApplied}
                           />
                         ))}
                     </div>
@@ -190,6 +194,7 @@ export function CarouselDisplay({
                           }`}
                           includedItems={includedItems}
                           matchedToItem={hasSeason(includedItems, tmdbId, seasonNum)}
+                          onArtworkApplied={onArtworkApplied}
                         />
                       )}
 
@@ -203,6 +208,7 @@ export function CarouselDisplay({
                           }`}
                           includedItems={includedItems}
                           matchedToItem={hasSeason(includedItems, tmdbId, seasonNum)}
+                          onArtworkApplied={onArtworkApplied}
                         />
                       )}
 
@@ -216,6 +222,7 @@ export function CarouselDisplay({
                           }`}
                           includedItems={includedItems}
                           matchedToItem={hasSeason(includedItems, tmdbId, seasonNum)}
+                          onArtworkApplied={onArtworkApplied}
                         />
                       )}
                     </div>
@@ -302,6 +309,7 @@ export function CarouselDisplay({
                                   card.season_number || 0,
                                   card.episode_number
                                 )}
+                                onArtworkApplied={onArtworkApplied}
                               />
                             </div>
                           </CarouselItem>

--- a/frontend/src/components/shared/download-modal.tsx
+++ b/frontend/src/components/shared/download-modal.tsx
@@ -696,6 +696,7 @@ const DownloadModal: React.FC<DownloadModalProps> = ({
       if (response.status === "error") {
         throw new Error(response.error?.message || "Unknown error");
       }
+      onDownloadComplete?.({ ...payload.mediaItem });
 
       updateTask(taskId, (t) => ({ ...t, status: "completed" }));
       return true;

--- a/frontend/src/components/shared/media-carousel.tsx
+++ b/frontend/src/components/shared/media-carousel.tsx
@@ -178,7 +178,12 @@ export function MediaCarousel({ set, includedItems, mediaItem, onMediaItemChange
       </div>
 
       <CarouselContent>
-        <CarouselDisplay sets={[set] as SetRef[]} includedItems={includedItems || {}} dimNotFound={dimNotFound} />
+        <CarouselDisplay
+          sets={[set] as SetRef[]}
+          includedItems={includedItems || {}}
+          dimNotFound={dimNotFound}
+          onArtworkApplied={onMediaItemChange}
+        />
       </CarouselContent>
     </Carousel>
   );

--- a/frontend/src/components/shared/media-item-details.tsx
+++ b/frontend/src/components/shared/media-item-details.tsx
@@ -55,6 +55,7 @@ type MediaItemDetailsProps = {
   ignoredInDB?: boolean;
   ignoredMode?: string;
   currentSetsAvailable?: string[];
+  onArtworkApplied?: (item: MediaItem) => void;
 };
 
 export function MediaItemDetails({
@@ -67,6 +68,7 @@ export function MediaItemDetails({
   ignoredInDB,
   ignoredMode,
   currentSetsAvailable = [],
+  onArtworkApplied,
 }: MediaItemDetailsProps) {
   const [isInDBLocal, setIsInDBLocal] = useState(existsInDB);
   const [isIgnoredLocal, setIsIgnoredLocal] = useState(ignoredInDB);
@@ -477,6 +479,7 @@ export function MediaItemDetails({
           mediaItem={mediaItem}
           isOpen={isManualImportModalOpen}
           onClose={() => setIsManualImportModalOpen(false)}
+          onArtworkApplied={onArtworkApplied}
         />
       )}
 

--- a/frontend/src/components/shared/media-item-manual-import-modal.tsx
+++ b/frontend/src/components/shared/media-item-manual-import-modal.tsx
@@ -34,6 +34,7 @@ export type MediaItemManualImportModalProps = {
   mediaItem: MediaItem;
   isOpen: boolean;
   onClose: () => void;
+  onArtworkApplied?: (item: MediaItem) => void;
 };
 
 type ImportTaskStatus = "pending" | "in-progress" | "completed" | "failed";
@@ -66,7 +67,7 @@ const getImportPercentComplete = (progress: ImportProgress) => {
   return Math.min(100, Math.round((done / total) * 100));
 };
 
-export function ManualImportModal({ mediaItem, isOpen, onClose }: MediaItemManualImportModalProps) {
+export function ManualImportModal({ mediaItem, isOpen, onClose, onArtworkApplied }: MediaItemManualImportModalProps) {
   // States for YAML text input
   const [yamlText, setYamlText] = useState("");
   const [isValidYaml, setIsValidYaml] = useState(false);
@@ -197,6 +198,7 @@ export function ManualImportModal({ mediaItem, isOpen, onClose }: MediaItemManua
       if (response.status === "error") {
         throw new Error(response.error?.message || "Unknown error");
       }
+      onArtworkApplied?.({ ...mediaItem });
 
       updateImportTask(t.id, (task) => ({ ...task, status: "completed" }));
     } catch (error) {

--- a/frontend/src/services/downloads/artwork-version.test.ts
+++ b/frontend/src/services/downloads/artwork-version.test.ts
@@ -3,11 +3,18 @@ import test from "node:test";
 
 import { updateArtworkVersion } from "./artwork-version.ts";
 
-test("updateArtworkVersion applies returned version to in-memory item", () => {
+test("updateArtworkVersion applies returned version and notifies the page", () => {
   const item = { updated_at: 10 };
+  let appliedItem: typeof item | undefined;
 
-  assert.equal(updateArtworkVersion(item, 11), item);
+  assert.equal(
+    updateArtworkVersion(item, 11, (updatedItem) => {
+      appliedItem = updatedItem;
+    }),
+    item
+  );
   assert.equal(item.updated_at, 11);
+  assert.equal(appliedItem, item);
 });
 
 test("updateArtworkVersion ignores missing and stale versions", () => {

--- a/frontend/src/services/downloads/artwork-version.test.ts
+++ b/frontend/src/services/downloads/artwork-version.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { updateArtworkVersion } from "./artwork-version.ts";
+
+test("updateArtworkVersion applies returned version to in-memory item", () => {
+  const item = { updated_at: 10 };
+
+  assert.equal(updateArtworkVersion(item, 11), item);
+  assert.equal(item.updated_at, 11);
+});
+
+test("updateArtworkVersion ignores missing and stale versions", () => {
+  const item = { updated_at: 10 };
+
+  updateArtworkVersion(item, undefined);
+  updateArtworkVersion(item, 9);
+
+  assert.equal(item.updated_at, 10);
+});

--- a/frontend/src/services/downloads/artwork-version.ts
+++ b/frontend/src/services/downloads/artwork-version.ts
@@ -1,4 +1,9 @@
-export function updateArtworkVersion<T extends { updated_at: number }>(item: T, updatedAt?: number): T {
+export function updateArtworkVersion<T extends { updated_at: number }>(
+  item: T,
+  updatedAt?: number,
+  onArtworkApplied?: (item: T) => void
+): T {
   if (updatedAt !== undefined && updatedAt > item.updated_at) item.updated_at = updatedAt;
+  onArtworkApplied?.(item);
   return item;
 }

--- a/frontend/src/services/downloads/artwork-version.ts
+++ b/frontend/src/services/downloads/artwork-version.ts
@@ -1,0 +1,4 @@
+export function updateArtworkVersion<T extends { updated_at: number }>(item: T, updatedAt?: number): T {
+  if (updatedAt !== undefined && updatedAt > item.updated_at) item.updated_at = updatedAt;
+  return item;
+}

--- a/frontend/src/services/downloads/download-collection-image.ts
+++ b/frontend/src/services/downloads/download-collection-image.ts
@@ -1,6 +1,7 @@
 import { collectionItemInfo } from "@/helper/item-info";
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import { updateArtworkVersion } from "@/services/downloads/artwork-version";
 
 import { log } from "@/lib/logger";
 
@@ -16,6 +17,7 @@ export interface DownloadCollectionImage_Request {
 
 export interface DownloadCollectionImage_Response {
   result: string;
+  updated_at?: number;
 }
 
 export const DownloadImageFileForCollectionItem = async (
@@ -43,6 +45,7 @@ export const DownloadImageFileForCollectionItem = async (
         response.data.error?.message || `Unknown error downloading ${imageType} image and updating media server`
       );
     } else {
+      updateArtworkVersion(collectionItem, response.data.data?.updated_at);
       log(
         "INFO",
         "API - Media Server",

--- a/frontend/src/services/downloads/download-image.ts
+++ b/frontend/src/services/downloads/download-image.ts
@@ -21,7 +21,8 @@ export interface DownloadImageFileForMediaItem_Response {
 export const downloadImageFileForMediaItem = async (
   imageFile: ImageFile,
   mediaItem: MediaItem,
-  fileName: string
+  fileName: string,
+  onArtworkApplied?: (item: MediaItem) => void
 ): Promise<APIResponse<DownloadImageFileForMediaItem_Response>> => {
   try {
     const req: DownloadImageFileForMediaItem_Request = {
@@ -37,7 +38,7 @@ export const downloadImageFileForMediaItem = async (
         response.data.error?.message || "Unknown error downloading poster file and updating media server"
       );
     }
-    updateArtworkVersion(mediaItem, response.data.data?.updated_at);
+    updateArtworkVersion(mediaItem, response.data.data?.updated_at, onArtworkApplied);
     return response.data;
   } catch (error) {
     log(

--- a/frontend/src/services/downloads/download-image.ts
+++ b/frontend/src/services/downloads/download-image.ts
@@ -1,5 +1,6 @@
 import apiClient from "@/services/api-client";
 import { ReturnErrorMessage } from "@/services/api-error-return";
+import { updateArtworkVersion } from "@/services/downloads/artwork-version";
 
 import { log } from "@/lib/logger";
 
@@ -13,7 +14,8 @@ export interface DownloadImageFileForMediaItem_Request {
 }
 
 export interface DownloadImageFileForMediaItem_Response {
-  message: string;
+  result: string;
+  updated_at?: number;
 }
 
 export const downloadImageFileForMediaItem = async (
@@ -35,6 +37,7 @@ export const downloadImageFileForMediaItem = async (
         response.data.error?.message || "Unknown error downloading poster file and updating media server"
       );
     }
+    updateArtworkVersion(mediaItem, response.data.data?.updated_at);
     return response.data;
   } catch (error) {
     log(


### PR DESCRIPTION
## Summary
- return advanced `updated_at` from successful media-item and collection artwork applies
- update frontend in-memory artwork versions immediately after apply
- cover success and failure response behavior plus frontend version updates

## Validation
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go test ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go vet ./...`
- `CONFIG_PATH=$(mktemp -d) CGO_ENABLED=1 go build ./...`
- `gofmt -l .`
- `npm test`
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `npm run build`

Closes #161