### PR TITLE
fix(renovate): avoid Bundler pin update failures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>jabrown93/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Work around Bundler pin bug: https://github.com/renovatebot/renovate/discussions/43902",
+      "matchManagers": ["bundler"],
+      "rangeStrategy": "update-lockfile"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     {
       "description": "Work around Bundler pin bug: https://github.com/renovatebot/renovate/discussions/43902",
       "matchManagers": ["bundler"],
+      "matchUpdateTypes": ["pin"],
       "rangeStrategy": "update-lockfile"
     }
   ]


### PR DESCRIPTION
## Summary

Overrides shared Renovate `rangeStrategy: pin` behavior for Bundler. Bundler updates use `update-lockfile`, avoiding malformed Gemfile pin replacements while preserving normal dependency updates.

## Background

Dependency Dashboard reports `Error updating branch: update failure` for Bundler pin branches. Renovate discussion [#43902](https://github.com/renovatebot/renovate/discussions/43902) documents pin replacement dropping required Ruby quotes.

Refs #6

## Changes

- Add Bundler-specific `rangeStrategy: update-lockfile` package rule.
- Document upstream bug tracked by Renovate discussion #43902.

## Testing

- `renovate-config-validator --strict renovate.json`
- `git diff --check`
- `jq empty renovate.json`

## Additional Notes

Dependency Dashboard warning should clear after merge and next Renovate run.
