### PR TITLE
fix(images): split artwork version from media timestamps

### DIFF
--- a/backend/api-docs/docs.go
+++ b/backend/api-docs/docs.go
@@ -4765,6 +4765,9 @@ const docTemplate = `{
         "models.CollectionItem": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "child_count": {
                     "type": "integer"
                 },
@@ -5089,6 +5092,10 @@ const docTemplate = `{
                     "description": "Added timestamp",
                     "type": "integer"
                 },
+                "artwork_version": {
+                    "description": "Opaque image cache version",
+                    "type": "integer"
+                },
                 "content_rating": {
                     "description": "Used in MediaItem Details Page - For more information about the item",
                     "type": "string"
@@ -5174,7 +5181,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
-                    "description": "Last updated timestamp",
+                    "description": "Last updated timestamp from the media server",
                     "type": "integer"
                 },
                 "year": {
@@ -5774,11 +5781,11 @@ const docTemplate = `{
         "routes_download.DownloadCollectionImage_Response": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "result": {
                     "type": "string"
-                },
-                "updated_at": {
-                    "type": "integer"
                 }
             }
         },
@@ -5796,11 +5803,11 @@ const docTemplate = `{
         "routes_download.DownloadImageFileForMediaItem_Response": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "result": {
                     "type": "string"
-                },
-                "updated_at": {
-                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.json
+++ b/backend/api-docs/swagger.json
@@ -4757,6 +4757,9 @@
         "models.CollectionItem": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "child_count": {
                     "type": "integer"
                 },
@@ -5081,6 +5084,10 @@
                     "description": "Added timestamp",
                     "type": "integer"
                 },
+                "artwork_version": {
+                    "description": "Opaque image cache version",
+                    "type": "integer"
+                },
                 "content_rating": {
                     "description": "Used in MediaItem Details Page - For more information about the item",
                     "type": "string"
@@ -5166,7 +5173,7 @@
                     "type": "string"
                 },
                 "updated_at": {
-                    "description": "Last updated timestamp",
+                    "description": "Last updated timestamp from the media server",
                     "type": "integer"
                 },
                 "year": {
@@ -5766,11 +5773,11 @@
         "routes_download.DownloadCollectionImage_Response": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "result": {
                     "type": "string"
-                },
-                "updated_at": {
-                    "type": "integer"
                 }
             }
         },
@@ -5788,11 +5795,11 @@
         "routes_download.DownloadImageFileForMediaItem_Response": {
             "type": "object",
             "properties": {
+                "artwork_version": {
+                    "type": "integer"
+                },
                 "result": {
                     "type": "string"
-                },
-                "updated_at": {
-                    "type": "integer"
                 }
             }
         },

--- a/backend/api-docs/swagger.yaml
+++ b/backend/api-docs/swagger.yaml
@@ -1,6 +1,4 @@
 basePath: /
-# yamllint disable rule:indentation
-# yamllint disable rule:line-length
 definitions:
   autodownload.AutoDownloadResult:
     properties:
@@ -763,6 +761,8 @@ definitions:
     type: object
   models.CollectionItem:
     properties:
+      artwork_version:
+        type: integer
       child_count:
         type: integer
       index:
@@ -995,6 +995,9 @@ definitions:
       added_at:
         description: Added timestamp
         type: integer
+      artwork_version:
+        description: Opaque image cache version
+        type: integer
       content_rating:
         description: Used in MediaItem Details Page - For more information about the
           item
@@ -1056,7 +1059,7 @@ definitions:
         description: '"movie" or "show"'
         type: string
       updated_at:
-        description: Last updated timestamp
+        description: Last updated timestamp from the media server
         type: integer
       year:
         description: Release year of the media item
@@ -1459,10 +1462,10 @@ definitions:
     type: object
   routes_download.DownloadCollectionImage_Response:
     properties:
+      artwork_version:
+        type: integer
       result:
         type: string
-      updated_at:
-        type: integer
     type: object
   routes_download.DownloadImageFileForMediaItem_Request:
     properties:
@@ -1473,10 +1476,10 @@ definitions:
     type: object
   routes_download.DownloadImageFileForMediaItem_Response:
     properties:
+      artwork_version:
+        type: integer
       result:
         type: string
-      updated_at:
-        type: integer
     type: object
   routes_download.GetAllCollectionDownloadQueueItems_Response:
     properties:

--- a/backend/cache/mediaserver_collections.go
+++ b/backend/cache/mediaserver_collections.go
@@ -96,16 +96,16 @@ func (msc *MediaServerCollectionsCache) GetCollectionByRatingKey(ratingKey strin
 	return nil, false
 }
 
-// AdvanceCollectionUpdatedAt advances a cached collection image version atomically.
-func (msc *MediaServerCollectionsCache) AdvanceCollectionUpdatedAt(ratingKey string, now int64) (int64, bool) {
+// AdvanceCollectionArtworkVersion advances a cached collection image version atomically.
+func (msc *MediaServerCollectionsCache) AdvanceCollectionArtworkVersion(ratingKey string, now int64) (int64, bool) {
 	msc.mu.Lock()
 	defer msc.mu.Unlock()
 
 	for _, lib := range msc.collections {
 		for _, collection := range lib {
 			if collection.RatingKey == ratingKey {
-				collection.UpdatedAt = nextVersion(collection.UpdatedAt, now)
-				return collection.UpdatedAt, true
+				collection.ArtworkVersion = nextVersion(collection.ArtworkVersion, now)
+				return collection.ArtworkVersion, true
 			}
 		}
 	}
@@ -133,9 +133,10 @@ func (msc *MediaServerCollectionsCache) UpsertCollection(collection *models.Coll
 		lib = make(map[string]*models.CollectionItem)
 		msc.collections[collection.LibraryTitle] = lib
 	}
-	collection.UpdatedAt = hydratedVersion(collection.UpdatedAt, msc.generationFloor)
-	if existing := lib[collection.RatingKey]; existing != nil && collection.UpdatedAt < existing.UpdatedAt {
-		collection.UpdatedAt = existing.UpdatedAt
+	collection.ArtworkVersion = hydratedVersion(max(collection.UpdatedAt, collection.ArtworkVersion), msc.generationFloor)
+	if existing := lib[collection.RatingKey]; existing != nil {
+		collection.UpdatedAt = max(collection.UpdatedAt, existing.UpdatedAt)
+		collection.ArtworkVersion = max(collection.ArtworkVersion, existing.ArtworkVersion)
 	}
 	lib[collection.RatingKey] = collection
 }

--- a/backend/cache/mediaserver_items.go
+++ b/backend/cache/mediaserver_items.go
@@ -126,7 +126,7 @@ func (c *MediaServerLibraryCache) replaceSectionLocked(section *models.LibrarySe
 	itemIndexes := make(map[string]int, len(prepared.MediaItems))
 	for i := range prepared.MediaItems {
 		item := &prepared.MediaItems[i]
-		item.UpdatedAt = hydratedVersion(item.UpdatedAt, c.generationFloor)
+		item.ArtworkVersion = hydratedVersion(max(item.UpdatedAt, item.ArtworkVersion), c.generationFloor)
 		existing := existingByRatingKey[item.RatingKey]
 		if existing == nil {
 			key := mediaItemFallbackKey(item)
@@ -143,10 +143,10 @@ func (c *MediaServerLibraryCache) replaceSectionLocked(section *models.LibrarySe
 			preserveMediaItemVersion(item, existing)
 		}
 		section.MediaItems[i].UpdatedAt = item.UpdatedAt
+		section.MediaItems[i].ArtworkVersion = item.ArtworkVersion
 		if index, duplicate := itemIndexes[item.RatingKey]; item.RatingKey != "" && duplicate {
-			if item.UpdatedAt < items[index].UpdatedAt {
-				item.UpdatedAt = items[index].UpdatedAt
-			}
+			item.UpdatedAt = max(item.UpdatedAt, items[index].UpdatedAt)
+			item.ArtworkVersion = max(item.ArtworkVersion, items[index].ArtworkVersion)
 			items[index] = *item
 			continue
 		}
@@ -183,9 +183,8 @@ func preserveDBOwnedMediaItemState(item, existing *models.MediaItem) {
 }
 
 func preserveMediaItemVersion(item, existing *models.MediaItem) {
-	if item.UpdatedAt < existing.UpdatedAt {
-		item.UpdatedAt = existing.UpdatedAt
-	}
+	item.UpdatedAt = max(item.UpdatedAt, existing.UpdatedAt)
+	item.ArtworkVersion = max(item.ArtworkVersion, existing.ArtworkVersion)
 }
 
 // UpdateMediaItem updates a specific media item in a section
@@ -215,7 +214,7 @@ func (c *MediaServerLibraryCache) UpdateMediaItem(sectionTitle string, item *mod
 				}
 			}
 		}
-		item.UpdatedAt = hydratedVersion(item.UpdatedAt, c.generationFloor)
+		item.ArtworkVersion = hydratedVersion(max(item.UpdatedAt, item.ArtworkVersion), c.generationFloor)
 		if existingItem != nil {
 			oldKey := mediaItemMutationKeyFor(sectionTitle, existingItem)
 			generation := c.itemMutationGeneration[oldKey]
@@ -233,17 +232,17 @@ func (c *MediaServerLibraryCache) UpdateMediaItem(sectionTitle string, item *mod
 	}
 }
 
-// AdvanceMediaItemUpdatedAt advances the cached parent image version atomically.
+// AdvanceMediaItemArtworkVersion advances the cached parent image version atomically.
 // ratingKey is the parent key even when Plex applies artwork to a season or episode.
-func (c *MediaServerLibraryCache) AdvanceMediaItemUpdatedAt(ratingKey string, now int64) (int64, bool) {
+func (c *MediaServerLibraryCache) AdvanceMediaItemArtworkVersion(ratingKey string, now int64) (int64, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	for _, section := range c.sections {
 		for i := range section.MediaItems {
 			if section.MediaItems[i].RatingKey == ratingKey {
-				section.MediaItems[i].UpdatedAt = nextVersion(section.MediaItems[i].UpdatedAt, now)
-				return section.MediaItems[i].UpdatedAt, true
+				section.MediaItems[i].ArtworkVersion = nextVersion(section.MediaItems[i].ArtworkVersion, now)
+				return section.MediaItems[i].ArtworkVersion, true
 			}
 		}
 	}

--- a/backend/cache/version_test.go
+++ b/backend/cache/version_test.go
@@ -6,6 +6,35 @@ import (
 	"testing"
 )
 
+func TestHydrationPreservesUpdatedAtAndFloorsArtworkVersion(t *testing.T) {
+	library := newLibraryCache(500)
+	section := &models.LibrarySection{
+		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
+		MediaItems: []models.MediaItem{
+			{RatingKey: "older", UpdatedAt: 100},
+			{RatingKey: "newer", UpdatedAt: 200},
+		},
+	}
+
+	library.UpdateSection(section)
+
+	if section.MediaItems[0].UpdatedAt != 100 || section.MediaItems[1].UpdatedAt != 200 {
+		t.Fatalf("updated_at values flattened: %+v", section.MediaItems)
+	}
+	for _, item := range section.MediaItems {
+		if item.ArtworkVersion != 500 {
+			t.Fatalf("%s artwork version = %d, want generation floor 500", item.RatingKey, item.ArtworkVersion)
+		}
+	}
+
+	collections := newCollectionsCache(500)
+	collection := &models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: 100}
+	collections.UpsertCollection(collection)
+	if collection.UpdatedAt != 100 || collection.ArtworkVersion != 500 {
+		t.Fatalf("collection = %+v, want updated_at 100 and artwork_version 500", collection)
+	}
+}
+
 func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
 	library := newLibraryCache(0)
 	library.UpdateSection(&models.LibrarySection{
@@ -15,13 +44,13 @@ func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
 	collections := newCollectionsCache(0)
 	collections.UpsertCollection(&models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", UpdatedAt: 100})
 
-	if got, ok := library.AdvanceMediaItemUpdatedAt("show-1", 100); !ok || got != 101 {
+	if got, ok := library.AdvanceMediaItemArtworkVersion("show-1", 100); !ok || got != 101 {
 		t.Fatalf("media version = %d, found = %v; want 101, true", got, ok)
 	}
-	if got, ok := library.AdvanceMediaItemUpdatedAt("show-1", 100); !ok || got != 102 {
+	if got, ok := library.AdvanceMediaItemArtworkVersion("show-1", 100); !ok || got != 102 {
 		t.Fatalf("same-second media version = %d, found = %v; want 102, true", got, ok)
 	}
-	if got, ok := collections.AdvanceCollectionUpdatedAt("collection-1", 100); !ok || got != 101 {
+	if got, ok := collections.AdvanceCollectionArtworkVersion("collection-1", 100); !ok || got != 101 {
 		t.Fatalf("collection version = %d, found = %v; want 101, true", got, ok)
 	}
 
@@ -30,11 +59,11 @@ func TestArtworkVersionsAdvanceMonotonically(t *testing.T) {
 		MediaItems:         []models.MediaItem{{RatingKey: "show-1", UpdatedAt: 100}},
 	})
 	collections.UpsertCollection(&models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", UpdatedAt: 100})
-	if item, _ := library.GetMediaItemByRatingKey("show-1"); item.UpdatedAt != 102 {
-		t.Fatalf("library refresh regressed version to %d", item.UpdatedAt)
+	if item, _ := library.GetMediaItemByRatingKey("show-1"); item.UpdatedAt != 100 || item.ArtworkVersion != 102 {
+		t.Fatalf("library refresh changed timestamp or regressed version: %+v", item)
 	}
-	if collection, _ := collections.GetCollectionByRatingKey("collection-1"); collection.UpdatedAt != 101 {
-		t.Fatalf("collection refresh regressed version to %d", collection.UpdatedAt)
+	if collection, _ := collections.GetCollectionByRatingKey("collection-1"); collection.UpdatedAt != 100 || collection.ArtworkVersion != 101 {
+		t.Fatalf("collection refresh changed timestamp or regressed version: %+v", collection)
 	}
 }
 
@@ -51,7 +80,7 @@ func TestConcurrentArtworkVersionAdvance(t *testing.T) {
 	for range applies {
 		go func() {
 			defer wg.Done()
-			library.AdvanceMediaItemUpdatedAt("movie-1", 100)
+			library.AdvanceMediaItemArtworkVersion("movie-1", 100)
 		}()
 	}
 	wg.Wait()
@@ -60,8 +89,8 @@ func TestConcurrentArtworkVersionAdvance(t *testing.T) {
 	if !ok {
 		t.Fatal("movie-1 missing from cache")
 	}
-	if item.UpdatedAt != 100+applies {
-		t.Fatalf("media version = %d, want %d", item.UpdatedAt, 100+applies)
+	if item.UpdatedAt != 100 || item.ArtworkVersion != 100+applies {
+		t.Fatalf("media item = %+v, want timestamp 100 and version %d", item, 100+applies)
 	}
 }
 
@@ -74,8 +103,8 @@ func TestHydrationWritesMonotonicVersionsBackToResults(t *testing.T) {
 			{RatingKey: "detail-item", UpdatedAt: 600},
 		},
 	})
-	library.AdvanceMediaItemUpdatedAt("section-item", 700)
-	library.AdvanceMediaItemUpdatedAt("detail-item", 700)
+	library.AdvanceMediaItemArtworkVersion("section-item", 700)
+	library.AdvanceMediaItemArtworkVersion("detail-item", 700)
 
 	browseResult := &models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
@@ -85,24 +114,24 @@ func TestHydrationWritesMonotonicVersionsBackToResults(t *testing.T) {
 		},
 	}
 	library.UpdateSection(browseResult)
-	if got := browseResult.MediaItems[0].UpdatedAt; got != 700 {
-		t.Fatalf("browse result version = %d, want advanced cache version 700", got)
+	if got := browseResult.MediaItems[0]; got.UpdatedAt != 600 || got.ArtworkVersion != 700 {
+		t.Fatalf("browse result = %+v, want timestamp 600 and version 700", got)
 	}
 
 	detailResult := &models.MediaItem{RatingKey: "detail-item", UpdatedAt: 100}
 	library.UpdateMediaItem("Movies", detailResult)
-	if detailResult.UpdatedAt != 700 {
-		t.Fatalf("detail result version = %d, want advanced cache version 700", detailResult.UpdatedAt)
+	if detailResult.UpdatedAt != 600 || detailResult.ArtworkVersion != 700 {
+		t.Fatalf("detail result = %+v, want timestamp 600 and version 700", detailResult)
 	}
 
 	collections := newCollectionsCache(500)
 	collection := &models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: 600}
 	collections.UpsertCollection(collection)
-	collections.AdvanceCollectionUpdatedAt(collection.RatingKey, 700)
+	collections.AdvanceCollectionArtworkVersion(collection.RatingKey, 700)
 	collectionResult := &models.CollectionItem{RatingKey: collection.RatingKey, LibraryTitle: "Movies", UpdatedAt: 100}
 	collections.UpsertCollection(collectionResult)
-	if collectionResult.UpdatedAt != 700 {
-		t.Fatalf("collection result version = %d, want advanced cache version 700", collectionResult.UpdatedAt)
+	if collectionResult.UpdatedAt != 600 || collectionResult.ArtworkVersion != 700 {
+		t.Fatalf("collection result = %+v, want timestamp 600 and version 700", collectionResult)
 	}
 }
 
@@ -114,14 +143,14 @@ func TestHydrationUsesStableProcessGenerationAndChangesAfterRestart(t *testing.T
 		MediaItems:         []models.MediaItem{*firstResult},
 	})
 	firstProcess.UpdateMediaItem("Movies", firstResult)
-	if firstResult.UpdatedAt != 1000 {
-		t.Fatalf("first process version = %d, want generation floor 1000", firstResult.UpdatedAt)
+	if firstResult.UpdatedAt != 100 || firstResult.ArtworkVersion != 1000 {
+		t.Fatalf("first process result = %+v, want timestamp 100 and version 1000", firstResult)
 	}
 
 	repeatedResult := &models.MediaItem{RatingKey: "movie-1", UpdatedAt: 100}
 	firstProcess.UpdateMediaItem("Movies", repeatedResult)
-	if repeatedResult.UpdatedAt != firstResult.UpdatedAt {
-		t.Fatalf("same-process versions differ: %d and %d", firstResult.UpdatedAt, repeatedResult.UpdatedAt)
+	if repeatedResult.UpdatedAt != firstResult.UpdatedAt || repeatedResult.ArtworkVersion != firstResult.ArtworkVersion {
+		t.Fatalf("same-process results differ: %+v and %+v", firstResult, repeatedResult)
 	}
 
 	restartedProcess := newLibraryCache(1001)
@@ -130,8 +159,8 @@ func TestHydrationUsesStableProcessGenerationAndChangesAfterRestart(t *testing.T
 		MediaItems:         []models.MediaItem{{RatingKey: "movie-1", UpdatedAt: 100}},
 	}
 	restartedProcess.UpdateSection(restartedSection)
-	if got := restartedSection.MediaItems[0].UpdatedAt; got != 1001 {
-		t.Fatalf("restarted process version = %d, want new generation floor 1001", got)
+	if got := restartedSection.MediaItems[0]; got.UpdatedAt != 100 || got.ArtworkVersion != 1001 {
+		t.Fatalf("restarted process result = %+v, want timestamp 100 and version 1001", got)
 	}
 
 	if Cache_NewLibraryCache().generationFloor != processArtworkVersionFloor || Cache_NewCollectionsCache().generationFloor != processArtworkVersionFloor {

--- a/backend/mediaserver/artwork_version_test.go
+++ b/backend/mediaserver/artwork_version_test.go
@@ -29,7 +29,7 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 	baseVersion := time.Now().Add(time.Second).UnixMicro()
 	seasonNumber, episodeNumber := 1, 2
 	item := models.MediaItem{
-		RatingKey: "show-1", Type: "show", Title: "Show", LibraryTitle: "TV", UpdatedAt: baseVersion,
+		RatingKey: "show-1", Type: "show", Title: "Show", LibraryTitle: "TV", UpdatedAt: 100, ArtworkVersion: baseVersion,
 		Series: &models.MediaItemSeries{Seasons: []models.MediaItemSeason{{
 			RatingKey: "season-1", SeasonNumber: seasonNumber,
 			Episodes: []models.MediaItemEpisode{{RatingKey: "episode-2", SeasonNumber: seasonNumber, EpisodeNumber: episodeNumber}},
@@ -39,7 +39,7 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 		LibrarySectionBase: models.LibrarySectionBase{Title: "TV"},
 		MediaItems:         []models.MediaItem{item},
 	})
-	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", Title: "Collection", UpdatedAt: baseVersion}
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "TV", Title: "Collection", UpdatedAt: 100, ArtworkVersion: baseVersion}
 	cache.CollectionsStore.UpsertCollection(&collection)
 
 	images := []models.ImageFile{
@@ -52,11 +52,11 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 			t.Fatalf("apply %s failed: %s", image.Type, err.Message)
 		}
 		cached, ok := cache.LibraryStore.GetMediaItemByRatingKey(item.RatingKey)
-		if !ok || cached.UpdatedAt != baseVersion+int64(i)+1 {
-			t.Fatalf("after %s parent version = %d, found = %v; want %d", image.Type, cached.UpdatedAt, ok, baseVersion+int64(i)+1)
+		if !ok || cached.UpdatedAt != 100 || cached.ArtworkVersion != baseVersion+int64(i)+1 {
+			t.Fatalf("after %s cached item = %+v, found = %v; want timestamp 100 and version %d", image.Type, cached, ok, baseVersion+int64(i)+1)
 		}
-		if item.UpdatedAt != cached.UpdatedAt {
-			t.Fatalf("after %s mutation result version = %d, want cached version %d", image.Type, item.UpdatedAt, cached.UpdatedAt)
+		if item.UpdatedAt != 100 || item.ArtworkVersion != cached.ArtworkVersion {
+			t.Fatalf("after %s mutation result = %+v, want timestamp 100 and cached version %d", image.Type, item, cached.ArtworkVersion)
 		}
 	}
 
@@ -65,11 +65,11 @@ func TestSuccessfulArtworkAppliesAdvanceParentVersions(t *testing.T) {
 		t.Fatalf("collection apply failed: %s", err.Message)
 	}
 	cachedCollection, ok := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey)
-	if !ok || cachedCollection.UpdatedAt != baseVersion+1 {
-		t.Fatalf("collection version = %d, found = %v; want %d", cachedCollection.UpdatedAt, ok, baseVersion+1)
+	if !ok || cachedCollection.UpdatedAt != 100 || cachedCollection.ArtworkVersion != baseVersion+1 {
+		t.Fatalf("cached collection = %+v, found = %v; want timestamp 100 and version %d", cachedCollection, ok, baseVersion+1)
 	}
-	if collection.UpdatedAt != cachedCollection.UpdatedAt {
-		t.Fatalf("collection mutation result version = %d, want cached version %d", collection.UpdatedAt, cachedCollection.UpdatedAt)
+	if collection.UpdatedAt != 100 || collection.ArtworkVersion != cachedCollection.ArtworkVersion {
+		t.Fatalf("collection mutation result = %+v, want timestamp 100 and cached version %d", collection, cachedCollection.ArtworkVersion)
 	}
 
 	mu.Lock()
@@ -98,23 +98,23 @@ func TestSuccessfulArtworkAppliesAdvanceUncachedParentVersions(t *testing.T) {
 
 	cleanupArtworkVersionTest(t, server.URL)
 	baseVersion := time.Now().Add(time.Second).UnixMicro()
-	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion}
+	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: baseVersion}
 	image := models.ImageFile{ID: "poster", Type: "poster", Modified: time.Unix(1, 0)}
 
 	if err := DownloadApplyImageToMediaItem(testLogContext(), &item, image); err.Message != "" {
 		t.Fatalf("media apply failed: %s", err.Message)
 	}
-	if item.UpdatedAt != baseVersion+1 {
-		t.Fatalf("uncached media version = %d, want %d", item.UpdatedAt, baseVersion+1)
+	if item.UpdatedAt != 100 || item.ArtworkVersion != baseVersion+1 {
+		t.Fatalf("uncached media item = %+v, want timestamp 100 and version %d", item, baseVersion+1)
 	}
 
-	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: baseVersion}
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: baseVersion}
 	image.Type = "collection_poster"
 	if err := ApplyCollectionImage(testLogContext(), &collection, image); err.Message != "" {
 		t.Fatalf("collection apply failed: %s", err.Message)
 	}
-	if collection.UpdatedAt != baseVersion+1 {
-		t.Fatalf("uncached collection version = %d, want %d", collection.UpdatedAt, baseVersion+1)
+	if collection.UpdatedAt != 100 || collection.ArtworkVersion != baseVersion+1 {
+		t.Fatalf("uncached collection = %+v, want timestamp 100 and version %d", collection, baseVersion+1)
 	}
 }
 
@@ -126,27 +126,27 @@ func TestFailedArtworkAppliesDoNotAdvanceVersions(t *testing.T) {
 
 	cleanupArtworkVersionTest(t, server.URL)
 	version := time.Now().Add(time.Second).UnixMicro()
-	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: version}
+	item := models.MediaItem{RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: version}
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
 		MediaItems:         []models.MediaItem{item},
 	})
-	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: version}
+	collection := models.CollectionItem{RatingKey: "collection-1", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: version}
 	cache.CollectionsStore.UpsertCollection(&collection)
 	image := models.ImageFile{ID: "image", Type: "poster", Modified: time.Unix(1, 0)}
 
 	if err := DownloadApplyImageToMediaItem(testLogContext(), &item, image); err.Message == "" {
 		t.Fatal("media apply unexpectedly succeeded")
 	}
-	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(item.RatingKey); cached.UpdatedAt != version {
-		t.Fatalf("failed media apply advanced version to %d", cached.UpdatedAt)
+	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(item.RatingKey); cached.UpdatedAt != 100 || cached.ArtworkVersion != version {
+		t.Fatalf("failed media apply changed item: %+v", cached)
 	}
 	image.Type = "collection_poster"
 	if err := ApplyCollectionImage(testLogContext(), &collection, image); err.Message == "" {
 		t.Fatal("collection apply unexpectedly succeeded")
 	}
-	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != version {
-		t.Fatalf("failed collection apply advanced version to %d", cached.UpdatedAt)
+	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != 100 || cached.ArtworkVersion != version {
+		t.Fatalf("failed collection apply changed item: %+v", cached)
 	}
 }
 

--- a/backend/mediaserver/mediaserver.go
+++ b/backend/mediaserver/mediaserver.go
@@ -232,11 +232,11 @@ func DownloadApplyImageToMediaItem(ctx context.Context, item *models.MediaItem, 
 	}
 	if Err = msClient.DownloadApplyImageToMediaItem(ctx, item, imageFile); Err.Message == "" {
 		now := time.Now().UnixMicro()
-		version := max(item.UpdatedAt+1, now)
-		if cachedVersion, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt(item.RatingKey, now); ok {
+		version := max(max(item.ArtworkVersion, item.UpdatedAt)+1, now)
+		if cachedVersion, ok := cache.LibraryStore.AdvanceMediaItemArtworkVersion(item.RatingKey, now); ok {
 			version = cachedVersion
 		}
-		item.UpdatedAt = version
+		item.ArtworkVersion = version
 	}
 	return Err
 }
@@ -256,11 +256,11 @@ func ApplyCollectionImage(ctx context.Context, collectionItem *models.Collection
 	}
 	if Err = msClient.ApplyCollectionImage(ctx, collectionItem, imageFile); Err.Message == "" {
 		now := time.Now().UnixMicro()
-		version := max(collectionItem.UpdatedAt+1, now)
-		if cachedVersion, ok := cache.CollectionsStore.AdvanceCollectionUpdatedAt(collectionItem.RatingKey, now); ok {
+		version := max(max(collectionItem.ArtworkVersion, collectionItem.UpdatedAt)+1, now)
+		if cachedVersion, ok := cache.CollectionsStore.AdvanceCollectionArtworkVersion(collectionItem.RatingKey, now); ok {
 			version = cachedVersion
 		}
-		collectionItem.UpdatedAt = version
+		collectionItem.ArtworkVersion = version
 	}
 	return Err
 }

--- a/backend/mediaserver/plex/get_media_item_image.go
+++ b/backend/mediaserver/plex/get_media_item_image.go
@@ -21,7 +21,7 @@ func (p *Plex) GetMediaItemImage(ctx context.Context, item *models.MediaItem, im
 	imageData = []byte{}
 	Err = logging.LogErrorInfo{}
 
-	respBody, Err := GetImageFromPlex(ctx, imageRatingKey, imageType, item.UpdatedAt)
+	respBody, Err := GetImageFromPlex(ctx, imageRatingKey, imageType, item.ArtworkVersion)
 	if Err.Message != "" {
 		return imageData, Err
 	}
@@ -40,7 +40,7 @@ func (p *Plex) GetCollectionItemImage(ctx context.Context, collection *models.Co
 	imageData = []byte{}
 	Err = logging.LogErrorInfo{}
 
-	respBody, Err := GetImageFromPlex(ctx, collection.RatingKey, imageType, collection.UpdatedAt)
+	respBody, Err := GetImageFromPlex(ctx, collection.RatingKey, imageType, collection.ArtworkVersion)
 	if Err.Message != "" {
 		return imageData, Err
 	}
@@ -49,7 +49,7 @@ func (p *Plex) GetCollectionItemImage(ctx context.Context, collection *models.Co
 	return imageData, Err
 }
 
-func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string, updatedAt int64) (imageData []byte, Err logging.LogErrorInfo) {
+func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string, artworkVersion int64) (imageData []byte, Err logging.LogErrorInfo) {
 	width := "600"
 	height := "900"
 	switch imageType {
@@ -63,7 +63,7 @@ func GetImageFromPlex(ctx context.Context, ratingKey string, imageType string, u
 	}
 
 	// Construct the URL for the Plex Image request
-	photoPath := path.Join("/library/metadata", ratingKey, imageType, fmt.Sprintf("%d", updatedAt))
+	photoPath := path.Join("/library/metadata", ratingKey, imageType, fmt.Sprintf("%d", artworkVersion))
 	encodedPhotoPath := url.QueryEscape(photoPath)
 	u, err := url.Parse(config.Current.MediaServer.URL)
 	if err != nil {

--- a/backend/models/media_item.go
+++ b/backend/models/media_item.go
@@ -18,7 +18,8 @@ type MediaItem struct {
 
 	// Used in Home Page - sorting and filtering
 	HasMediuxSets        bool  `json:"has_mediux_sets"` // Whether the item has MediUX sets
-	UpdatedAt            int64 `json:"updated_at"`      // Last updated timestamp
+	UpdatedAt            int64 `json:"updated_at"`      // Last updated timestamp from the media server
+	ArtworkVersion       int64 `json:"artwork_version"` // Opaque image cache version
 	AddedAt              int64 `json:"added_at"`        // Added timestamp
 	ReleasedAt           int64 `json:"released_at"`     // Release date timestamp
 	LatestEpisodeAddedAt int64 `json:"latest_episode_added_at"`
@@ -85,13 +86,14 @@ type SelectedTypes struct {
 }
 
 type CollectionItem struct {
-	RatingKey    string      `json:"rating_key"`
-	Index        string      `json:"index"` // Unique identifier for the collection in Plex
-	TMDB_ID      string      `json:"tmdb_id,omitempty"`
-	Title        string      `json:"title"`
-	Summary      string      `json:"summary,omitempty"`
-	ChildCount   int         `json:"child_count"`
-	MediaItems   []MediaItem `json:"media_items"`
-	LibraryTitle string      `json:"library_title,omitempty"`
-	UpdatedAt    int64       `json:"updated_at"`
+	RatingKey      string      `json:"rating_key"`
+	Index          string      `json:"index"` // Unique identifier for the collection in Plex
+	TMDB_ID        string      `json:"tmdb_id,omitempty"`
+	Title          string      `json:"title"`
+	Summary        string      `json:"summary,omitempty"`
+	ChildCount     int         `json:"child_count"`
+	MediaItems     []MediaItem `json:"media_items"`
+	LibraryTitle   string      `json:"library_title,omitempty"`
+	UpdatedAt      int64       `json:"updated_at"`
+	ArtworkVersion int64       `json:"artwork_version"`
 }

--- a/backend/routing/download/artwork_version_response_test.go
+++ b/backend/routing/download/artwork_version_response_test.go
@@ -23,7 +23,7 @@ func TestArtworkApplyResponsesReturnAdvancedVersionOnCacheMiss(t *testing.T) {
 	baseVersion := time.Now().Add(time.Second).UnixMicro()
 
 	mediaItem := models.MediaItem{
-		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion,
+		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: baseVersion,
 	}
 	mediaResponse := postArtworkApply[DownloadImageFileForMediaItem_Response](t, "/api/download/image/item", map[string]any{
 		"media_item": mediaItem,
@@ -32,12 +32,12 @@ func TestArtworkApplyResponsesReturnAdvancedVersionOnCacheMiss(t *testing.T) {
 	if mediaResponse.Status != "success" {
 		t.Fatalf("media response status = %q, want success", mediaResponse.Status)
 	}
-	if mediaResponse.Data.UpdatedAt != baseVersion+1 {
-		t.Fatalf("media response updated_at = %d, want %d", mediaResponse.Data.UpdatedAt, baseVersion+1)
+	if mediaResponse.Data.ArtworkVersion != baseVersion+1 {
+		t.Fatalf("media response artwork_version = %d, want %d", mediaResponse.Data.ArtworkVersion, baseVersion+1)
 	}
 
 	collection := models.CollectionItem{
-		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: baseVersion,
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: 100, ArtworkVersion: baseVersion,
 	}
 	collectionResponse := postArtworkApply[DownloadCollectionImage_Response](t, "/api/download/image/collection", map[string]any{
 		"collection_item": collection,
@@ -46,8 +46,8 @@ func TestArtworkApplyResponsesReturnAdvancedVersionOnCacheMiss(t *testing.T) {
 	if collectionResponse.Status != "success" {
 		t.Fatalf("collection response status = %q, want success", collectionResponse.Status)
 	}
-	if collectionResponse.Data.UpdatedAt != baseVersion+1 {
-		t.Fatalf("collection response updated_at = %d, want %d", collectionResponse.Data.UpdatedAt, baseVersion+1)
+	if collectionResponse.Data.ArtworkVersion != baseVersion+1 {
+		t.Fatalf("collection response artwork_version = %d, want %d", collectionResponse.Data.ArtworkVersion, baseVersion+1)
 	}
 }
 
@@ -60,7 +60,7 @@ func TestFailedArtworkApplyResponsesDoNotReturnVersion(t *testing.T) {
 	cleanupArtworkApplyResponseTest(t, server.URL)
 	baseVersion := time.Now().Add(time.Second).UnixMicro()
 	mediaItem := models.MediaItem{
-		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: baseVersion,
+		RatingKey: "movie-1", Type: "movie", Title: "Movie", LibraryTitle: "Movies", UpdatedAt: 100, ArtworkVersion: baseVersion,
 	}
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
@@ -71,26 +71,26 @@ func TestFailedArtworkApplyResponsesDoNotReturnVersion(t *testing.T) {
 		"media_item": mediaItem,
 		"image_file": models.ImageFile{ID: "poster", Type: "poster"},
 	}, DownloadImageFileForMediaItem)
-	if _, ok := response.Data["updated_at"]; ok {
-		t.Fatal("failed apply response returned updated_at")
+	if _, ok := response.Data["artwork_version"]; ok {
+		t.Fatal("failed apply response returned artwork_version")
 	}
-	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(mediaItem.RatingKey); cached.UpdatedAt != baseVersion {
-		t.Fatalf("failed apply advanced version to %d", cached.UpdatedAt)
+	if cached, _ := cache.LibraryStore.GetMediaItemByRatingKey(mediaItem.RatingKey); cached.UpdatedAt != 100 || cached.ArtworkVersion != baseVersion {
+		t.Fatalf("failed apply changed item: %+v", cached)
 	}
 
 	collection := models.CollectionItem{
-		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: baseVersion,
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: 100, ArtworkVersion: baseVersion,
 	}
 	cache.CollectionsStore.UpsertCollection(&collection)
 	collectionResponse := postArtworkApply[map[string]any](t, "/api/download/image/collection", map[string]any{
 		"collection_item": collection,
 		"image_file":      models.ImageFile{ID: "collection-poster", Type: "collection_poster"},
 	}, DownloadImageFileForCollectionItem)
-	if _, ok := collectionResponse.Data["updated_at"]; ok {
-		t.Fatal("failed collection apply response returned updated_at")
+	if _, ok := collectionResponse.Data["artwork_version"]; ok {
+		t.Fatal("failed collection apply response returned artwork_version")
 	}
-	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != baseVersion {
-		t.Fatalf("failed collection apply advanced version to %d", cached.UpdatedAt)
+	if cached, _ := cache.CollectionsStore.GetCollectionByRatingKey(collection.RatingKey); cached.UpdatedAt != 100 || cached.ArtworkVersion != baseVersion {
+		t.Fatalf("failed collection apply changed item: %+v", cached)
 	}
 }
 

--- a/backend/routing/download/download_collection_image.go
+++ b/backend/routing/download/download_collection_image.go
@@ -14,8 +14,8 @@ type DownloadCollectionImage_Request struct {
 }
 
 type DownloadCollectionImage_Response struct {
-	Result    string `json:"result"`
-	UpdatedAt int64  `json:"updated_at,omitempty"`
+	Result         string `json:"result"`
+	ArtworkVersion int64  `json:"artwork_version,omitempty"`
 }
 
 // DownloadImageFileForCollectionItem godoc
@@ -80,6 +80,6 @@ func DownloadImageFileForCollectionItem(w http.ResponseWriter, r *http.Request) 
 	}
 
 	response.Result = "ok"
-	response.UpdatedAt = req.CollectionItem.UpdatedAt
+	response.ArtworkVersion = req.CollectionItem.ArtworkVersion
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/routing/download/download_image.go
+++ b/backend/routing/download/download_image.go
@@ -16,8 +16,8 @@ type DownloadImageFileForMediaItem_Request struct {
 }
 
 type DownloadImageFileForMediaItem_Response struct {
-	Result    string `json:"result"`
-	UpdatedAt int64  `json:"updated_at,omitempty"`
+	Result         string `json:"result"`
+	ArtworkVersion int64  `json:"artwork_version,omitempty"`
 }
 
 // DownloadImageFileForMediaItem godoc
@@ -82,6 +82,6 @@ func DownloadImageFileForMediaItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.Result = fmt.Sprintf("Successfully downloaded %s", utils.GetFileDownloadName(req.MediaItem.Title, req.ImageFile))
-	response.UpdatedAt = req.MediaItem.UpdatedAt
+	response.ArtworkVersion = req.MediaItem.ArtworkVersion
 	httpx.SendResponse(w, ld, response)
 }

--- a/backend/routing/images/cache_test.go
+++ b/backend/routing/images/cache_test.go
@@ -41,11 +41,11 @@ func TestSuccessfulImageResponsesUseSafeCachePolicies(t *testing.T) {
 	cache.LibraryStore = cache.Cache_NewLibraryCache()
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie", UpdatedAt: mediaVersion}},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", Title: "Movie", UpdatedAt: 100, ArtworkVersion: mediaVersion}},
 	})
 	cache.CollectionsStore = cache.Cache_NewCollectionsCache()
 	cache.CollectionsStore.UpsertCollection(&models.CollectionItem{
-		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: collectionVersion,
+		RatingKey: "collection-1", LibraryTitle: "Movies", Title: "Collection", UpdatedAt: 100, ArtworkVersion: collectionVersion,
 	})
 
 	tests := []struct {
@@ -99,9 +99,9 @@ func TestStaleBrowserVersionUsesCurrentPlexVersion(t *testing.T) {
 	cache.LibraryStore = cache.Cache_NewLibraryCache()
 	cache.LibraryStore.UpdateSection(&models.LibrarySection{
 		LibrarySectionBase: models.LibrarySectionBase{Title: "Movies"},
-		MediaItems:         []models.MediaItem{{RatingKey: "media-1", UpdatedAt: oldVersion}},
+		MediaItems:         []models.MediaItem{{RatingKey: "media-1", UpdatedAt: 100, ArtworkVersion: oldVersion}},
 	})
-	if version, ok := cache.LibraryStore.AdvanceMediaItemUpdatedAt("media-1", currentVersion); !ok || version != currentVersion {
+	if version, ok := cache.LibraryStore.AdvanceMediaItemArtworkVersion("media-1", currentVersion); !ok || version != currentVersion {
 		t.Fatalf("advanced version = %d, found = %v; want %d, true", version, ok, currentVersion)
 	}
 

--- a/backend/routing/images/mediaitem.go
+++ b/backend/routing/images/mediaitem.go
@@ -15,8 +15,8 @@ const (
 	unversionedImageCacheControl = "private, no-store"
 )
 
-func setMediaImageCacheControl(w http.ResponseWriter, r *http.Request, updatedAt int64) {
-	if config.Current.MediaServer.Type == "Plex" && updatedAt > 0 && r.URL.Query().Get("v") == strconv.FormatInt(updatedAt, 10) {
+func setMediaImageCacheControl(w http.ResponseWriter, r *http.Request, artworkVersion int64) {
+	if config.Current.MediaServer.Type == "Plex" && artworkVersion > 0 && r.URL.Query().Get("v") == strconv.FormatInt(artworkVersion, 10) {
 		w.Header().Set("Cache-Control", versionedImageCacheControl)
 		return
 	}
@@ -87,7 +87,7 @@ func GetMediaItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
-	setMediaImageCacheControl(w, r, item.UpdatedAt)
+	setMediaImageCacheControl(w, r, item.ArtworkVersion)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)
@@ -149,7 +149,7 @@ func GetCollectionItemImage(w http.ResponseWriter, r *http.Request) {
 
 	// Set the content type for the response
 	w.Header().Set("Content-Type", "image/jpeg")
-	setMediaImageCacheControl(w, r, item.UpdatedAt)
+	setMediaImageCacheControl(w, r, item.ArtworkVersion)
 	// Write the image data to the response
 	w.WriteHeader(http.StatusOK)
 	w.Write(imageData)

--- a/frontend/src/app/collection-item/page.tsx
+++ b/frontend/src/app/collection-item/page.tsx
@@ -342,7 +342,7 @@ export default function CollectionItemPage() {
   return (
     <>
       <DimmedBackground
-        backdropURL={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=backdrop&v=${collectionItem?.updated_at}`}
+        backdropURL={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=backdrop&v=${collectionItem?.artwork_version}`}
       />
 
       <div className="p-4 lg:p-6">

--- a/frontend/src/components/layout/app-search-bar.tsx
+++ b/frontend/src/components/layout/app-search-bar.tsx
@@ -453,7 +453,7 @@ export function DynamicSearch({ placeholder = "Search", className }: DynamicSear
                                 subtitle={`${item.library_title} • ${item.year}`}
                                 href={`/media-item/`}
                                 isHighlighted={isHighlighted}
-                                imageSrc={`/api/images/media/item?rating_key=${item.rating_key}&image_type=poster&v=${item.updated_at}`}
+                                imageSrc={`/api/images/media/item?rating_key=${item.rating_key}&image_type=poster&v=${item.artwork_version}`}
                                 imageAlt={item.title}
                                 fallbackIcon={
                                   item.type === "movie" ? (
@@ -500,7 +500,7 @@ export function DynamicSearch({ placeholder = "Search", className }: DynamicSear
                                 subtitle={subtitle}
                                 href={`/saved-sets/`}
                                 isHighlighted={isHighlighted}
-                                imageSrc={`/api/images/media/item?rating_key=${set.media_item.rating_key}&image_type=poster&v=${set.media_item.updated_at}`}
+                                imageSrc={`/api/images/media/item?rating_key=${set.media_item.rating_key}&image_type=poster&v=${set.media_item.artwork_version}`}
                                 imageAlt={set.media_item.title}
                                 fallbackIcon={<Film className="h-4 w-4 text-muted-foreground" />}
                                 onLinkClick={() => {

--- a/frontend/src/components/shared/asset-image.tsx
+++ b/frontend/src/components/shared/asset-image.tsx
@@ -114,9 +114,9 @@ export function AssetImage({
       ? kometaImageSrc(assetId)
       : `/api/images/mediux/item?asset_id=${assetId}&modified_date=${(image as ImageFile).modified}`;
   } else if (imageType === "item") {
-    imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}&v=${(image as MediaItem).updated_at}`;
+    imageSrc = `/api/images/media/item?rating_key=${(image as MediaItem).rating_key}&image_type=${aspect}&v=${(image as MediaItem).artwork_version}`;
   } else if (imageType === "collection") {
-    imageSrc = `/api/images/media/collection?rating_key=${(image as CollectionItem).rating_key}&image_type=${aspect}&index=${(image as CollectionItem).index}&v=${(image as CollectionItem).updated_at}`;
+    imageSrc = `/api/images/media/collection?rating_key=${(image as CollectionItem).rating_key}&image_type=${aspect}&index=${(image as CollectionItem).index}&v=${(image as CollectionItem).artwork_version}`;
   } else {
     imageSrc = "";
   }

--- a/frontend/src/components/shared/collection-item-details.tsx
+++ b/frontend/src/components/shared/collection-item-details.tsx
@@ -26,7 +26,7 @@ export function CollectionItemDetails({ collectionItem }: CollectionItemDetailsP
         {/* Poster Image */}
         <div className="flex-shrink-0 mb-4 lg:mb-0 lg:mr-8 flex justify-center">
           <AssetImage
-            image={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=poster&v=${collectionItem?.updated_at}`}
+            image={`/api/images/media/collection?rating_key=${collectionItem?.rating_key}&image_type=poster&v=${collectionItem?.artwork_version}`}
             imageType="url"
             className="w-[200px] h-auto transition-transform hover:scale-105 select-none"
           />

--- a/frontend/src/services/downloads/artwork-version.test.ts
+++ b/frontend/src/services/downloads/artwork-version.test.ts
@@ -3,25 +3,27 @@ import test from "node:test";
 
 import { updateArtworkVersion } from "./artwork-version.ts";
 
-test("updateArtworkVersion applies returned version and notifies the page", () => {
-  const item = { updated_at: 10 };
+test("updateArtworkVersion applies returned version without changing the media timestamp", () => {
+  const item = { updated_at: 10, artwork_version: 100 };
   let appliedItem: typeof item | undefined;
 
   assert.equal(
-    updateArtworkVersion(item, 11, (updatedItem) => {
+    updateArtworkVersion(item, 101, (updatedItem) => {
       appliedItem = updatedItem;
     }),
     item
   );
-  assert.equal(item.updated_at, 11);
+  assert.equal(item.updated_at, 10);
+  assert.equal(item.artwork_version, 101);
   assert.equal(appliedItem, item);
 });
 
 test("updateArtworkVersion ignores missing and stale versions", () => {
-  const item = { updated_at: 10 };
+  const item = { updated_at: 10, artwork_version: 100 };
 
   updateArtworkVersion(item, undefined);
-  updateArtworkVersion(item, 9);
+  updateArtworkVersion(item, 99);
 
   assert.equal(item.updated_at, 10);
+  assert.equal(item.artwork_version, 100);
 });

--- a/frontend/src/services/downloads/artwork-version.ts
+++ b/frontend/src/services/downloads/artwork-version.ts
@@ -1,9 +1,9 @@
-export function updateArtworkVersion<T extends { updated_at: number }>(
+export function updateArtworkVersion<T extends { artwork_version: number }>(
   item: T,
-  updatedAt?: number,
+  artworkVersion?: number,
   onArtworkApplied?: (item: T) => void
 ): T {
-  if (updatedAt !== undefined && updatedAt > item.updated_at) item.updated_at = updatedAt;
+  if (artworkVersion !== undefined && artworkVersion > item.artwork_version) item.artwork_version = artworkVersion;
   onArtworkApplied?.(item);
   return item;
 }

--- a/frontend/src/services/downloads/download-collection-image.ts
+++ b/frontend/src/services/downloads/download-collection-image.ts
@@ -17,7 +17,7 @@ export interface DownloadCollectionImage_Request {
 
 export interface DownloadCollectionImage_Response {
   result: string;
-  updated_at?: number;
+  artwork_version?: number;
 }
 
 export const DownloadImageFileForCollectionItem = async (
@@ -45,7 +45,7 @@ export const DownloadImageFileForCollectionItem = async (
         response.data.error?.message || `Unknown error downloading ${imageType} image and updating media server`
       );
     } else {
-      updateArtworkVersion(collectionItem, response.data.data?.updated_at);
+      updateArtworkVersion(collectionItem, response.data.data?.artwork_version);
       log(
         "INFO",
         "API - Media Server",

--- a/frontend/src/services/downloads/download-image.ts
+++ b/frontend/src/services/downloads/download-image.ts
@@ -15,7 +15,7 @@ export interface DownloadImageFileForMediaItem_Request {
 
 export interface DownloadImageFileForMediaItem_Response {
   result: string;
-  updated_at?: number;
+  artwork_version?: number;
 }
 
 export const downloadImageFileForMediaItem = async (
@@ -38,7 +38,7 @@ export const downloadImageFileForMediaItem = async (
         response.data.error?.message || "Unknown error downloading poster file and updating media server"
       );
     }
-    updateArtworkVersion(mediaItem, response.data.data?.updated_at, onArtworkApplied);
+    updateArtworkVersion(mediaItem, response.data.data?.artwork_version, onArtworkApplied);
     return response.data;
   } catch (error) {
     log(

--- a/frontend/src/types/media-and-posters/collection-item.ts
+++ b/frontend/src/types/media-and-posters/collection-item.ts
@@ -16,4 +16,5 @@ export interface CollectionItem {
   media_items: MediaItem[];
   library_title?: string;
   updated_at: number;
+  artwork_version: number;
 }

--- a/frontend/src/types/media-and-posters/media-item-and-library.ts
+++ b/frontend/src/types/media-and-posters/media-item-and-library.ts
@@ -26,6 +26,7 @@ export interface MediaItem {
 
   has_mediux_sets: boolean;
   updated_at: number;
+  artwork_version: number;
   added_at: number;
   released_at: number;
   latest_episode_added_at: number;


### PR DESCRIPTION
## Summary

`updated_at` did double duty: media-server timestamp for the `dateUpdated` sort, and monotonic artwork cache version for image URLs. Hydration clamps versions up to the process start floor, so every item untouched since boot collapsed to one identical value and the sort degenerated.

Splits the concerns. `updated_at` stays the media-server timestamp; new `artwork_version` carries the opaque cache version for both media items and collections.

## Changes

- `models.MediaItem` / `models.CollectionItem` gain `artwork_version`.
- Cache hydration floors `artwork_version` (seeded from `max(updated_at, artwork_version)`) and preserves both fields monotonically across refreshes; `updated_at` is never clamped.
- `Advance*UpdatedAt` renamed `Advance*ArtworkVersion`; artwork applies advance only the version.
- Artwork-apply responses return `artwork_version` instead of `updated_at`.
- Plex transcode source path and image `Cache-Control` validation key on `artwork_version`.
- Frontend types, image URL `v` params, and the artwork-version helper use `artwork_version`; `dateUpdated` sorting keeps the real timestamp.
- Swagger regenerated.

No DB migration: artwork versions stay process-local. Backend and frontend ship in one image, so no compatibility field.

## Testing

- `gofmt -l .` clean, `go test ./...`, `go vet ./...`, `go build ./...`
- `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`
- `npm run format:check` fails on 6 files untouched by this branch; same failures pre-exist on `main`.

Closes #162
